### PR TITLE
feat(analyze): add --controls and --skip-controls filtering for control execution

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/getplumber/plumber/configuration"
@@ -28,6 +29,8 @@ var (
 	pbomCycloneDXFile string
 	mrComment         bool
 	badge             bool
+	controlsFilter    string
+	skipControls      string
 )
 
 var analyzeCmd = &cobra.Command{
@@ -60,6 +63,8 @@ Optional flags:
   --pbom-cyclonedx   Write PBOM in CycloneDX format for integration with security tools
   --mr-comment       Post/update a compliance comment on the merge request (requires api scope, merge request pipeline only)
   --badge            Create/update a Plumber compliance badge on the project (requires api scope; only runs on default branch)
+  --controls         Run only listed controls (comma-separated)
+  --skip-controls    Skip listed controls (comma-separated)
 
 Exit codes:
   0  Analysis passed (compliance >= threshold)
@@ -101,6 +106,8 @@ func init() {
 	analyzeCmd.Flags().StringVar(&pbomCycloneDXFile, "pbom-cyclonedx", "", "Write PBOM in CycloneDX format (for security tool integration)")
 	analyzeCmd.Flags().BoolVar(&mrComment, "mr-comment", false, "Post/update a compliance comment on the merge request (requires api scope token; only works in merge request pipelines)")
 	analyzeCmd.Flags().BoolVar(&badge, "badge", false, "Create/update a Plumber compliance badge on the project (requires api scope; only runs on default branch)")
+	analyzeCmd.Flags().StringVar(&controlsFilter, "controls", "", "Run only listed controls (comma-separated)")
+	analyzeCmd.Flags().StringVar(&skipControls, "skip-controls", "", "Skip listed controls (comma-separated)")
 }
 
 func runAnalyze(cmd *cobra.Command, args []string) error {
@@ -144,15 +151,28 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--project is required (could not auto-detect from git remote)")
 	}
 
+	// Validate threshold
+	if threshold < 0 || threshold > 100 {
+		return fmt.Errorf("threshold must be between 0 and 100")
+	}
+	if controlsFilter != "" && skipControls != "" {
+		return fmt.Errorf("--controls and --skip-controls cannot be used together")
+	}
+
+	controlsFilterList, err := parseControlsFilter(controlsFilter)
+	if err != nil {
+		return err
+	}
+
+	skipControlsList, err := parseControlsFilter(skipControls)
+	if err != nil {
+		return err
+	}
+
 	// Get token from environment variable (required)
 	gitlabToken := os.Getenv("GITLAB_TOKEN")
 	if gitlabToken == "" {
 		return fmt.Errorf("GITLAB_TOKEN environment variable is required")
-	}
-
-	// Validate threshold
-	if threshold < 0 || threshold > 100 {
-		return fmt.Errorf("threshold must be between 0 and 100")
 	}
 
 	// Clean up URL
@@ -183,6 +203,8 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	conf.Branch = defaultBranch
 	conf.PlumberConfig = plumberConfig
 	conf.GitRepoRoot = gitRepoRoot
+	conf.ControlsFilter = controlsFilterList
+	conf.SkipControlsFilter = skipControlsList
 
 	// Determine if the local git repo matches the project being analyzed.
 	// Local CI file support only applies when the local repo IS the analyzed project.
@@ -347,6 +369,64 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// parseControlsFilter parses and validates a comma separated control list.
+func parseControlsFilter(raw string) ([]string, error) {
+	// Empty flag means that no filter,
+	// so keep current behavior (all controls run).
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	// Resolve valid names from the same schema used by .plumber.yaml validation.
+	validControls := configuration.ValidControlNames()
+	validSet := make(map[string]struct{}, len(validControls))
+	for _, control := range validControls {
+		validSet[control] = struct{}{}
+	}
+
+	controls := make([]string, 0)
+	controlsSet := make(map[string]struct{})
+	unknown := make([]string, 0)
+	unknownSet := make(map[string]struct{})
+
+	for _, part := range strings.Split(raw, ",") {
+		control := strings.TrimSpace(part)
+		if control == "" {
+			continue
+		}
+
+		// Collecting unknown names so it can return one actionable error.
+		if _, ok := validSet[control]; !ok {
+			if _, seen := unknownSet[control]; !seen {
+				unknownSet[control] = struct{}{}
+				unknown = append(unknown, control)
+			}
+			continue
+		}
+
+		// Keeps the first occurrence only,
+		// it will avoid duplicate work downstream.
+		if _, seen := controlsSet[control]; seen {
+			continue
+		}
+		controlsSet[control] = struct{}{}
+		controls = append(controls, control)
+	}
+
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		sort.Strings(validControls)
+		return nil, fmt.Errorf(
+			strings.Join(unknown, ", "),
+			"unknown control names: %s. valid controls: %s",
+			strings.Join(validControls, ", "),
+		)
+	}
+
+	return controls, nil
 }
 
 func writeJSONToFile(result *control.AnalysisResult, threshold, compliance float64, filePath string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -21,7 +20,14 @@ and enforces trust policies on third-party components, images, and branch protec
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		// Duplicated output
+		// Cobra give same output;
+		// from github.com/spf13/cobra v1.8.1
+		// just commenting this duplication for now.
+		// to validate, just uncomment that fmt line and run this command:
+		// make build && ./plumber analyze --gitlab-url https://gitlab.com --project a/b --controls nope
+		//
+		// fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -40,6 +40,12 @@ type Configuration struct {
 
 	// Plumber Configuration (from .plumber.yaml file)
 	PlumberConfig *PlumberConfig
+
+	// Values must match .plumber.yaml control keys
+	// ControlsFilter runs only the listed controls when set;
+	ControlsFilter []string
+	// SkipControlsFilter skips the listed controls when set;
+	SkipControlsFilter []string
 }
 
 // NewDefaultConfiguration creates a Configuration with sensible defaults

