### PR TITLE
fix(detection): support SSH URL and Git protocol formats in remote auto-detection

### DIFF
--- a/utils/gitremote.go
+++ b/utils/gitremote.go
@@ -34,13 +34,28 @@ func DetectGitRemote() *GitRemoteInfo {
 }
 
 // ParseGitRemoteURL parses a git remote URL and extracts host and project path.
-// Supports both SSH and HTTPS formats:
-//   - SSH:   git@gitlab.com:group/project.git
-//   - HTTPS: https://gitlab.com/group/project.git
+// Supports the following formats:
+//   - SSH URL:       ssh://git@host[:port]/group/project.git
+//   - SSH SCP-like:  git@host:group/project.git
+//   - HTTPS:         https://host[:port]/group/project.git
+//   - Git protocol:  git://host[:port]/group/project.git
 //
 // Returns nil if the URL cannot be parsed.
 func ParseGitRemoteURL(remoteURL string) *GitRemoteInfo {
-	// Try SSH format: git@host:path.git
+	// Try SSH URL format: ssh://[user@]host[:port]/path.git
+	// The port is intentionally ignored as the GitLab API uses HTTPS
+	sshURLRegex := regexp.MustCompile(`^ssh://[^@]+@([^/:]+)(?::\d+)?/(.+?)(?:\.git)?$`)
+	if matches := sshURLRegex.FindStringSubmatch(remoteURL); matches != nil {
+		host := matches[1]
+		projectPath := matches[2]
+		return &GitRemoteInfo{
+			Host:        host,
+			ProjectPath: projectPath,
+			URL:         fmt.Sprintf("https://%s", host),
+		}
+	}
+
+	// Try SSH SCP-like format: git@host:path.git
 	sshRegex := regexp.MustCompile(`^git@([^:]+):(.+?)(?:\.git)?$`)
 	if matches := sshRegex.FindStringSubmatch(remoteURL); matches != nil {
 		host := matches[1]
@@ -52,9 +67,21 @@ func ParseGitRemoteURL(remoteURL string) *GitRemoteInfo {
 		}
 	}
 
-	// Try HTTPS format: https://host/path.git or https://host/path
+	// Try HTTPS format: https://host[:port]/path.git
 	httpsRegex := regexp.MustCompile(`^https?://([^/]+)/(.+?)(?:\.git)?$`)
 	if matches := httpsRegex.FindStringSubmatch(remoteURL); matches != nil {
+		host := matches[1]
+		projectPath := matches[2]
+		return &GitRemoteInfo{
+			Host:        host,
+			ProjectPath: projectPath,
+			URL:         fmt.Sprintf("https://%s", host),
+		}
+	}
+
+	// Try Git protocol format: git://host[:port]/path.git
+	gitRegex := regexp.MustCompile(`^git://([^/:]+)(?::\d+)?/(.+?)(?:\.git)?$`)
+	if matches := gitRegex.FindStringSubmatch(remoteURL); matches != nil {
 		host := matches[1]
 		projectPath := matches[2]
 		return &GitRemoteInfo{

--- a/utils/gitremote_test.go
+++ b/utils/gitremote_test.go
@@ -1,0 +1,175 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestParseGitRemoteURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		remoteURL    string
+		wantHost     string
+		wantProject  string
+		wantURL      string
+		wantNil      bool
+	}{
+		// SSH SCP-like format (git@host:path)
+		{
+			name:        "SSH SCP-like basic",
+			remoteURL:   "git@gitlab.com:group/project.git",
+			wantHost:    "gitlab.com",
+			wantProject: "group/project",
+			wantURL:     "https://gitlab.com",
+		},
+		{
+			name:        "SSH SCP-like without .git suffix",
+			remoteURL:   "git@gitlab.com:group/project",
+			wantHost:    "gitlab.com",
+			wantProject: "group/project",
+			wantURL:     "https://gitlab.com",
+		},
+		{
+			name:        "SSH SCP-like with nested groups",
+			remoteURL:   "git@gitlab.example.com:group/subgroup/project.git",
+			wantHost:    "gitlab.example.com",
+			wantProject: "group/subgroup/project",
+			wantURL:     "https://gitlab.example.com",
+		},
+
+		// SSH URL format (ssh://user@host[:port]/path)
+		{
+			name:        "SSH URL with custom port",
+			remoteURL:   "ssh://git@git.toto.intra:2222/areno/areno-opensearch.git",
+			wantHost:    "git.toto.intra",
+			wantProject: "areno/areno-opensearch",
+			wantURL:     "https://git.toto.intra",
+		},
+		{
+			name:        "SSH URL without port",
+			remoteURL:   "ssh://git@gitlab.com/group/project.git",
+			wantHost:    "gitlab.com",
+			wantProject: "group/project",
+			wantURL:     "https://gitlab.com",
+		},
+		{
+			name:        "SSH URL without .git suffix",
+			remoteURL:   "ssh://git@gitlab.com/group/project",
+			wantHost:    "gitlab.com",
+			wantProject: "group/project",
+			wantURL:     "https://gitlab.com",
+		},
+		{
+			name:        "SSH URL with nested groups and port",
+			remoteURL:   "ssh://git@gitlab.example.com:2222/group/subgroup/project.git",
+			wantHost:    "gitlab.example.com",
+			wantProject: "group/subgroup/project",
+			wantURL:     "https://gitlab.example.com",
+		},
+		{
+			name:        "SSH URL with standard port 22",
+			remoteURL:   "ssh://git@gitlab.com:22/group/project.git",
+			wantHost:    "gitlab.com",
+			wantProject: "group/project",
+			wantURL:     "https://gitlab.com",
+		},
+
+		// HTTPS format
+		{
+			name:        "HTTPS basic",
+			remoteURL:   "https://gitlab.com/group/project.git",
+			wantHost:    "gitlab.com",
+			wantProject: "group/project",
+			wantURL:     "https://gitlab.com",
+		},
+		{
+			name:        "HTTPS without .git suffix",
+			remoteURL:   "https://gitlab.com/group/project",
+			wantHost:    "gitlab.com",
+			wantProject: "group/project",
+			wantURL:     "https://gitlab.com",
+		},
+		{
+			name:        "HTTPS with port",
+			remoteURL:   "https://gitlab.example.com:8443/group/project.git",
+			wantHost:    "gitlab.example.com:8443",
+			wantProject: "group/project",
+			wantURL:     "https://gitlab.example.com:8443",
+		},
+		{
+			name:        "HTTPS with nested groups",
+			remoteURL:   "https://gitlab.com/group/subgroup/project.git",
+			wantHost:    "gitlab.com",
+			wantProject: "group/subgroup/project",
+			wantURL:     "https://gitlab.com",
+		},
+		{
+			name:        "HTTP format",
+			remoteURL:   "http://gitlab.example.com/group/project.git",
+			wantHost:    "gitlab.example.com",
+			wantProject: "group/project",
+			wantURL:     "https://gitlab.example.com",
+		},
+
+		// Git protocol format
+		{
+			name:        "Git protocol basic",
+			remoteURL:   "git://gitlab.com/group/project.git",
+			wantHost:    "gitlab.com",
+			wantProject: "group/project",
+			wantURL:     "https://gitlab.com",
+		},
+		{
+			name:        "Git protocol with port",
+			remoteURL:   "git://gitlab.example.com:9418/group/project.git",
+			wantHost:    "gitlab.example.com",
+			wantProject: "group/project",
+			wantURL:     "https://gitlab.example.com",
+		},
+
+		// Invalid URLs
+		{
+			name:      "Empty string",
+			remoteURL: "",
+			wantNil:   true,
+		},
+		{
+			name:      "Invalid format",
+			remoteURL: "not-a-valid-url",
+			wantNil:   true,
+		},
+		{
+			name:      "FTP protocol unsupported",
+			remoteURL: "ftp://gitlab.com/group/project.git",
+			wantNil:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseGitRemoteURL(tt.remoteURL)
+
+			if tt.wantNil {
+				if result != nil {
+					t.Errorf("ParseGitRemoteURL(%q) = %+v, want nil", tt.remoteURL, result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatalf("ParseGitRemoteURL(%q) = nil, want non-nil", tt.remoteURL)
+			}
+
+			if result.Host != tt.wantHost {
+				t.Errorf("ParseGitRemoteURL(%q).Host = %q, want %q", tt.remoteURL, result.Host, tt.wantHost)
+			}
+
+			if result.ProjectPath != tt.wantProject {
+				t.Errorf("ParseGitRemoteURL(%q).ProjectPath = %q, want %q", tt.remoteURL, result.ProjectPath, tt.wantProject)
+			}
+
+			if result.URL != tt.wantURL {
+				t.Errorf("ParseGitRemoteURL(%q).URL = %q, want %q", tt.remoteURL, result.URL, tt.wantURL)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #36

The git remote URL parser only handled SCP-like SSH (`git@host:path`) and HTTPS formats. URLs using the `ssh://` scheme with a custom port — such as `ssh://git@git.toto.intra:2222/areno/areno-opensearch.git` from the issue report — were not recognized, causing auto-detection to silently fail.

## Why this approach

`ParseGitRemoteURL()` is the single entry point for all remote URL parsing. Adding new regex patterns here fixes the issue for every caller without changing any function signatures or downstream logic. The SSH port is intentionally ignored since the GitLab API is accessed over HTTPS.

## Changes

| File | Change |
|------|--------|
| `utils/gitremote.go` | Add `ssh://[user@]host[:port]/path.git` regex pattern |
| `utils/gitremote.go` | Add `git://host[:port]/path.git` regex pattern |
| `utils/gitremote_test.go` | Add 18 unit tests covering all four formats, edge cases, and invalid inputs |

### Supported formats after this fix

| Format | Example | Status |
|--------|---------|--------|
| SSH URL | `ssh://git@host:2222/group/project.git` | **New** |
| SSH SCP-like | `git@host:group/project.git` | Existing |
| HTTPS | `https://host/group/project.git` | Existing |
| Git protocol | `git://host/group/project.git` | **New** |

## Test plan

- [ ] `go test ./utils/ -v -run TestParseGitRemoteURL` — 18/18 passing
- [ ] Build: `go build ./...`
- [ ] Verify the exact URL from the issue report is parsed correctly: `ssh://git@git.toto.intra:2222/areno/areno-opensearch.git`
- [ ] Verify existing SCP-like and HTTPS formats are unchanged
- [ ] Verify default behavior (no `--branch` flag) is unchanged