### PR TITLE
Add ValidateKnownKeys to warn on unknown config keys

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -21,7 +21,7 @@ var (
 	// config generate flags
 	configGenerateOutput string
 	configGenerateForce  bool
-// config validate flags
+	// config validate flags
 	configValidateFile string
 )
 
@@ -107,7 +107,7 @@ func init() {
 	rootCmd.AddCommand(configCmd)
 	configCmd.AddCommand(configViewCmd)
 	configCmd.AddCommand(configGenerateCmd)
-configCmd.AddCommand(configValidateCmd)
+	configCmd.AddCommand(configValidateCmd)
 
 	// config validate flags
 	configValidateCmd.Flags().StringVarP(&configValidateFile, "config", "c", ".plumber.yaml", "Path to configuration file")
@@ -312,21 +312,27 @@ func runConfigGenerate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-
 func runConfigValidate(cmd *cobra.Command, args []string) error {
 	// Suppress debug logs for clean output (unless verbose)
 	if !verbose {
 		logrus.SetLevel(logrus.WarnLevel)
 	}
 
-	// Load the configuration
-	config, _, err := configuration.LoadPlumberConfig(configValidateFile)
+	// Read raw config file for unknown key validation
+	rawData, err := os.ReadFile(configValidateFile)
+	if err != nil {
+		return fmt.Errorf("failed to read configuration file: %w", err)
+	}
+
+	// Check for unknown keys in raw YAML (before struct parsing loses them)
+	warnings := configuration.ValidateKnownKeys(rawData)
+
+	// Also validate the config parses correctly and passes structural validation
+	_, _, err = configuration.LoadPlumberConfig(configValidateFile)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
-	// Validate known keys
-	warnings := configuration.ValidateKnownKeys(config)
 	if len(warnings) > 0 {
 		fmt.Fprintf(os.Stderr, "Configuration validation warnings:\n")
 		for _, warning := range warnings {

--- a/configuration/plumberconfig.go
+++ b/configuration/plumberconfig.go
@@ -9,16 +9,44 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// validControlKeys contains all known control names in .plumber.yaml
-var validControlKeys = []string{
-	"containerImageMustNotUseForbiddenTags",
-	"containerImageMustComeFromAuthorizedSources",
-	"branchMustBeProtected",
-	"pipelineMustNotIncludeHardcodedJobs",
-	"includesMustBeUpToDate",
-	"includesMustNotUseForbiddenVersions",
-	"pipelineMustIncludeComponent",
-	"pipelineMustIncludeTemplate",
+// validControlSchema maps each known control name to its valid sub-keys.
+// When adding a new control, add its entry here to enable validation.
+var validControlSchema = map[string][]string{
+	"containerImageMustNotUseForbiddenTags": {
+		"enabled", "tags", "containerImagesMustBePinnedByDigest",
+	},
+	"containerImageMustComeFromAuthorizedSources": {
+		"enabled", "trustedUrls", "trustDockerHubOfficialImages",
+	},
+	"branchMustBeProtected": {
+		"enabled", "namePatterns", "defaultMustBeProtected",
+		"allowForcePush", "codeOwnerApprovalRequired",
+		"minMergeAccessLevel", "minPushAccessLevel",
+	},
+	"pipelineMustNotIncludeHardcodedJobs": {
+		"enabled",
+	},
+	"includesMustBeUpToDate": {
+		"enabled",
+	},
+	"includesMustNotUseForbiddenVersions": {
+		"enabled", "forbiddenVersions", "defaultBranchIsForbiddenVersion",
+	},
+	"pipelineMustIncludeComponent": {
+		"enabled", "required", "requiredGroups",
+	},
+	"pipelineMustIncludeTemplate": {
+		"enabled", "required", "requiredGroups",
+	},
+}
+
+// validControlKeys returns the list of known control names.
+func validControlNames() []string {
+	keys := make([]string, 0, len(validControlSchema))
+	for k := range validControlSchema {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 // PlumberConfig represents the .plumber.yaml configuration file structure
@@ -439,46 +467,42 @@ func (c *RequiredTemplatesControlConfig) IsEnabled() bool {
 }
 
 // levenshteinDistance calculates the Levenshtein distance between two strings
-func levenshteinDistance(a, b string) int {
-	if len(a) == 0 {
-		return len(b)
+func levenshteinDistance(input, target string) int {
+	if len(input) == 0 {
+		return len(target)
 	}
-	if len(b) == 0 {
-		return len(a)
+	if len(target) == 0 {
+		return len(input)
 	}
 
-	// Create matrix
-	matrix := make([][]int, len(a)+1)
+	matrix := make([][]int, len(input)+1)
 	for i := range matrix {
-		matrix[i] = make([]int, len(b)+1)
+		matrix[i] = make([]int, len(target)+1)
 	}
-
 	// Initialize first column
-	for i := 0; i <= len(a); i++ {
+	for i := 0; i <= len(input); i++ {
 		matrix[i][0] = i
 	}
-
 	// Initialize first row
-	for j := 0; j <= len(b); j++ {
+	for j := 0; j <= len(target); j++ {
 		matrix[0][j] = j
 	}
 
 	// Fill in the rest
-	for i := 1; i <= len(a); i++ {
-		for j := 1; j <= len(b); j++ {
-			cost := 1
-			if a[i-1] == b[j-1] {
-				cost = 0
+	for i := 1; i <= len(input); i++ {
+		for j := 1; j <= len(target); j++ {
+			if input[i-1] == target[j-1] {
+				matrix[i][j] = matrix[i-1][j-1]
+			} else {
+				matrix[i][j] = min(
+					matrix[i-1][j],
+					matrix[i][j-1],
+					matrix[i-1][j-1],
+				) + 1
 			}
-			matrix[i][j] = min(
-				matrix[i-1][j]+1,      // deletion
-				matrix[i][j-1]+1,      // insertion
-				matrix[i-1][j-1]+cost, // substitution
-			)
 		}
 	}
-
-	return matrix[len(a)][len(b)]
+	return matrix[len(input)][len(target)]
 }
 
 func min(a, b, c int) int {
@@ -532,26 +556,67 @@ func contains(slice []string, item string) bool {
 }
 
 // ValidateKnownKeys checks for unknown configuration keys in .plumber.yaml
-// Returns a list of warning messages for unknown keys
+// at both the control level and the sub-key level.
+// Returns a list of warning messages for unknown keys.
 func ValidateKnownKeys(data []byte) []string {
-	var raw map[string]interface{}
+	var raw map[interface{}]interface{}
 	if err := yaml.Unmarshal(data, &raw); err != nil {
-		return nil // If we can't parse, let the normal parsing handle the error
+		return nil
 	}
 
 	var warnings []string
 
-	// Check controls section
-	if controls, ok := raw["controls"].(map[string]interface{}); ok {
-		for key := range controls {
-			if !contains(validControlKeys, key) {
-				suggestion := findClosestMatch(key, validControlKeys)
+	controlsRaw, exists := raw["controls"]
+	if !exists {
+		return warnings
+	}
+
+	controls, ok := controlsRaw.(map[interface{}]interface{})
+	if !ok {
+		return warnings
+	}
+
+	knownNames := validControlNames()
+
+	for keyRaw, valueRaw := range controls {
+		controlName, ok := keyRaw.(string)
+		if !ok {
+			continue
+		}
+
+		// Check control name
+		if !contains(knownNames, controlName) {
+			suggestion := findClosestMatch(controlName, knownNames)
+			if suggestion != "" {
+				warnings = append(warnings,
+					fmt.Sprintf("Unknown control in .plumber.yaml: %q. Did you mean %q?", controlName, suggestion))
+			} else {
+				warnings = append(warnings,
+					fmt.Sprintf("Unknown control in .plumber.yaml: %q", controlName))
+			}
+			continue
+		}
+
+		// Check sub-keys within this control
+		subMap, ok := valueRaw.(map[interface{}]interface{})
+		if !ok {
+			continue
+		}
+		validSubKeys := validControlSchema[controlName]
+
+		for subKeyRaw := range subMap {
+			subKey, ok := subKeyRaw.(string)
+			if !ok {
+				continue
+			}
+			if !contains(validSubKeys, subKey) {
+				suggestion := findClosestMatch(subKey, validSubKeys)
 				if suggestion != "" {
 					warnings = append(warnings,
-						fmt.Sprintf("Unknown control in .plumber.yaml: %q. Did you mean %q?", key, suggestion))
+						fmt.Sprintf("Unknown key %q in control %q. Did you mean %q?", subKey, controlName, suggestion))
 				} else {
 					warnings = append(warnings,
-						fmt.Sprintf("Unknown control in .plumber.yaml: %q", key))
+						fmt.Sprintf("Unknown key %q in control %q", subKey, controlName))
 				}
 			}
 		}

--- a/configuration/plumberconfig_test.go
+++ b/configuration/plumberconfig_test.go
@@ -90,52 +90,46 @@ func TestFindClosestMatch(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		input         string
-		expectMatch   bool
-		expectedKey   string
-		maxDistance   int
+		name        string
+		input       string
+		expectMatch bool
+		expectedKey string
 	}{
 		{
 			name:        "exact match",
 			input:       "containerImageMustNotUseForbiddenTags",
 			expectMatch: true,
 			expectedKey: "containerImageMustNotUseForbiddenTags",
-			maxDistance: 3,
 		},
 		{
 			name:        "typo - missing 's' at end",
 			input:       "containerImageMustNotUseForbiddenTag",
 			expectMatch: true,
 			expectedKey: "containerImageMustNotUseForbiddenTags",
-			maxDistance: 3,
 		},
 		{
 			name:        "typo - wrong character",
 			input:       "branchMustBeProtectod",
 			expectMatch: true,
 			expectedKey: "branchMustBeProtected",
-			maxDistance: 3,
 		},
 		{
 			name:        "completely different string - no match",
 			input:       "xyz123",
 			expectMatch: false,
 			expectedKey: "",
-			maxDistance: 3,
 		},
 		{
 			name:        "similar but too different",
 			input:       "containerMustNotUseTags",
 			expectMatch: false,
 			expectedKey: "",
-			maxDistance: 5,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := findClosestMatch(tt.input, validKeys, tt.maxDistance)
+			result := findClosestMatch(tt.input, validKeys)
 			if tt.expectMatch {
 				if result != tt.expectedKey {
 					t.Errorf("findClosestMatch(%q) = %q, want %q", tt.input, result, tt.expectedKey)
@@ -152,38 +146,181 @@ func TestFindClosestMatch(t *testing.T) {
 func TestValidateKnownKeys(t *testing.T) {
 	tests := []struct {
 		name           string
-		config         *PlumberConfig
+		yamlContent    string
 		expectWarnings int
+		wantContains   string
 	}{
 		{
 			name: "valid config - no warnings",
-			config: &PlumberConfig{
-				Controls: ControlsConfig{
-					ContainerImageMustNotUseForbiddenTags:   &ContainerImageMustNotUseForbiddenTagsControlConfig{},
-					ContainerImageMustComeFromAuthorizedSources: &ContainerImageMustComeFromAuthorizedSourcesControlConfig{},
-				},
-			},
+			yamlContent: `
+version: "1"
+controls:
+  containerImageMustNotUseForbiddenTags:
+    enabled: true
+  branchMustBeProtected:
+    enabled: true
+`,
 			expectWarnings: 0,
 		},
 		{
-			name: "unknown control key",
-			config: &PlumberConfig{
-				Controls: ControlsConfig{
-					ContainerImageMustNotUseForbiddenTags: &ContainerImageMustNotUseForbiddenTagsControlConfig{},
-					// This would need to be tested differently since ControlsConfig is a struct
-					// The actual implementation checks for unknown keys in the raw YAML
-				},
-			},
-			expectWarnings: 0, // Will be adjusted based on actual implementation
+			name: "unknown control key - typo missing 's'",
+			yamlContent: `
+version: "1"
+controls:
+  containerImageMustNotUseForbiddenTag:
+    enabled: true
+`,
+			expectWarnings: 1,
+			wantContains:   "containerImageMustNotUseForbiddenTags",
+		},
+		{
+			name: "multiple unknown keys",
+			yamlContent: `
+version: "1"
+controls:
+  containerImageMustNotUseForbiddenTag:
+    enabled: true
+  branchMustBeProtectod:
+    enabled: true
+`,
+			expectWarnings: 2,
+		},
+		{
+			name: "completely unknown key",
+			yamlContent: `
+version: "1"
+controls:
+  someRandomControl:
+    enabled: true
+`,
+			expectWarnings: 1,
+		},
+		{
+			name: "unknown sub-key - tags typo",
+			yamlContent: `
+version: "1"
+controls:
+  containerImageMustNotUseForbiddenTags:
+    enabled: true
+    tag:
+      - latest
+`,
+			expectWarnings: 1,
+			wantContains:   "tags",
+		},
+		{
+			name: "unknown sub-key - allowForcePush typo",
+			yamlContent: `
+version: "1"
+controls:
+  branchMustBeProtected:
+    enabled: true
+    allowForcePushes: false
+`,
+			expectWarnings: 1,
+			wantContains:   "allowForcePush",
+		},
+		{
+			name: "multiple sub-key typos in same control",
+			yamlContent: `
+version: "1"
+controls:
+  branchMustBeProtected:
+    enabled: true
+    namePattern:
+      - main
+    allowForcePushes: false
+`,
+			expectWarnings: 2,
+		},
+		{
+			name: "typo at both control and sub-key level",
+			yamlContent: `
+version: "1"
+controls:
+  containerImageMustNotUseForbiddenTag:
+    enabled: true
+  branchMustBeProtected:
+    enabled: true
+    allowForcePushes: false
+`,
+			expectWarnings: 2,
+		},
+		{
+			name: "valid sub-keys - no warnings",
+			yamlContent: `
+version: "1"
+controls:
+  branchMustBeProtected:
+    enabled: true
+    namePatterns:
+      - main
+    defaultMustBeProtected: true
+    allowForcePush: false
+    codeOwnerApprovalRequired: false
+    minMergeAccessLevel: 30
+    minPushAccessLevel: 40
+`,
+			expectWarnings: 0,
+		},
+		{
+			name: "completely unknown sub-key",
+			yamlContent: `
+version: "1"
+controls:
+  includesMustBeUpToDate:
+    enabled: true
+    somethingTotallyRandom: true
+`,
+			expectWarnings: 1,
+		},
+		{
+			name:           "invalid yaml - no warnings returned",
+			yamlContent:    `{{{invalid yaml`,
+			expectWarnings: 0,
+		},
+		{
+			name: "empty controls section - no warnings",
+			yamlContent: `
+version: "1"
+controls: {}
+`,
+			expectWarnings: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Note: ValidateKnownKeys checks for unknown keys in raw YAML
-			// This test verifies the function runs without error
-			_ = ValidateKnownKeys(tt.config)
-			// The actual warning count depends on the YAML parsing
+			warnings := ValidateKnownKeys([]byte(tt.yamlContent))
+			if len(warnings) != tt.expectWarnings {
+				t.Errorf("ValidateKnownKeys() returned %d warnings, want %d. Warnings: %v",
+					len(warnings), tt.expectWarnings, warnings)
+			}
+			if tt.wantContains != "" && len(warnings) > 0 {
+				found := false
+				for _, w := range warnings {
+					if contains([]string{w}, tt.wantContains) || len(w) > 0 && containsSubstring(w, tt.wantContains) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected warning to contain %q, but got: %v", tt.wantContains, warnings)
+				}
+			}
 		})
 	}
+}
+
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && findSubstring(s, substr))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Description
This PR implements issue #58 by adding validation for unknown configuration keys in .plumber.yaml.

Fixes #58

## Changes Made
- Added `validControlKeys` list with all 8 known control names
- Added `levenshteinDistance()` function for fuzzy string matching
- Added `findClosestMatch()` function to suggest corrections
- Added `ValidateKnownKeys()` function to check for unknown keys

## Usage
The function returns warning messages like:
```
Unknown control in .plumber.yaml: "containerImageMustNotUseForbiddenTag". 
Did you mean "containerImageMustNotUseForbiddenTags"?
```

## Implementation Details
- Uses Levenshtein distance algorithm for typo detection
- Only suggests corrections if distance is reasonable (< half key length + 2)
- Returns warnings as []string for caller to print to stderr

## Benefits
- Prevents silent misconfiguration
- Helps users catch typos immediately
- Easy to extend with new controls