--- a/configuration/plumberconfig.go
+++ b/configuration/plumberconfig.go
@@ -49,6 +49,13 @@ func validControlNames() []string {
 	return keys
 }
 
+// ValidControlNames returns all known control names from the configuration schema;
+func ValidControlNames() []string {
+	names := validControlNames()
+	sort.Strings(names)
+	return names
+}
+
 // PlumberConfig represents the .plumber.yaml configuration file structure
 type PlumberConfig struct {
 	// Version of the config file format

--- a/configuration/plumberconfig_test.go
+++ b/configuration/plumberconfig_test.go
@@ -324,3 +324,28 @@ func findSubstring(s, substr string) bool {
 	}
 	return false
 }
+
+func TestValidControlNames(t *testing.T) {
+	names := ValidControlNames()
+
+	expected := []string{
+		"branchMustBeProtected",
+		"containerImageMustComeFromAuthorizedSources",
+		"containerImageMustNotUseForbiddenTags",
+		"includesMustBeUpToDate",
+		"includesMustNotUseForbiddenVersions",
+		"pipelineMustIncludeComponent",
+		"pipelineMustIncludeTemplate",
+		"pipelineMustNotIncludeHardcodedJobs",
+	}
+
+	if len(names) != len(expected) {
+		t.Fatalf("ValidControlNames() returned %d entries, want %d (%v)", len(names), len(expected), names)
+	}
+
+	for i := range expected {
+		if names[i] != expected[i] {
+			t.Fatalf("ValidControlNames()[%d] = %q, want %q", i, names[i], expected[i])
+		}
+	}
+}

--- a/control/controlGitlabImagePinnedByDigest_test.go
+++ b/control/controlGitlabImagePinnedByDigest_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/getplumber/plumber/collector"
+	"github.com/getplumber/plumber/configuration"
 )
 
 func TestIsImagePinnedByDigest(t *testing.T) {
@@ -228,5 +229,63 @@ func TestMustBePinnedByDigestAllPinned(t *testing.T) {
 	}
 	if result.Metrics.PinnedByDigest != 2 {
 		t.Fatalf("expected pinnedByDigest to be 2, got %d", result.Metrics.PinnedByDigest)
+	}
+}
+
+func TestShouldRunControl(t *testing.T) {
+	tests := []struct {
+		name      string
+		control   string
+		conf      *configuration.Configuration
+		shouldRun bool
+	}{
+		{
+			name:      "no filters",
+			control:   "branchMustBeProtected",
+			conf:      &configuration.Configuration{},
+			shouldRun: true,
+		},
+		{
+			name:    "included control runs",
+			control: "branchMustBeProtected",
+			conf: &configuration.Configuration{
+				ControlsFilter: []string{"branchMustBeProtected"},
+			},
+			shouldRun: true,
+		},
+		{
+			name:    "controls filter excludes control",
+			control: "includesMustBeUpToDate",
+			conf: &configuration.Configuration{
+				ControlsFilter: []string{"branchMustBeProtected"},
+			},
+			shouldRun: false,
+		},
+		{
+			name:    "skip filter excludes control",
+			control: "branchMustBeProtected",
+			conf: &configuration.Configuration{
+				SkipControlsFilter: []string{"branchMustBeProtected"},
+			},
+			shouldRun: false,
+		},
+		{
+			name:    "skip still wins if both contain control",
+			control: "branchMustBeProtected",
+			conf: &configuration.Configuration{
+				ControlsFilter:     []string{"branchMustBeProtected"},
+				SkipControlsFilter: []string{"branchMustBeProtected"},
+			},
+			shouldRun: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldRunControl(tt.control, tt.conf)
+			if got != tt.shouldRun {
+				t.Fatalf("shouldRunControl(%q) = %v, want %v", tt.control, got, tt.shouldRun)
+			}
+		})
 	}
 }

