### PR TITLE
feat(controls): add image digest pinning control

### DIFF
--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -36,6 +36,18 @@ controls:
       # - unstable
 
   # ===========================================
+  # Container images must be pinned by digest
+  # ===========================================
+  # Detects CI/CD jobs using container images referenced by mutable tags
+  # (e.g., alpine:3.19, node:20) instead of immutable digests.
+  #
+  # Best practice: Use image references pinned by digest
+  # (e.g., alpine@sha256:..., node@sha256:...)
+  containerImagesMustBePinnedByDigest:
+    # Set to false to disable this control
+    enabled: true
+
+  # ===========================================
   # Container images must come from authorized sources
   # ===========================================
   # Detects CI/CD jobs using Docker images from untrusted registries.

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ This creates `.plumber.yaml` with sensible [defaults](./.plumber.yaml). Customiz
 
 ### Available Controls
 
-Plumber includes 8 compliance controls. Each can be enabled/disabled and customized in [.plumber.yaml](.plumber.yaml):
+Plumber includes 9 compliance controls. Each can be enabled/disabled and customized in [.plumber.yaml](.plumber.yaml):
 
 <details>
 <summary><b>1. Container images must not use forbidden tags</b></summary>
@@ -258,7 +258,19 @@ containerImageMustNotUseForbiddenTags:
 </details>
 
 <details>
-<summary><b>2. Container images must come from authorized sources</b></summary>
+<summary><b>2. Container images must be pinned by digest</b></summary>
+
+Prevents use of mutable image references and enforces immutable digest references.
+
+```yaml
+containerImagesMustBePinnedByDigest:
+  enabled: true
+```
+
+</details>
+
+<details>
+<summary><b>3. Container images must come from authorized sources</b></summary>
 
 Ensures container images come from trusted registries only.
 
@@ -279,7 +291,7 @@ containerImageMustComeFromAuthorizedSources:
 </details>
 
 <details>
-<summary><b>3. Branch must be protected</b></summary>
+<summary><b>4. Branch must be protected</b></summary>
 
 Verifies that critical branches have proper protection settings.
 
@@ -302,7 +314,7 @@ branchMustBeProtected:
 </details>
 
 <details>
-<summary><b>4. Pipeline must not include hardcoded jobs</b></summary>
+<summary><b>5. Pipeline must not include hardcoded jobs</b></summary>
 
 Detects jobs defined directly in `.gitlab-ci.yml` instead of coming from includes/components.
 
@@ -314,7 +326,7 @@ pipelineMustNotIncludeHardcodedJobs:
 </details>
 
 <details>
-<summary><b>5. Includes must be up to date</b></summary>
+<summary><b>6. Includes must be up to date</b></summary>
 
 Checks if included templates/components have newer versions available.
 
@@ -326,7 +338,7 @@ includesMustBeUpToDate:
 </details>
 
 <details>
-<summary><b>6. Includes must not use forbidden versions</b></summary>
+<summary><b>7. Includes must not use forbidden versions</b></summary>
 
 Prevents use of mutable version references for includes that can change unexpectedly.
 
@@ -345,7 +357,7 @@ includesMustNotUseForbiddenVersions:
 </details>
 
 <details>
-<summary><b>7. Pipeline must include component</b></summary>
+<summary><b>8. Pipeline must include component</b></summary>
 
 Ensures required GitLab CI/CD components are included in the pipeline.
 
@@ -378,7 +390,7 @@ pipelineMustIncludeComponent:
 </details>
 
 <details>
-<summary><b>8. Pipeline must include template</b></summary>
+<summary><b>9. Pipeline must include template</b></summary>
 
 Ensures required templates (project includes) are present in the pipeline.
 

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -38,6 +38,7 @@ configuration, and runs various checks including:
 - Pipeline origin analysis (components, templates, local files)
 - Pipeline image analysis (registries, tags)
 - Mutable image tag detection
+- Image digest pinning enforcement
 
 Required environment variables:
   GITLAB_TOKEN    GitLab API token (required)
@@ -217,6 +218,11 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 
 	if result.RequiredTemplatesResult != nil && !result.RequiredTemplatesResult.Skipped {
 		complianceSum += result.RequiredTemplatesResult.Compliance
+		controlCount++
+	}
+
+	if result.ImagePinnedByDigestResult != nil && !result.ImagePinnedByDigestResult.Skipped {
+		complianceSum += result.ImagePinnedByDigestResult.Compliance
 		controlCount++
 	}
 
