### PR TITLE
Feat/controls filter fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Add this to your `.gitlab-ci.yml`:
 
 ```yaml
 include:
-  - component: gitlab.com/getplumber/plumber/plumber@v0.1.26
+  - component: gitlab.com/getplumber/plumber/plumber@v0.1.27
 ```
 * Get the latest version from the [Catalog](https://gitlab.com/explore/catalog/getplumber/plumber)
 
@@ -206,7 +206,7 @@ Override any input to fit your needs:
 
 ```yaml
 include:
-  - component: gitlab.com/getplumber/plumber/plumber@v0.1.26
+  - component: gitlab.com/getplumber/plumber/plumber@v0.1.27
     inputs:
       threshold: 80                           # Minimum % to pass (default: 100)
       config_file: configs/my-plumber.yaml    # Custom config path
@@ -236,6 +236,8 @@ include:
 | `verbose` | `false` | Enable debug output |
 | `mr_comment` | `false` | Post/update a compliance comment on the merge request (requires `api` scope) |
 | `badge` | `false` | Create/update a Plumber compliance badge on the project (requires `api` scope; only runs on default branch) |
+| `controls` | — | Run only listed controls (comma-separated). Cannot be used with `skip_controls` |
+| `skip_controls` | — | Skip listed controls (comma-separated). Cannot be used with `controls` |
 
 </details>
 
@@ -432,6 +434,51 @@ pipelineMustIncludeTemplate:
 
 </details>
 
+### Selective Control Execution
+
+You can run or skip specific controls using their YAML key names from `.plumber.yaml`. This is useful for iterative debugging or targeted CI checks.
+
+**Run only specific controls:**
+
+```bash
+# Only check image tags and branch protection
+plumber analyze --controls containerImageMustNotUseForbiddenTags,branchMustBeProtected
+```
+
+**Skip specific controls:**
+
+```bash
+# Run everything except branch protection (avoids API calls you don't need)
+plumber analyze --skip-controls branchMustBeProtected
+```
+
+**In the GitLab CI component:**
+
+```yaml
+include:
+  - component: gitlab.com/getplumber/plumber/plumber@v0.1.27
+    inputs:
+      controls: containerImageMustNotUseForbiddenTags,containerImageMustComeFromAuthorizedSources
+```
+
+Controls not selected are reported as **skipped** in the output. The `--controls` and `--skip-controls` flags are mutually exclusive.
+
+<details>
+<summary><b>Valid control names</b></summary>
+
+| Control Name |
+|-------------|
+| `branchMustBeProtected` |
+| `containerImageMustComeFromAuthorizedSources` |
+| `containerImageMustNotUseForbiddenTags` |
+| `includesMustBeUpToDate` |
+| `includesMustNotUseForbiddenVersions` |
+| `pipelineMustIncludeComponent` |
+| `pipelineMustIncludeTemplate` |
+| `pipelineMustNotIncludeHardcodedJobs` |
+
+</details>
+
 ---
 
 ## 📊 Artifacts & Outputs
@@ -511,7 +558,7 @@ Automatically post compliance summaries on merge requests to catch issues before
 
 ```yaml
 include:
-  - component: gitlab.com/getplumber/plumber/plumber@v0.1.26
+  - component: gitlab.com/getplumber/plumber/plumber@v0.1.27
     inputs:
       mr_comment: true  # Requires api scope on token
 ```
@@ -534,7 +581,7 @@ Display a live compliance badge on your project's overview page.
 
 ```yaml
 include:
-  - component: gitlab.com/getplumber/plumber/plumber@v0.1.26
+  - component: gitlab.com/getplumber/plumber/plumber@v0.1.27
     inputs:
       badge: true  # Requires api scope on token
 ```
@@ -692,6 +739,8 @@ plumber analyze [flags]
 | `--print` | No | `true` | Print text output to stdout |
 | `--mr-comment` | No | `false` | Post/update a compliance comment on the merge request (MR pipelines only: requires `api` scope) |
 | `--badge` | No | `false` | Create/update a Plumber compliance badge on the project (requires `api` scope; only runs on default branch) |
+| `--controls` | No | — | Run only listed controls (comma-separated). Cannot be used with `--skip-controls` |
+| `--skip-controls` | No | — | Skip listed controls (comma-separated). Cannot be used with `--controls` |
 | `--verbose`, `-v` | No | `false` | Enable verbose/debug output for troubleshooting |
 
 > \* Auto-detected from git remote (`origin`) if not specified. Supports both SSH and HTTPS remote URLs.

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -419,11 +419,16 @@ func parseControlsFilter(raw string) ([]string, error) {
 	if len(unknown) > 0 {
 		sort.Strings(unknown)
 		sort.Strings(validControls)
-		return nil, fmt.Errorf(
-			strings.Join(unknown, ", "),
-			"unknown control names: %s. valid controls: %s",
-			strings.Join(validControls, ", "),
-		)
+		var b strings.Builder
+		b.WriteString("unknown control names: ")
+		b.WriteString(strings.Join(unknown, ", "))
+		b.WriteString("\n\nValid controls:\n")
+		for _, name := range validControls {
+			b.WriteString("  - ")
+			b.WriteString(name)
+			b.WriteString("\n")
+		}
+		return nil, fmt.Errorf("%s", b.String())
 	}
 
 	return controls, nil

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/getplumber/plumber/configuration"
@@ -28,6 +29,8 @@ var (
 	pbomCycloneDXFile string
 	mrComment         bool
 	badge             bool
+	controlsFilter    string
+	skipControls      string
 )
 
 var analyzeCmd = &cobra.Command{
@@ -60,6 +63,8 @@ Optional flags:
   --pbom-cyclonedx   Write PBOM in CycloneDX format for integration with security tools
   --mr-comment       Post/update a compliance comment on the merge request (requires api scope, merge request pipeline only)
   --badge            Create/update a Plumber compliance badge on the project (requires api scope; only runs on default branch)
+  --controls         Run only listed controls (comma-separated)
+  --skip-controls    Skip listed controls (comma-separated)
 
 Exit codes:
   0  Analysis passed (compliance >= threshold)
@@ -101,6 +106,8 @@ func init() {
 	analyzeCmd.Flags().StringVar(&pbomCycloneDXFile, "pbom-cyclonedx", "", "Write PBOM in CycloneDX format (for security tool integration)")
 	analyzeCmd.Flags().BoolVar(&mrComment, "mr-comment", false, "Post/update a compliance comment on the merge request (requires api scope token; only works in merge request pipelines)")
 	analyzeCmd.Flags().BoolVar(&badge, "badge", false, "Create/update a Plumber compliance badge on the project (requires api scope; only runs on default branch)")
+	analyzeCmd.Flags().StringVar(&controlsFilter, "controls", "", "Run only listed controls (comma-separated)")
+	analyzeCmd.Flags().StringVar(&skipControls, "skip-controls", "", "Skip listed controls (comma-separated)")
 }
 
 func runAnalyze(cmd *cobra.Command, args []string) error {
@@ -144,15 +151,28 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--project is required (could not auto-detect from git remote)")
 	}
 
+	// Validate threshold
+	if threshold < 0 || threshold > 100 {
+		return fmt.Errorf("threshold must be between 0 and 100")
+	}
+	if controlsFilter != "" && skipControls != "" {
+		return fmt.Errorf("--controls and --skip-controls cannot be used together")
+	}
+
+	controlsFilterList, err := parseControlsFilter(controlsFilter)
+	if err != nil {
+		return err
+	}
+
+	skipControlsList, err := parseControlsFilter(skipControls)
+	if err != nil {
+		return err
+	}
+
 	// Get token from environment variable (required)
 	gitlabToken := os.Getenv("GITLAB_TOKEN")
 	if gitlabToken == "" {
 		return fmt.Errorf("GITLAB_TOKEN environment variable is required")
-	}
-
-	// Validate threshold
-	if threshold < 0 || threshold > 100 {
-		return fmt.Errorf("threshold must be between 0 and 100")
 	}
 
 	// Clean up URL
@@ -183,6 +203,8 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	conf.Branch = defaultBranch
 	conf.PlumberConfig = plumberConfig
 	conf.GitRepoRoot = gitRepoRoot
+	conf.ControlsFilter = controlsFilterList
+	conf.SkipControlsFilter = skipControlsList
 
 	// Determine if the local git repo matches the project being analyzed.
 	// Local CI file support only applies when the local repo IS the analyzed project.
@@ -347,6 +369,64 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// parseControlsFilter parses and validates a comma separated control list.
+func parseControlsFilter(raw string) ([]string, error) {
+	// Empty flag means that no filter,
+	// so keep current behavior (all controls run).
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	// Resolve valid names from the same schema used by .plumber.yaml validation.
+	validControls := configuration.ValidControlNames()
+	validSet := make(map[string]struct{}, len(validControls))
+	for _, control := range validControls {
+		validSet[control] = struct{}{}
+	}
+
+	controls := make([]string, 0)
+	controlsSet := make(map[string]struct{})
+	unknown := make([]string, 0)
+	unknownSet := make(map[string]struct{})
+
+	for _, part := range strings.Split(raw, ",") {
+		control := strings.TrimSpace(part)
+		if control == "" {
+			continue
+		}
+
+		// Collecting unknown names so it can return one actionable error.
+		if _, ok := validSet[control]; !ok {
+			if _, seen := unknownSet[control]; !seen {
+				unknownSet[control] = struct{}{}
+				unknown = append(unknown, control)
+			}
+			continue
+		}
+
+		// Keeps the first occurrence only,
+		// it will avoid duplicate work downstream.
+		if _, seen := controlsSet[control]; seen {
+			continue
+		}
+		controlsSet[control] = struct{}{}
+		controls = append(controls, control)
+	}
+
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		sort.Strings(validControls)
+		return nil, fmt.Errorf(
+			strings.Join(unknown, ", "),
+			"unknown control names: %s. valid controls: %s",
+			strings.Join(validControls, ", "),
+		)
+	}
+
+	return controls, nil
 }
 
 func writeJSONToFile(result *control.AnalysisResult, threshold, compliance float64, filePath string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -21,7 +20,14 @@ and enforces trust policies on third-party components, images, and branch protec
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		// Duplicated output
+		// Cobra give same output;
+		// from github.com/spf13/cobra v1.8.1
+		// just commenting this duplication for now.
+		// to validate, just uncomment that fmt line and run this command:
+		// make build && ./plumber analyze --gitlab-url https://gitlab.com --project a/b --controls nope
+		//
+		// fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -40,6 +40,12 @@ type Configuration struct {
 
 	// Plumber Configuration (from .plumber.yaml file)
 	PlumberConfig *PlumberConfig
+
+	// Values must match .plumber.yaml control keys
+	// ControlsFilter runs only the listed controls when set;
+	ControlsFilter []string
+	// SkipControlsFilter skips the listed controls when set;
+	SkipControlsFilter []string
 }
 
 // NewDefaultConfiguration creates a Configuration with sensible defaults

--- a/configuration/plumberconfig.go
+++ b/configuration/plumberconfig.go
@@ -49,6 +49,13 @@ func validControlNames() []string {
 	return keys
 }
 
+// ValidControlNames returns all known control names from the configuration schema;
+func ValidControlNames() []string {
+	names := validControlNames()
+	sort.Strings(names)
+	return names
+}
+
 // PlumberConfig represents the .plumber.yaml configuration file structure
 type PlumberConfig struct {
 	// Version of the config file format

--- a/configuration/plumberconfig_test.go
+++ b/configuration/plumberconfig_test.go
@@ -324,3 +324,28 @@ func findSubstring(s, substr string) bool {
 	}
 	return false
 }
+
+func TestValidControlNames(t *testing.T) {
+	names := ValidControlNames()
+
+	expected := []string{
+		"branchMustBeProtected",
+		"containerImageMustComeFromAuthorizedSources",
+		"containerImageMustNotUseForbiddenTags",
+		"includesMustBeUpToDate",
+		"includesMustNotUseForbiddenVersions",
+		"pipelineMustIncludeComponent",
+		"pipelineMustIncludeTemplate",
+		"pipelineMustNotIncludeHardcodedJobs",
+	}
+
+	if len(names) != len(expected) {
+		t.Fatalf("ValidControlNames() returned %d entries, want %d (%v)", len(names), len(expected), names)
+	}
+
+	for i := range expected {
+		if names[i] != expected[i] {
+			t.Fatalf("ValidControlNames()[%d] = %q, want %q", i, names[i], expected[i])
+		}
+	}
+}

--- a/configuration/plumberconfig_test.go
+++ b/configuration/plumberconfig_test.go
@@ -1,6 +1,7 @@
 package configuration
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -299,7 +300,7 @@ controls: {}
 			if tt.wantContains != "" && len(warnings) > 0 {
 				found := false
 				for _, w := range warnings {
-					if contains([]string{w}, tt.wantContains) || len(w) > 0 && containsSubstring(w, tt.wantContains) {
+					if strings.Contains(w, tt.wantContains) {
 						found = true
 						break
 					}
@@ -312,17 +313,30 @@ controls: {}
 	}
 }
 
-func containsSubstring(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && findSubstring(s, substr))
-}
 
-func findSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
+func TestValidControlNames(t *testing.T) {
+	names := ValidControlNames()
+
+	expected := []string{
+		"branchMustBeProtected",
+		"containerImageMustComeFromAuthorizedSources",
+		"containerImageMustNotUseForbiddenTags",
+		"includesMustBeUpToDate",
+		"includesMustNotUseForbiddenVersions",
+		"pipelineMustIncludeComponent",
+		"pipelineMustIncludeTemplate",
+		"pipelineMustNotIncludeHardcodedJobs",
+	}
+
+	if len(names) != len(expected) {
+		t.Fatalf("ValidControlNames() returned %d entries, want %d (%v)", len(names), len(expected), names)
+	}
+
+	for i := range expected {
+		if names[i] != expected[i] {
+			t.Fatalf("ValidControlNames()[%d] = %q, want %q", i, names[i], expected[i])
 		}
 	}
-	return false
 }
 
 func TestValidControlNames(t *testing.T) {

--- a/control/controlGitlabImagePinnedByDigest_test.go
+++ b/control/controlGitlabImagePinnedByDigest_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/getplumber/plumber/collector"
+	"github.com/getplumber/plumber/configuration"
 )
 
 func TestIsImagePinnedByDigest(t *testing.T) {
@@ -228,5 +229,63 @@ func TestMustBePinnedByDigestAllPinned(t *testing.T) {
 	}
 	if result.Metrics.PinnedByDigest != 2 {
 		t.Fatalf("expected pinnedByDigest to be 2, got %d", result.Metrics.PinnedByDigest)
+	}
+}
+
+func TestShouldRunControl(t *testing.T) {
+	tests := []struct {
+		name      string
+		control   string
+		conf      *configuration.Configuration
+		shouldRun bool
+	}{
+		{
+			name:      "no filters",
+			control:   "branchMustBeProtected",
+			conf:      &configuration.Configuration{},
+			shouldRun: true,
+		},
+		{
+			name:    "included control runs",
+			control: "branchMustBeProtected",
+			conf: &configuration.Configuration{
+				ControlsFilter: []string{"branchMustBeProtected"},
+			},
+			shouldRun: true,
+		},
+		{
+			name:    "controls filter excludes control",
+			control: "includesMustBeUpToDate",
+			conf: &configuration.Configuration{
+				ControlsFilter: []string{"branchMustBeProtected"},
+			},
+			shouldRun: false,
+		},
+		{
+			name:    "skip filter excludes control",
+			control: "branchMustBeProtected",
+			conf: &configuration.Configuration{
+				SkipControlsFilter: []string{"branchMustBeProtected"},
+			},
+			shouldRun: false,
+		},
+		{
+			name:    "skip still wins if both contain control",
+			control: "branchMustBeProtected",
+			conf: &configuration.Configuration{
+				ControlsFilter:     []string{"branchMustBeProtected"},
+				SkipControlsFilter: []string{"branchMustBeProtected"},
+			},
+			shouldRun: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldRunControl(tt.control, tt.conf)
+			if got != tt.shouldRun {
+				t.Fatalf("shouldRunControl(%q) = %v, want %v", tt.control, got, tt.shouldRun)
+			}
+		})
 	}
 }

--- a/control/controlGitlabImagePinnedByDigest_test.go
+++ b/control/controlGitlabImagePinnedByDigest_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/getplumber/plumber/collector"
-	"github.com/getplumber/plumber/configuration"
 )
 
 func TestIsImagePinnedByDigest(t *testing.T) {
@@ -229,63 +228,5 @@ func TestMustBePinnedByDigestAllPinned(t *testing.T) {
 	}
 	if result.Metrics.PinnedByDigest != 2 {
 		t.Fatalf("expected pinnedByDigest to be 2, got %d", result.Metrics.PinnedByDigest)
-	}
-}
-
-func TestShouldRunControl(t *testing.T) {
-	tests := []struct {
-		name      string
-		control   string
-		conf      *configuration.Configuration
-		shouldRun bool
-	}{
-		{
-			name:      "no filters",
-			control:   "branchMustBeProtected",
-			conf:      &configuration.Configuration{},
-			shouldRun: true,
-		},
-		{
-			name:    "included control runs",
-			control: "branchMustBeProtected",
-			conf: &configuration.Configuration{
-				ControlsFilter: []string{"branchMustBeProtected"},
-			},
-			shouldRun: true,
-		},
-		{
-			name:    "controls filter excludes control",
-			control: "includesMustBeUpToDate",
-			conf: &configuration.Configuration{
-				ControlsFilter: []string{"branchMustBeProtected"},
-			},
-			shouldRun: false,
-		},
-		{
-			name:    "skip filter excludes control",
-			control: "branchMustBeProtected",
-			conf: &configuration.Configuration{
-				SkipControlsFilter: []string{"branchMustBeProtected"},
-			},
-			shouldRun: false,
-		},
-		{
-			name:    "skip still wins if both contain control",
-			control: "branchMustBeProtected",
-			conf: &configuration.Configuration{
-				ControlsFilter:     []string{"branchMustBeProtected"},
-				SkipControlsFilter: []string{"branchMustBeProtected"},
-			},
-			shouldRun: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := shouldRunControl(tt.control, tt.conf)
-			if got != tt.shouldRun {
-				t.Fatalf("shouldRunControl(%q) = %v, want %v", tt.control, got, tt.shouldRun)
-			}
-		})
 	}
 }

--- a/control/control_filter_test.go
+++ b/control/control_filter_test.go
@@ -1,0 +1,65 @@
+package control
+
+import (
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+)
+
+func TestShouldRunControl(t *testing.T) {
+	tests := []struct {
+		name      string
+		control   string
+		conf      *configuration.Configuration
+		shouldRun bool
+	}{
+		{
+			name:      "no filters",
+			control:   "branchMustBeProtected",
+			conf:      &configuration.Configuration{},
+			shouldRun: true,
+		},
+		{
+			name:    "included control runs",
+			control: "branchMustBeProtected",
+			conf: &configuration.Configuration{
+				ControlsFilter: []string{"branchMustBeProtected"},
+			},
+			shouldRun: true,
+		},
+		{
+			name:    "controls filter excludes control",
+			control: "includesMustBeUpToDate",
+			conf: &configuration.Configuration{
+				ControlsFilter: []string{"branchMustBeProtected"},
+			},
+			shouldRun: false,
+		},
+		{
+			name:    "skip filter excludes control",
+			control: "branchMustBeProtected",
+			conf: &configuration.Configuration{
+				SkipControlsFilter: []string{"branchMustBeProtected"},
+			},
+			shouldRun: false,
+		},
+		{
+			name:    "skip still wins if both contain control",
+			control: "branchMustBeProtected",
+			conf: &configuration.Configuration{
+				ControlsFilter:     []string{"branchMustBeProtected"},
+				SkipControlsFilter: []string{"branchMustBeProtected"},
+			},
+			shouldRun: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldRunControl(tt.control, tt.conf)
+			if got != tt.shouldRun {
+				t.Fatalf("shouldRunControl(%q) = %v, want %v", tt.control, got, tt.shouldRun)
+			}
+		})
+	}
+}

--- a/control/task.go
+++ b/control/task.go
@@ -26,6 +26,7 @@ const (
 // shouldRunControl applies --controls / --skip-controls filtering for a control.
 // If --controls is set, only listed controls are eligible.
 // Then --skip-controls removes controls from that eligible set.
+// Normally the CLI will not allow setting both --controls and --skip-controls together
 func shouldRunControl(controlName string, conf *configuration.Configuration) bool {
 	if conf == nil {
 		return true

--- a/control/task.go
+++ b/control/task.go
@@ -11,6 +11,50 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	// Control names match .plumber.yaml keys exactly.
+	controlContainerImageMustNotUseForbiddenTags       = "containerImageMustNotUseForbiddenTags"
+	controlContainerImageMustComeFromAuthorizedSources = "containerImageMustComeFromAuthorizedSources"
+	controlBranchMustBeProtected                       = "branchMustBeProtected"
+	controlPipelineMustNotIncludeHardcodedJobs         = "pipelineMustNotIncludeHardcodedJobs"
+	controlIncludesMustBeUpToDate                      = "includesMustBeUpToDate"
+	controlIncludesMustNotUseForbiddenVersions         = "includesMustNotUseForbiddenVersions"
+	controlPipelineMustIncludeComponent                = "pipelineMustIncludeComponent"
+	controlPipelineMustIncludeTemplate                 = "pipelineMustIncludeTemplate"
+)
+
+// shouldRunControl applies --controls / --skip-controls filtering for a control.
+// If --controls is set, only listed controls are eligible.
+// Then --skip-controls removes controls from that eligible set.
+func shouldRunControl(controlName string, conf *configuration.Configuration) bool {
+	if conf == nil {
+		return true
+	}
+
+	// If --controls is set, only listed controls should run
+	if len(conf.ControlsFilter) > 0 {
+		found := false
+		for _, name := range conf.ControlsFilter {
+			if name == controlName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// If --skip-controls is set, listed controls should not run
+	for _, name := range conf.SkipControlsFilter {
+		if name == controlName {
+			return false
+		}
+	}
+
+	return true
+}
+
 // RunAnalysis executes the complete pipeline analysis for a GitLab project
 func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 	l := l.WithFields(logrus.Fields{
@@ -200,9 +244,13 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 
 	// Load control configuration from PlumberConfig (required)
 	forbiddenTagsConf := &GitlabImageForbiddenTagsConf{}
-	if err := forbiddenTagsConf.GetConf(conf.PlumberConfig); err != nil {
-		l.WithError(err).Error("Failed to load ImageForbiddenTags config from .plumber.yaml file")
-		return result, fmt.Errorf("invalid configuration: %w", err)
+	if shouldRunControl(controlContainerImageMustNotUseForbiddenTags, conf) {
+		if err := forbiddenTagsConf.GetConf(conf.PlumberConfig); err != nil {
+			l.WithError(err).Error("Failed to load ImageForbiddenTags config from .plumber.yaml file")
+			return result, fmt.Errorf("invalid configuration: %w", err)
+		}
+	} else {
+		forbiddenTagsConf.Enabled = false
 	}
 
 	forbiddenTagsResult := forbiddenTagsConf.Run(pipelineImageData)
@@ -212,9 +260,13 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 	l.Info("Running Image Authorized Sources control")
 
 	authorizedSourcesConf := &GitlabImageAuthorizedSourcesConf{}
-	if err := authorizedSourcesConf.GetConf(conf.PlumberConfig); err != nil {
-		l.WithError(err).Error("Failed to load ImageAuthorizedSources config from .plumber.yaml file")
-		return result, fmt.Errorf("invalid configuration: %w", err)
+	if shouldRunControl(controlContainerImageMustComeFromAuthorizedSources, conf) {
+		if err := authorizedSourcesConf.GetConf(conf.PlumberConfig); err != nil {
+			l.WithError(err).Error("Failed to load ImageAuthorizedSources config from .plumber.yaml file")
+			return result, fmt.Errorf("invalid configuration: %w", err)
+		}
+	} else {
+		authorizedSourcesConf.Enabled = false
 	}
 
 	authorizedSourcesResult := authorizedSourcesConf.Run(pipelineImageData)
@@ -224,9 +276,13 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 	l.Info("Running Pipeline Must Not Include Hardcoded Jobs control")
 
 	hardcodedJobsConf := &GitlabPipelineHardcodedJobsConf{}
-	if err := hardcodedJobsConf.GetConf(conf.PlumberConfig); err != nil {
-		l.WithError(err).Error("Failed to load HardcodedJobs config from .plumber.yaml file")
-		return result, fmt.Errorf("invalid configuration: %w", err)
+	if shouldRunControl(controlPipelineMustNotIncludeHardcodedJobs, conf) {
+		if err := hardcodedJobsConf.GetConf(conf.PlumberConfig); err != nil {
+			l.WithError(err).Error("Failed to load HardcodedJobs config from .plumber.yaml file")
+			return result, fmt.Errorf("invalid configuration: %w", err)
+		}
+	} else {
+		hardcodedJobsConf.Enabled = false
 	}
 
 	hardcodedJobsResult := hardcodedJobsConf.Run(pipelineOriginData)
@@ -236,9 +292,13 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 	l.Info("Running Includes Must Be Up To Date control")
 
 	outdatedConf := &GitlabPipelineIncludesOutdatedConf{}
-	if err := outdatedConf.GetConf(conf.PlumberConfig); err != nil {
-		l.WithError(err).Error("Failed to load IncludesOutdated config from .plumber.yaml file")
-		return result, fmt.Errorf("invalid configuration: %w", err)
+	if shouldRunControl(controlIncludesMustBeUpToDate, conf) {
+		if err := outdatedConf.GetConf(conf.PlumberConfig); err != nil {
+			l.WithError(err).Error("Failed to load IncludesOutdated config from .plumber.yaml file")
+			return result, fmt.Errorf("invalid configuration: %w", err)
+		}
+	} else {
+		outdatedConf.Enabled = false
 	}
 
 	outdatedResult := outdatedConf.Run(pipelineOriginData)
@@ -248,48 +308,65 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 	l.Info("Running Includes Must Not Use Forbidden Versions control")
 
 	forbiddenVersionConf := &GitlabPipelineIncludesForbiddenVersionConf{}
-	if err := forbiddenVersionConf.GetConf(conf.PlumberConfig); err != nil {
-		l.WithError(err).Error("Failed to load ForbiddenVersions config from .plumber.yaml file")
-		return result, fmt.Errorf("invalid configuration: %w", err)
+	if shouldRunControl(controlIncludesMustNotUseForbiddenVersions, conf) {
+		if err := forbiddenVersionConf.GetConf(conf.PlumberConfig); err != nil {
+			l.WithError(err).Error("Failed to load ForbiddenVersions config from .plumber.yaml file")
+			return result, fmt.Errorf("invalid configuration: %w", err)
+		}
+	} else {
+		forbiddenVersionConf.Enabled = false
 	}
 
 	forbiddenVersionResult := forbiddenVersionConf.Run(pipelineOriginData, projectInfo.DefaultBranch)
 	result.ForbiddenVersionsIncludesResult = forbiddenVersionResult
 
 	// 8. Run Branch Must Be Protected control (if enabled)
-	branchProtectionConfig := conf.PlumberConfig.GetBranchMustBeProtectedConfig()
-	if branchProtectionConfig != nil && branchProtectionConfig.IsEnabled() {
-		l.Info("Running Branch Must Be Protected control")
+	if shouldRunControl(controlBranchMustBeProtected, conf) {
+		branchProtectionConfig := conf.PlumberConfig.GetBranchMustBeProtectedConfig()
+		if branchProtectionConfig != nil && branchProtectionConfig.IsEnabled() {
+			l.Info("Running Branch Must Be Protected control")
 
-		// Run Protection data collection first
-		protectionDC := &collector.GitlabProtectionDataCollection{}
-		protectionData, _, err := protectionDC.Run(projectInfo, conf.GitlabToken, conf)
-		if err != nil {
-			l.WithError(err).Error("Protection data collection failed")
-			// Data collection failed - set compliance to 0 but continue
-			result.BranchProtectionResult = &GitlabBranchProtectionResult{
-				Enabled:    true,
-				Compliance: 0,
-				Version:    ControlTypeGitlabProtectionBranchProtectionNotCompliantVersion,
-				Error:      err.Error(),
+			// Run Protection data collection first
+			protectionDC := &collector.GitlabProtectionDataCollection{}
+			protectionData, _, err := protectionDC.Run(projectInfo, conf.GitlabToken, conf)
+			if err != nil {
+				l.WithError(err).Error("Protection data collection failed")
+				// Data collection failed - set compliance to 0 but continue
+				result.BranchProtectionResult = &GitlabBranchProtectionResult{
+					Enabled:    true,
+					Compliance: 0,
+					Version:    ControlTypeGitlabProtectionBranchProtectionNotCompliantVersion,
+					Error:      err.Error(),
+				}
+			} else {
+				// Run the branch protection control
+				branchProtectionControl := NewGitlabBranchProtectionControl(branchProtectionConfig)
+				branchProtectionResult := branchProtectionControl.Run(protectionData, projectInfo)
+				result.BranchProtectionResult = branchProtectionResult
 			}
 		} else {
-			// Run the branch protection control
-			branchProtectionControl := NewGitlabBranchProtectionControl(branchProtectionConfig)
-			branchProtectionResult := branchProtectionControl.Run(protectionData, projectInfo)
-			result.BranchProtectionResult = branchProtectionResult
+			l.Debug("Branch Must Be Protected control is disabled or not configured")
 		}
 	} else {
-		l.Debug("Branch Must Be Protected control is disabled or not configured")
+		result.BranchProtectionResult = &GitlabBranchProtectionResult{
+			Enabled:    false,
+			Skipped:    true,
+			Compliance: 100.0,
+			Version:    ControlTypeGitlabProtectionBranchProtectionNotCompliantVersion,
+		}
 	}
 
 	// 9. Run Pipeline Must Include Component control
 	l.Info("Running Pipeline Must Include Component control")
 
 	requiredComponentsConf := &GitlabPipelineRequiredComponentsConf{}
-	if err := requiredComponentsConf.GetConf(conf.PlumberConfig); err != nil {
-		l.WithError(err).Error("Failed to load RequiredComponents config from .plumber.yaml file")
-		return result, fmt.Errorf("invalid configuration: %w", err)
+	if shouldRunControl(controlPipelineMustIncludeComponent, conf) {
+		if err := requiredComponentsConf.GetConf(conf.PlumberConfig); err != nil {
+			l.WithError(err).Error("Failed to load RequiredComponents config from .plumber.yaml file")
+			return result, fmt.Errorf("invalid configuration: %w", err)
+		}
+	} else {
+		requiredComponentsConf.Enabled = false
 	}
 
 	requiredComponentsResult := requiredComponentsConf.Run(pipelineOriginData, conf.GitlabURL)
@@ -299,9 +376,13 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 	l.Info("Running Pipeline Must Include Template control")
 
 	requiredTemplatesConf := &GitlabPipelineRequiredTemplatesConf{}
-	if err := requiredTemplatesConf.GetConf(conf.PlumberConfig); err != nil {
-		l.WithError(err).Error("Failed to load RequiredTemplates config from .plumber.yaml file")
-		return result, fmt.Errorf("invalid configuration: %w", err)
+	if shouldRunControl(controlPipelineMustIncludeTemplate, conf) {
+		if err := requiredTemplatesConf.GetConf(conf.PlumberConfig); err != nil {
+			l.WithError(err).Error("Failed to load RequiredTemplates config from .plumber.yaml file")
+			return result, fmt.Errorf("invalid configuration: %w", err)
+		}
+	} else {
+		requiredTemplatesConf.Enabled = false
 	}
 
 	requiredTemplatesResult := requiredTemplatesConf.Run(pipelineOriginData)

--- a/docs/PBOM.md
+++ b/docs/PBOM.md
@@ -298,7 +298,7 @@ When using the Plumber component in GitLab CI, the CycloneDX output is automatic
 
 ```yaml
 include:
-  - component: gitlab.com/getplumber/plumber/plumber@v0.1.26
+  - component: gitlab.com/getplumber/plumber/plumber@v0.1.27
 ```
 
 Both `plumber-pbom.json` (native PBOM) and `plumber-cyclonedx-sbom.json` (CycloneDX) are generated and stored as pipeline artifacts by default.

--- a/templates/plumber.yml
+++ b/templates/plumber.yml
@@ -70,6 +70,12 @@ spec:
       description: "Create/update a Plumber compliance badge on the project (requires api scope; only runs on default branch pipelines)"
       default: false
       type: boolean
+    controls:
+      description: "Run only listed controls (comma-separated control names). Cannot be used with skip_controls."
+      default: ""
+    skip_controls:
+      description: "Skip listed controls (comma-separated control names). Cannot be used with controls."
+      default: ""
 
 ---
 
@@ -160,6 +166,14 @@ spec:
       if [ "$[[ inputs.badge ]]" = "true" ]; then
         BADGE_FLAG="--badge"
       fi
+      CONTROLS_FLAG=""
+      if [ -n "$[[ inputs.controls ]]" ]; then
+        CONTROLS_FLAG="--controls $[[ inputs.controls ]]"
+      fi
+      SKIP_CONTROLS_FLAG=""
+      if [ -n "$[[ inputs.skip_controls ]]" ]; then
+        SKIP_CONTROLS_FLAG="--skip-controls $[[ inputs.skip_controls ]]"
+      fi
       /plumber analyze \
         --gitlab-url "$[[ inputs.server_url ]]" \
         --project "$[[ inputs.project_path ]]" \
@@ -172,7 +186,9 @@ spec:
         $PBOM_CDX_FLAG \
         $VERBOSE_FLAG \
         $MR_COMMENT_FLAG \
-        $BADGE_FLAG
+        $BADGE_FLAG \
+        $CONTROLS_FLAG \
+        $SKIP_CONTROLS_FLAG
   artifacts:
     paths:
       - $[[ inputs.output_file ]]


### PR DESCRIPTION
Based off of @slyt3 's work in #66 

closes #57 

* Added the documentation in the README 
* Fixed a bug in `analyze.go` for the error format output
* Moved tests to their appropriate location
* Updated the gitlab component template to enable the usage of the new flags
* used built-in go `strings.Contains` instead of self-defined ones
