### PR TITLE
fix(branch): use correct SHA for ciConfig query when --branch is specified

### DIFF
--- a/control/task.go
+++ b/control/task.go
@@ -60,6 +60,20 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 	// projectInfo.AnalyzeBranch = branch to analyze from CLI (e.g., "testing-branch" or defaults to DefaultBranch)
 	if conf.Branch != "" {
 		projectInfo.AnalyzeBranch = conf.Branch
+
+		// When analyzing a non-default branch, fetch the correct SHA so that
+		// GitLab's ciConfig GraphQL query resolves include:local files from
+		// the target branch's file tree, not the default branch's.
+		if conf.Branch != projectInfo.DefaultBranch {
+			branchSha, err := gitlab.FetchLatestCommitSha(
+				conf.GitlabToken, conf.GitlabURL, conf.ProjectPath, conf.Branch, conf,
+			)
+			if err != nil {
+				l.WithError(err).Warn("Unable to fetch commit SHA for analyze branch, using default branch SHA")
+			} else {
+				projectInfo.LatestHeadCommitSha = branchSha
+			}
+		}
 	}
 
 	///////////////////////

--- a/gitlab/project.go
+++ b/gitlab/project.go
@@ -216,6 +216,23 @@ func EnhanceProjectWithGraphQL(project *Project, token string, instanceURL strin
 	return nil
 }
 
+// FetchLatestCommitSha gets the latest commit SHA for a given branch.
+// Exported wrapper around fetchLatestCommitSha for use outside the gitlab package.
+func FetchLatestCommitSha(token, instanceURL, projectPath, branch string, conf *configuration.Configuration) (string, error) {
+	l := logger.WithFields(logrus.Fields{
+		"action": "FetchLatestCommitSha",
+		"branch": branch,
+	})
+
+	glab, err := GetNewGitlabClient(token, instanceURL, conf)
+	if err != nil {
+		l.WithError(err).Error("Unable to get a GitLab client")
+		return "", err
+	}
+
+	return fetchLatestCommitSha(glab, projectPath, branch, l)
+}
+
 // ToProjectInfo converts Project to the simpler ProjectInfo struct used by collectors
 func (p *Project) ToProjectInfo() *ProjectInfo {
 	return &ProjectInfo{


### PR DESCRIPTION
## Summary

Fixes #34

When `--branch` targets a non-default branch, the GraphQL `ciConfig` query receives the default branch's commit SHA. GitLab uses this SHA to resolve `include: local` paths, so included files are looked up in the wrong branch's file tree.

- **Export** `fetchLatestCommitSha` as `FetchLatestCommitSha` in `gitlab/project.go` so it can be called from outside the package
- **Fetch the correct SHA** in `control/task.go` when `--branch` differs from the default branch, and update `LatestHeadCommitSha` before any downstream consumer reads it

## Why this approach

All downstream callers (`GetFullGitlabCI` at `utilsCI.go:180`, `FetchGitlabInclude` at `collector/...875`) already read from `project.LatestHeadCommitSha`. By fixing the value at the source — right after `AnalyzeBranch` is set — every consumer automatically gets the correct SHA. No function signatures or call sites need to change.

## Changes

| File | Change |
|------|--------|
| `gitlab/project.go` | Add exported `FetchLatestCommitSha()` wrapper |
| `control/task.go` | Fetch branch-specific SHA when `--branch` != default branch |

## Test plan

- [ ] Build: `go build ./gitlab/... ./control/...`
- [ ] Run against a project where `--branch dev` has different CI includes than `main`
- [ ] Verify in `--verbose` output that the SHA matches the target branch's latest commit
- [ ] Verify `include: local` files are resolved correctly
- [ ] Verify default behavior (no `--branch` flag) is unchanged