@@ -645,6 +651,35 @@ func outputText(result *control.AnalysisResult, threshold, compliance float64, c
 				fmt.Printf("\n  %sMissing Templates:%s\n", colorYellow, colorReset)
 				for _, issue := range result.RequiredTemplatesResult.Issues {
 					fmt.Printf("    %s•%s %s (group %d)\n", colorYellow, colorReset, issue.TemplatePath, issue.GroupIndex+1)
+				}
+			}
+		}
+		fmt.Println()
+	}
+
+	// Control 9: Container images must be pinned by digest
+	if result.ImagePinnedByDigestResult != nil {
+		ctrl := controlSummary{
+			name:       "Container images must be pinned by digest",
+			compliance: result.ImagePinnedByDigestResult.Compliance,
+			issues:     len(result.ImagePinnedByDigestResult.Issues),
+			skipped:    result.ImagePinnedByDigestResult.Skipped,
+		}
+		controls = append(controls, ctrl)
+
+		printControlHeader("Container images must be pinned by digest", result.ImagePinnedByDigestResult.Compliance, result.ImagePinnedByDigestResult.Skipped)
+
+		if result.ImagePinnedByDigestResult.Skipped {
+			fmt.Printf("  %sStatus: SKIPPED (disabled in configuration)%s\n", colorDim, colorReset)
+		} else {
+			fmt.Printf("  Total Images: %d\n", result.ImagePinnedByDigestResult.Metrics.Total)
+			fmt.Printf("  Pinned By Digest: %d\n", result.ImagePinnedByDigestResult.Metrics.PinnedByDigest)
+			fmt.Printf("  Not Pinned By Digest: %d\n", result.ImagePinnedByDigestResult.Metrics.NotPinnedByDigest)
+
+			if len(result.ImagePinnedByDigestResult.Issues) > 0 {
+				fmt.Printf("\n  %sImages Not Pinned By Digest Found:%s\n", colorYellow, colorReset)
+				for _, issue := range result.ImagePinnedByDigestResult.Issues {
+					fmt.Printf("    %s•%s Job '%s' uses image without digest pinning: %s\n", colorYellow, colorReset, issue.Job, issue.Link)
 				}
 			}
 		}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -64,6 +64,7 @@ customize for your organization's compliance requirements.
 
 The generated config includes:
 - Container image tag policies (forbid 'latest', 'dev', etc.)
+- Container image digest pinning policy
 - Trusted registry whitelist
 - Branch protection requirements
 

--- a/configuration/plumberconfig.go
+++ b/configuration/plumberconfig.go
@@ -22,6 +22,9 @@ type ControlsConfig struct {
 	// ContainerImageMustNotUseForbiddenTags control configuration
 	ContainerImageMustNotUseForbiddenTags *ImageForbiddenTagsControlConfig `yaml:"containerImageMustNotUseForbiddenTags,omitempty"`
 
+	// ContainerImagesMustBePinnedByDigest control configuration
+	ContainerImagesMustBePinnedByDigest *ImagePinnedByDigestControlConfig `yaml:"containerImagesMustBePinnedByDigest,omitempty"`
+
 	// ContainerImageMustComeFromAuthorizedSources control configuration
 	ContainerImageMustComeFromAuthorizedSources *ImageAuthorizedSourcesControlConfig `yaml:"containerImageMustComeFromAuthorizedSources,omitempty"`
 
@@ -51,6 +54,12 @@ type ImageForbiddenTagsControlConfig struct {
 
 	// Tags is a list of forbidden tags (e.g., latest, dev)
 	Tags []string `yaml:"tags,omitempty"`
+}
+
+// ImagePinnedByDigestControlConfig configuration for the digest pinning control
+type ImagePinnedByDigestControlConfig struct {
+	// Enabled controls whether this check runs
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // ImageAuthorizedSourcesControlConfig configuration for the authorized image sources control
@@ -278,6 +287,15 @@ func (c *PlumberConfig) GetContainerImageMustNotUseForbiddenTagsConfig() *ImageF
 	return c.Controls.ContainerImageMustNotUseForbiddenTags
 }
 
+// GetContainerImagesMustBePinnedByDigestConfig returns the control configuration
+// Returns nil if not configured
+func (c *PlumberConfig) GetContainerImagesMustBePinnedByDigestConfig() *ImagePinnedByDigestControlConfig {
+	if c == nil {
+		return nil
+	}
+	return c.Controls.ContainerImagesMustBePinnedByDigest
+}
+
 // GetContainerImageMustComeFromAuthorizedSourcesConfig returns the control configuration
 // Returns nil if not configured
 func (c *PlumberConfig) GetContainerImageMustComeFromAuthorizedSourcesConfig() *ImageAuthorizedSourcesControlConfig {
@@ -290,6 +308,15 @@ func (c *PlumberConfig) GetContainerImageMustComeFromAuthorizedSourcesConfig() *
 // IsEnabled returns whether the control is enabled
 // Returns false if not properly configured
 func (c *ImageForbiddenTagsControlConfig) IsEnabled() bool {
+	if c == nil || c.Enabled == nil {
+		return false
+	}
+	return *c.Enabled
+}
+
+// IsEnabled returns whether the control is enabled
+// Returns false if not properly configured
+func (c *ImagePinnedByDigestControlConfig) IsEnabled() bool {
 	if c == nil || c.Enabled == nil {
 		return false
 	}

--- a/control/controlGitlabImagePinnedByDigest.go
+++ b/control/controlGitlabImagePinnedByDigest.go
@@ -1,0 +1,169 @@
+package control
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/getplumber/plumber/collector"
+	"github.com/getplumber/plumber/configuration"
+	"github.com/sirupsen/logrus"
+)
+
+const ControlTypeGitlabImagePinnedByDigestVersion = "0.1.0"
+
+var imageDigestPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*(?:[+._-][A-Za-z][A-Za-z0-9]*)*:[0-9a-fA-F]{32,}$`)
+
+// GitlabImagePinnedByDigestConf holds the configuration for digest pinning detection.
+type GitlabImagePinnedByDigestConf struct {
+	// Enabled controls whether this check runs.
+	Enabled bool `json:"enabled"`
+}
+
+// GetConf loads configuration from PlumberConfig.
+// Returns error if config is missing or incomplete.
+func (p *GitlabImagePinnedByDigestConf) GetConf(plumberConfig *configuration.PlumberConfig) error {
+	// Plumber config is required
+	if plumberConfig == nil {
+		return fmt.Errorf("Plumber config is required but not provided")
+	}
+
+	// Get control config from PlumberConfig
+	imgConfig := plumberConfig.GetContainerImagesMustBePinnedByDigestConfig()
+	if imgConfig == nil {
+		return fmt.Errorf("containerImagesMustBePinnedByDigest control configuration is missing from .plumber.yaml config file")
+	}
+
+	// Check if enabled field is set
+	if imgConfig.Enabled == nil {
+		return fmt.Errorf("containerImagesMustBePinnedByDigest.enabled field is required in .plumber.yaml config file")
+	}
+
+	// Apply configuration
+	p.Enabled = imgConfig.IsEnabled()
+
+	l.WithField("enabled", p.Enabled).Debug("containerImagesMustBePinnedByDigest control configuration loaded from .plumber.yaml file")
+
+	return nil
+}
+
+// GitlabImagePinnedByDigestMetrics holds metrics about digest pinning.
+type GitlabImagePinnedByDigestMetrics struct {
+	Total             uint `json:"total"`
+	PinnedByDigest    uint `json:"pinnedByDigest"`
+	NotPinnedByDigest uint `json:"notPinnedByDigest"`
+	CiInvalid         uint `json:"ciInvalid"`
+	CiMissing         uint `json:"ciMissing"`
+}
+
+// GitlabImagePinnedByDigestResult holds the result of the digest pinning control.
+type GitlabImagePinnedByDigestResult struct {
+	Issues     []GitlabPipelineImageIssueNotPinnedByDigest `json:"issues"`
+	Metrics    GitlabImagePinnedByDigestMetrics            `json:"metrics"`
+	Compliance float64                                     `json:"compliance"`
+	Version    string                                      `json:"version"`
+	CiValid    bool                                        `json:"ciValid"`
+	CiMissing  bool                                        `json:"ciMissing"`
+	Skipped    bool                                        `json:"skipped"`         // True if control was disabled
+	Error      string                                      `json:"error,omitempty"` // Error message if data collection failed
+}
+
+////////////////////
+// Control issues //
+////////////////////
+
+// GitlabPipelineImageIssueNotPinnedByDigest represents an image reference without an immutable digest.
+type GitlabPipelineImageIssueNotPinnedByDigest struct {
+	Link string `json:"link"`
+	Job  string `json:"job"`
+}
+
+///////////////////////
+// Control functions //
+///////////////////////
+
+func isImagePinnedByDigest(imageLink string) bool {
+	link := strings.TrimSpace(imageLink)
+	if link == "" {
+		return false
+	}
+
+	lastAt := strings.LastIndex(link, "@")
+	if lastAt <= 0 || lastAt >= len(link)-1 {
+		return false
+	}
+
+	digest := link[lastAt+1:]
+	return imageDigestPattern.MatchString(digest)
+}
+
+// Run executes the digest pinning control.
+func (p *GitlabImagePinnedByDigestConf) Run(pipelineImageData *collector.GitlabPipelineImageData) *GitlabImagePinnedByDigestResult {
+	l := l.WithFields(logrus.Fields{
+		"control":        "GitlabImagePinnedByDigest",
+		"controlVersion": ControlTypeGitlabImagePinnedByDigestVersion,
+	})
+	l.Info("Start image digest pinning control")
+
+	result := &GitlabImagePinnedByDigestResult{
+		Issues:     []GitlabPipelineImageIssueNotPinnedByDigest{},
+		Metrics:    GitlabImagePinnedByDigestMetrics{},
+		Compliance: 100.0,
+		Version:    ControlTypeGitlabImagePinnedByDigestVersion,
+		CiValid:    pipelineImageData.CiValid,
+		CiMissing:  pipelineImageData.CiMissing,
+		Skipped:    false,
+	}
+
+	// Check if control is enabled
+	if !p.Enabled {
+		l.Info("Image digest pinning control is disabled, skipping")
+		result.Skipped = true
+		return result
+	}
+
+	// If CI is invalid or missing, return early
+	if !pipelineImageData.CiValid || pipelineImageData.CiMissing {
+		result.Compliance = 0.0
+		if !pipelineImageData.CiValid {
+			result.Metrics.CiInvalid = 1
+		}
+		if pipelineImageData.CiMissing {
+			result.Metrics.CiMissing = 1
+		}
+		return result
+	}
+
+	// Loop over all images and check digest pinning
+	for _, image := range pipelineImageData.Images {
+		if isImagePinnedByDigest(image.Link) {
+			result.Metrics.PinnedByDigest++
+			continue
+		}
+
+		issue := GitlabPipelineImageIssueNotPinnedByDigest{
+			Link: image.Link,
+			Job:  image.Job,
+		}
+		result.Issues = append(result.Issues, issue)
+		result.Metrics.NotPinnedByDigest++
+	}
+
+	// Calculate compliance based on issues
+	if len(result.Issues) > 0 {
+		result.Compliance = 0.0
+		l.WithField("issuesCount", len(result.Issues)).Debug("Found images not pinned by digest, setting compliance to 0")
+	}
+
+	// Set total metrics
+	result.Metrics.Total = uint(len(pipelineImageData.Images))
+
+	l.WithFields(logrus.Fields{
+		"totalImages":         result.Metrics.Total,
+		"pinnedByDigestCount": result.Metrics.PinnedByDigest,
+		"notPinnedCount":      result.Metrics.NotPinnedByDigest,
+		"compliance":          result.Compliance,
+	}).Info("Image digest pinning control completed")
+
+	return result
+}

--- a/control/controlGitlabImagePinnedByDigest_test.go
+++ b/control/controlGitlabImagePinnedByDigest_test.go
@@ -1,0 +1,141 @@
+package control
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/collector"
+)
+
+func TestIsImagePinnedByDigest(t *testing.T) {
+	sha256Digest := strings.Repeat("a", 64)
+	sha512Digest := strings.Repeat("b", 128)
+
+	tests := []struct {
+		name  string
+		image string
+		want  bool
+	}{
+		{
+			name:  "digest only",
+			image: "docker.io/library/alpine@sha256:" + sha256Digest,
+			want:  true,
+		},
+		{
+			name:  "tag and digest",
+			image: "docker.io/library/node:20@sha256:" + sha256Digest,
+			want:  true,
+		},
+		{
+			name:  "sha512 digest",
+			image: "registry.example.com/team/app@sha512:" + sha512Digest,
+			want:  true,
+		},
+		{
+			name:  "tag only",
+			image: "docker.io/library/alpine:3.19",
+			want:  false,
+		},
+		{
+			name:  "implicit latest",
+			image: "docker.io/library/alpine",
+			want:  false,
+		},
+		{
+			name:  "digest variable",
+			image: "docker.io/library/alpine@$DIGEST",
+			want:  false,
+		},
+		{
+			name:  "invalid digest format",
+			image: "docker.io/library/alpine@sha256:not-a-hex-digest",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isImagePinnedByDigest(tt.image)
+			if got != tt.want {
+				t.Fatalf("isImagePinnedByDigest(%q) = %v, want %v", tt.image, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGitlabImagePinnedByDigestRunEnabled(t *testing.T) {
+	conf := &GitlabImagePinnedByDigestConf{
+		Enabled: true,
+	}
+
+	sha256Digest := strings.Repeat("a", 64)
+
+	data := &collector.GitlabPipelineImageData{
+		CiValid:   true,
+		CiMissing: false,
+		Images: []collector.GitlabPipelineImageInfo{
+			{
+				Link: "docker.io/library/alpine@sha256:" + sha256Digest,
+				Job:  "build",
+			},
+			{
+				Link: "docker.io/library/node:20",
+				Job:  "test",
+			},
+			{
+				Link: "docker.io/library/golang",
+				Job:  "lint",
+			},
+		},
+	}
+
+	result := conf.Run(data)
+
+	if result.Skipped {
+		t.Fatalf("expected control to run, but it was skipped")
+	}
+	if result.Compliance != 0 {
+		t.Fatalf("expected compliance to be 0, got %v", result.Compliance)
+	}
+	if result.Metrics.Total != 3 {
+		t.Fatalf("expected total metric to be 3, got %d", result.Metrics.Total)
+	}
+	if result.Metrics.PinnedByDigest != 1 {
+		t.Fatalf("expected pinnedByDigest metric to be 1, got %d", result.Metrics.PinnedByDigest)
+	}
+	if result.Metrics.NotPinnedByDigest != 2 {
+		t.Fatalf("expected notPinnedByDigest metric to be 2, got %d", result.Metrics.NotPinnedByDigest)
+	}
+	if len(result.Issues) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(result.Issues))
+	}
+}
+
+func TestGitlabImagePinnedByDigestRunDisabled(t *testing.T) {
+	conf := &GitlabImagePinnedByDigestConf{
+		Enabled: false,
+	}
+
+	data := &collector.GitlabPipelineImageData{
+		CiValid:   true,
+		CiMissing: false,
+		Images: []collector.GitlabPipelineImageInfo{
+			{
+				Link: "docker.io/library/node:20",
+				Job:  "build",
+			},
+		},
+	}
+
+	result := conf.Run(data)
+
+	if !result.Skipped {
+		t.Fatalf("expected control to be skipped")
+	}
+	if result.Compliance != 100 {
+		t.Fatalf("expected compliance to remain 100 when skipped, got %v", result.Compliance)
+	}
+	if len(result.Issues) != 0 {
+		t.Fatalf("expected no issues when skipped, got %d", len(result.Issues))
+	}
+}

--- a/control/task.go
+++ b/control/task.go
@@ -264,6 +264,18 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 	requiredTemplatesResult := requiredTemplatesConf.Run(pipelineOriginData)
 	result.RequiredTemplatesResult = requiredTemplatesResult
 
+	// 11. Run Image Pinned By Digest control
+	l.Info("Running Image Pinned By Digest control")
+
+	pinnedByDigestConf := &GitlabImagePinnedByDigestConf{}
+	if err := pinnedByDigestConf.GetConf(conf.PlumberConfig); err != nil {
+		l.WithError(err).Error("Failed to load ImagePinnedByDigest config from .plumber.yaml file")
+		return result, fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	pinnedByDigestResult := pinnedByDigestConf.Run(pipelineImageData)
+	result.ImagePinnedByDigestResult = pinnedByDigestResult
+
 	l.WithFields(logrus.Fields{
 		"ciValid":   result.CiValid,
 		"ciMissing": result.CiMissing,

--- a/control/types.go
+++ b/control/types.go
@@ -25,6 +25,7 @@ type AnalysisResult struct {
 
 	// Control results
 	ImageForbiddenTagsResult        *GitlabImageForbiddenTagsResult               `json:"imageForbiddenTagsResult,omitempty"`
+	ImagePinnedByDigestResult       *GitlabImagePinnedByDigestResult              `json:"imagePinnedByDigestResult,omitempty"`
 	ImageAuthorizedSourcesResult    *GitlabImageAuthorizedSourcesResult           `json:"imageAuthorizedSourcesResult,omitempty"`
 	BranchProtectionResult          *GitlabBranchProtectionResult                 `json:"branchProtectionResult,omitempty"`
 	HardcodedJobsResult             *GitlabPipelineHardcodedJobsResult            `json:"hardcodedJobsResult,omitempty"`


### PR DESCRIPTION
## Related issue
  Closes #45 
  ## Summary
  - wire config, analysis task, output, docs
  - add the unit tests for digest detection

  ## AI disclosure
  This PR was AI-assisted using Codex (GPT-5).
  AI assistance covered wiring, readme, and tests.
  All changes were reviewed and validated by me.

  ## Human verification
  - `make build` OK
  - `make test` OK
  - Smoke test on personal GitLab project:
    - image tag (`alpine:3.22`) => control fails as expected
    - image digest (`alpine@sha256:...`) => control passes as expected