--- a/control/task.go
+++ b/control/task.go
@@ -11,6 +11,50 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	// Control names match .plumber.yaml keys exactly.
+	controlContainerImageMustNotUseForbiddenTags       = "containerImageMustNotUseForbiddenTags"
+	controlContainerImageMustComeFromAuthorizedSources = "containerImageMustComeFromAuthorizedSources"
+	controlBranchMustBeProtected                       = "branchMustBeProtected"
+	controlPipelineMustNotIncludeHardcodedJobs         = "pipelineMustNotIncludeHardcodedJobs"
+	controlIncludesMustBeUpToDate                      = "includesMustBeUpToDate"
+	controlIncludesMustNotUseForbiddenVersions         = "includesMustNotUseForbiddenVersions"
+	controlPipelineMustIncludeComponent                = "pipelineMustIncludeComponent"
+	controlPipelineMustIncludeTemplate                 = "pipelineMustIncludeTemplate"
+)
+
+// shouldRunControl applies --controls / --skip-controls filtering for a control.
+// If --controls is set, only listed controls are eligible.
+// Then --skip-controls removes controls from that eligible set.
+func shouldRunControl(controlName string, conf *configuration.Configuration) bool {
+	if conf == nil {
+		return true
+	}
+
+	// If --controls is set, only listed controls should run
+	if len(conf.ControlsFilter) > 0 {
+		found := false
+		for _, name := range conf.ControlsFilter {
+			if name == controlName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// If --skip-controls is set, listed controls should not run
+	for _, name := range conf.SkipControlsFilter {
+		if name == controlName {
+			return false
+		}
+	}
+
+	return true
+}
+
 // RunAnalysis executes the complete pipeline analysis for a GitLab project
 func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 	l := l.WithFields(logrus.Fields{
@@ -200,9 +244,13 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 
 	// Load control configuration from PlumberConfig (required)
 	forbiddenTagsConf := &GitlabImageForbiddenTagsConf{}
-	if err := forbiddenTagsConf.GetConf(conf.PlumberConfig); err != nil {
-		l.WithError(err).Error("Failed to load ImageForbiddenTags config from .plumber.yaml file")
-		return result, fmt.Errorf("invalid configuration: %w", err)
+	if shouldRunControl(controlContainerImageMustNotUseForbiddenTags, conf) {
+		if err := forbiddenTagsConf.GetConf(conf.PlumberConfig); err != nil {
+			l.WithError(err).Error("Failed to load ImageForbiddenTags config from .plumber.yaml file")
+			return result, fmt.Errorf("invalid configuration: %w", err)
+		}
+	} else {
+		forbiddenTagsConf.Enabled = false
 	}
 
 	forbiddenTagsResult := forbiddenTagsConf.Run(pipelineImageData)
@@ -212,9 +260,13 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 	l.Info("Running Image Authorized Sources control")
 
 	authorizedSourcesConf := &GitlabImageAuthorizedSourcesConf{}
-	if err := authorizedSourcesConf.GetConf(conf.PlumberConfig); err != nil {
-		l.WithError(err).Error("Failed to load ImageAuthorizedSources config from .plumber.yaml file")
-		return result, fmt.Errorf("invalid configuration: %w", err)
+	if shouldRunControl(controlContainerImageMustComeFromAuthorizedSources, conf) {
+		if err := authorizedSourcesConf.GetConf(conf.PlumberConfig); err != nil {
+			l.WithError(err).Error("Failed to load ImageAuthorizedSources config from .plumber.yaml file")
+			return result, fmt.Errorf("invalid configuration: %w", err)
+		}
+	} else {
+		authorizedSourcesConf.Enabled = false
 	}
 
 	authorizedSourcesResult := authorizedSourcesConf.Run(pipelineImageData)
@@ -224,9 +276,13 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 	l.Info("Running Pipeline Must Not Include Hardcoded Jobs control")
 
 	hardcodedJobsConf := &GitlabPipelineHardcodedJobsConf{}
-	if err := hardcodedJobsConf.GetConf(conf.PlumberConfig); err != nil {
-		l.WithError(err).Error("Failed to load HardcodedJobs config from .plumber.yaml file")
-		return result, fmt.Errorf("invalid configuration: %w", err)
+	if shouldRunControl(controlPipelineMustNotIncludeHardcodedJobs, conf) {
+		if err := hardcodedJobsConf.GetConf(conf.PlumberConfig); err != nil {
+			l.WithError(err).Error("Failed to load HardcodedJobs config from .plumber.yaml file")
+			return result, fmt.Errorf("invalid configuration: %w", err)
+		}
+	} else {
+		hardcodedJobsConf.Enabled = false
 	}
 
 	hardcodedJobsResult := hardcodedJobsConf.Run(pipelineOriginData)
@@ -236,9 +292,13 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 	l.Info("Running Includes Must Be Up To Date control")
 
 	outdatedConf := &GitlabPipelineIncludesOutdatedConf{}
-	if err := outdatedConf.GetConf(conf.PlumberConfig); err != nil {
-		l.WithError(err).Error("Failed to load IncludesOutdated config from .plumber.yaml file")
-		return result, fmt.Errorf("invalid configuration: %w", err)
+	if shouldRunControl(controlIncludesMustBeUpToDate, conf) {
+		if err := outdatedConf.GetConf(conf.PlumberConfig); err != nil {
+			l.WithError(err).Error("Failed to load IncludesOutdated config from .plumber.yaml file")
+			return result, fmt.Errorf("invalid configuration: %w", err)
+		}
+	} else {
+		outdatedConf.Enabled = false
 	}
 
 	outdatedResult := outdatedConf.Run(pipelineOriginData)
@@ -248,48 +308,65 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 	l.Info("Running Includes Must Not Use Forbidden Versions control")
 
 	forbiddenVersionConf := &GitlabPipelineIncludesForbiddenVersionConf{}
-	if err := forbiddenVersionConf.GetConf(conf.PlumberConfig); err != nil {
-		l.WithError(err).Error("Failed to load ForbiddenVersions config from .plumber.yaml file")
-		return result, fmt.Errorf("invalid configuration: %w", err)
+	if shouldRunControl(controlIncludesMustNotUseForbiddenVersions, conf) {
+		if err := forbiddenVersionConf.GetConf(conf.PlumberConfig); err != nil {
+			l.WithError(err).Error("Failed to load ForbiddenVersions config from .plumber.yaml file")
+			return result, fmt.Errorf("invalid configuration: %w", err)
+		}
+	} else {
+		forbiddenVersionConf.Enabled = false
 	}
 
 	forbiddenVersionResult := forbiddenVersionConf.Run(pipelineOriginData, projectInfo.DefaultBranch)
 	result.ForbiddenVersionsIncludesResult = forbiddenVersionResult
 
 	// 8. Run Branch Must Be Protected control (if enabled)
-	branchProtectionConfig := conf.PlumberConfig.GetBranchMustBeProtectedConfig()
-	if branchProtectionConfig != nil && branchProtectionConfig.IsEnabled() {
-		l.Info("Running Branch Must Be Protected control")
+	if shouldRunControl(controlBranchMustBeProtected, conf) {
+		branchProtectionConfig := conf.PlumberConfig.GetBranchMustBeProtectedConfig()
+		if branchProtectionConfig != nil && branchProtectionConfig.IsEnabled() {
+			l.Info("Running Branch Must Be Protected control")
 
-		// Run Protection data collection first
-		protectionDC := &collector.GitlabProtectionDataCollection{}
-		protectionData, _, err := protectionDC.Run(projectInfo, conf.GitlabToken, conf)
-		if err != nil {
-			l.WithError(err).Error("Protection data collection failed")
-			// Data collection failed - set compliance to 0 but continue
-			result.BranchProtectionResult = &GitlabBranchProtectionResult{
-				Enabled:    true,
-				Compliance: 0,
-				Version:    ControlTypeGitlabProtectionBranchProtectionNotCompliantVersion,
-				Error:      err.Error(),
+			// Run Protection data collection first
+			protectionDC := &collector.GitlabProtectionDataCollection{}
+			protectionData, _, err := protectionDC.Run(projectInfo, conf.GitlabToken, conf)
+			if err != nil {
+				l.WithError(err).Error("Protection data collection failed")
+				// Data collection failed - set compliance to 0 but continue
+				result.BranchProtectionResult = &GitlabBranchProtectionResult{
+					Enabled:    true,
+					Compliance: 0,
+					Version:    ControlTypeGitlabProtectionBranchProtectionNotCompliantVersion,
+					Error:      err.Error(),
+				}
+			} else {
+				// Run the branch protection control
+				branchProtectionControl := NewGitlabBranchProtectionControl(branchProtectionConfig)
+				branchProtectionResult := branchProtectionControl.Run(protectionData, projectInfo)
+				result.BranchProtectionResult = branchProtectionResult
 			}
 		} else {
-			// Run the branch protection control
-			branchProtectionControl := NewGitlabBranchProtectionControl(branchProtectionConfig)
-			branchProtectionResult := branchProtectionControl.Run(protectionData, projectInfo)
-			result.BranchProtectionResult = branchProtectionResult
+			l.Debug("Branch Must Be Protected control is disabled or not configured")
 		}
 	} else {
-		l.Debug("Branch Must Be Protected control is disabled or not configured")
+		result.BranchProtectionResult = &GitlabBranchProtectionResult{
+			Enabled:    false,
+			Skipped:    true,
+			Compliance: 100.0,
+			Version:    ControlTypeGitlabProtectionBranchProtectionNotCompliantVersion,
+		}
 	}
 
 	// 9. Run Pipeline Must Include Component control
 	l.Info("Running Pipeline Must Include Component control")
 
 	requiredComponentsConf := &GitlabPipelineRequiredComponentsConf{}
-	if err := requiredComponentsConf.GetConf(conf.PlumberConfig); err != nil {
-		l.WithError(err).Error("Failed to load RequiredComponents config from .plumber.yaml file")
-		return result, fmt.Errorf("invalid configuration: %w", err)
+	if shouldRunControl(controlPipelineMustIncludeComponent, conf) {
+		if err := requiredComponentsConf.GetConf(conf.PlumberConfig); err != nil {
+			l.WithError(err).Error("Failed to load RequiredComponents config from .plumber.yaml file")
+			return result, fmt.Errorf("invalid configuration: %w", err)
+		}
+	} else {
+		requiredComponentsConf.Enabled = false
 	}
 
 	requiredComponentsResult := requiredComponentsConf.Run(pipelineOriginData, conf.GitlabURL)
@@ -299,9 +376,13 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 	l.Info("Running Pipeline Must Include Template control")
 
 	requiredTemplatesConf := &GitlabPipelineRequiredTemplatesConf{}
-	if err := requiredTemplatesConf.GetConf(conf.PlumberConfig); err != nil {
-		l.WithError(err).Error("Failed to load RequiredTemplates config from .plumber.yaml file")
-		return result, fmt.Errorf("invalid configuration: %w", err)
+	if shouldRunControl(controlPipelineMustIncludeTemplate, conf) {
+		if err := requiredTemplatesConf.GetConf(conf.PlumberConfig); err != nil {
+			l.WithError(err).Error("Failed to load RequiredTemplates config from .plumber.yaml file")
+			return result, fmt.Errorf("invalid configuration: %w", err)
+		}
+	} else {
+		requiredTemplatesConf.Enabled = false
 	}
 
 	requiredTemplatesResult := requiredTemplatesConf.Run(pipelineOriginData)


### PR DESCRIPTION
### Summary

It will add two new `analyze` flags for control selection
(comma-seperated)

- `--controls`  runs only the listed controls
- `--skip-controls`  runs everything except the listed controls

if no flags is used, behavior stays the same

closes #57 

### Behavior

So unknown control names now return an error with valid name and using both flags togerther returns error, filtered controls are marked as skipped in output

### Tests

added test for valid control name list and for filter decision logic `shouldRunControl`

### NOTICE

In root.go check the comment, duplication 

