### PR TITLE
feat(cmd): notify user when a newer version of plumber is available

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,14 +1,17 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 )
 
 var (
 	// Global flags
-	verbose bool
+	verbose   bool
+	updateMsg chan string
 )
 
 var rootCmd = &cobra.Command{
@@ -17,21 +20,33 @@ var rootCmd = &cobra.Command{
 	Long: `Plumber is a command-line tool that analyzes GitLab CI/CD pipelines
 and enforces trust policies on third-party components, images, and branch protections.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		checkForNewerVersion()
+		if os.Getenv("PLUMBER_NO_UPDATE_CHECK") == "" {
+			updateMsg = make(chan string, 1)
+			go checkForNewerVersion(updateMsg)
+		}
 		return nil
 	},
 }
 
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		// Duplicated output
-		// Cobra give same output;
-		// from github.com/spf13/cobra v1.8.1
-		// just commenting this duplication for now.
-		// to validate, just uncomment that fmt line and run this command:
-		// make build && ./plumber analyze --gitlab-url https://gitlab.com --project a/b --controls nope
-		//
-		// fmt.Fprintln(os.Stderr, err)
+	err := rootCmd.Execute()
+
+	if updateMsg != nil {
+		select {
+		case msg := <-updateMsg:
+			if msg != "" {
+				fmt.Fprint(os.Stderr, msg)
+			}
+
+		case <-time.After(500 * time.Millisecond):
+			// Fast commands (e.g. "plumber version") finish before the GitHub
+			// API responds. Give the check up to 500ms after the command ends
+			// to avoid hanging on firewalled networks where packets are silently
+			// dropped and the HTTP client waits for the full 3s timeout.
+		}
+	}
+
+	if err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/update_check.go
+++ b/cmd/update_check.go
@@ -4,11 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
 	"time"
 
-	goversion "github.com/hashicorp/go-version"
 	glabCI "github.com/getplumber/plumber/gitlab"
+	goversion "github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
 )
 
@@ -23,21 +22,23 @@ type githubRelease struct {
 }
 
 // checkForNewerVersion fetches the latest plumber release from GitHub and
-// prints a notice if a newer version is available. It is intentionally
-// fail-fast: network errors, timeouts, or parse failures are silently
-// ignored so that users are never blocked by the check.
+// sends an upgrade notice to ch when a newer version is available.
+// It always sends exactly one value (possibly empty) so the receiver
+// never blocks indefinitely. Network errors, timeouts, or parse failures
+// result in an empty send so that users are never blocked by the check.
 //
 // The check is skipped:
 //   - in CI environments (GITLAB_CI / CI env vars are set)
 //   - when the binary was built without a real version tag (Version == "dev")
-func checkForNewerVersion() {
-	// Skip in CI: Docker images embed plumber and the check adds no value there.
+func checkForNewerVersion(ch chan<- string) {
+	var msg string
+	defer func() { ch <- msg }()
+
 	if glabCI.IsRunningInCI() {
 		logrus.Debug("version check: skipping in CI environment")
 		return
 	}
 
-	// Skip for dev builds where there is no meaningful version to compare.
 	if Version == "dev" || Version == "" {
 		logrus.Debug("version check: skipping for dev build")
 		return
@@ -62,27 +63,26 @@ func checkForNewerVersion() {
 		return
 	}
 
-	checkVersionNotice(Version, release.TagName, "")
+	msg = buildUpdateNotice(Version, release.TagName)
 }
 
-// checkVersionNotice compares currentVer against latestTag and prints an
-// upgrade notice to stderr when a newer version is available.
-// releaseURL is used in tests to override the real GitHub URL (pass "" to use default).
-func checkVersionNotice(currentVer, latestTag, _ string) {
+// buildUpdateNotice compares currentVer against latestTag and returns an
+// upgrade notice when a newer version is available, or "" if up-to-date.
+func buildUpdateNotice(currentVer, latestTag string) string {
 	current, err := goversion.NewVersion(currentVer)
 	if err != nil {
 		logrus.Debugf("version check: could not parse current version %q: %v", currentVer, err)
-		return
+		return ""
 	}
 
 	latest, err := goversion.NewVersion(latestTag)
 	if err != nil {
 		logrus.Debugf("version check: could not parse latest version %q: %v", latestTag, err)
-		return
+		return ""
 	}
 
 	if latest.GreaterThan(current) {
-		fmt.Fprintf(os.Stderr, "\nA newer version of plumber is available: %s (you have %s)\n", latestTag, currentVer)
-		fmt.Fprintf(os.Stderr, "Upgrade instructions: %s\n\n", upgradeDocsURL)
+		return fmt.Sprintf("\nA newer version of plumber is available: %s (you have %s)\nUpgrade instructions: %s\nTo disable this check: export PLUMBER_NO_UPDATE_CHECK=1\n\n", latestTag, currentVer, upgradeDocsURL)
 	}
+	return ""
 }

--- a/cmd/update_check_test.go
+++ b/cmd/update_check_test.go
@@ -1,79 +1,61 @@
 package cmd
 
 import (
-	"os"
 	"strings"
 	"testing"
 )
 
-func captureStderr(f func()) string {
-	r, w, _ := os.Pipe()
-	oldStderr := os.Stderr
-	os.Stderr = w
-	f()
-	w.Close()
-	os.Stderr = oldStderr
-	buf := make([]byte, 4096)
-	n, _ := r.Read(buf)
-	return string(buf[:n])
-}
-
 func TestCheckForNewerVersion_SkipsDevBuild(t *testing.T) {
-	// checkForNewerVersion must not make network calls for dev builds
 	Version = "dev"
-	// If the guard fails, the real GitHub URL would be called in tests.
-	// The test simply verifies it returns without panicking or blocking.
-	checkForNewerVersion()
+	ch := make(chan string, 1)
+	checkForNewerVersion(ch)
+	if msg := <-ch; msg != "" {
+		t.Errorf("expected empty message for dev build, got: %q", msg)
+	}
 }
 
 func TestCheckForNewerVersion_SkipsInCI(t *testing.T) {
 	t.Setenv("CI", "true")
 	Version = "0.1.0"
-	checkForNewerVersion() // should return immediately due to CI guard
-}
-
-func TestCheckVersionNotice_PrintsUpgradeNotice(t *testing.T) {
-	output := captureStderr(func() {
-		checkVersionNotice("0.1.0", "v0.2.0", "")
-	})
-
-	if !strings.Contains(output, "v0.2.0") {
-		t.Errorf("expected upgrade notice mentioning v0.2.0, got: %q", output)
-	}
-	if !strings.Contains(output, "0.1.0") {
-		t.Errorf("expected current version 0.1.0 in notice, got: %q", output)
-	}
-	if !strings.Contains(output, upgradeDocsURL) {
-		t.Errorf("expected upgrade docs URL in notice, got: %q", output)
+	ch := make(chan string, 1)
+	checkForNewerVersion(ch)
+	if msg := <-ch; msg != "" {
+		t.Errorf("expected empty message in CI, got: %q", msg)
 	}
 }
 
-func TestCheckVersionNotice_SilentWhenUpToDate(t *testing.T) {
-	output := captureStderr(func() {
-		checkVersionNotice("0.2.0", "v0.2.0", "")
-	})
-	if output != "" {
-		t.Errorf("expected no output when versions match, got: %q", output)
+func TestBuildUpdateNotice_PrintsUpgradeNotice(t *testing.T) {
+	msg := buildUpdateNotice("0.1.0", "v0.2.0")
+
+	if !strings.Contains(msg, "v0.2.0") {
+		t.Errorf("expected upgrade notice mentioning v0.2.0, got: %q", msg)
+	}
+	if !strings.Contains(msg, "0.1.0") {
+		t.Errorf("expected current version 0.1.0 in notice, got: %q", msg)
+	}
+	if !strings.Contains(msg, upgradeDocsURL) {
+		t.Errorf("expected upgrade docs URL in notice, got: %q", msg)
 	}
 }
 
-func TestCheckVersionNotice_SilentWhenNewer(t *testing.T) {
-	// User is on a newer version than the release (e.g., dev/pre-release builds)
-	output := captureStderr(func() {
-		checkVersionNotice("0.3.0", "v0.2.0", "")
-	})
-	if output != "" {
-		t.Errorf("expected no output when current is newer, got: %q", output)
+func TestBuildUpdateNotice_SilentWhenUpToDate(t *testing.T) {
+	msg := buildUpdateNotice("0.2.0", "v0.2.0")
+	if msg != "" {
+		t.Errorf("expected no message when versions match, got: %q", msg)
 	}
 }
 
-func TestCheckVersionNotice_InvalidVersionsAreSilent(t *testing.T) {
-	// Malformed version strings must not panic
-	output := captureStderr(func() {
-		checkVersionNotice("not-a-version", "v0.2.0", "")
-		checkVersionNotice("0.1.0", "not-a-version", "")
-	})
-	if output != "" {
-		t.Errorf("expected no output for invalid versions, got: %q", output)
+func TestBuildUpdateNotice_SilentWhenNewer(t *testing.T) {
+	msg := buildUpdateNotice("0.3.0", "v0.2.0")
+	if msg != "" {
+		t.Errorf("expected no message when current is newer, got: %q", msg)
+	}
+}
+
+func TestBuildUpdateNotice_InvalidVersionsAreSilent(t *testing.T) {
+	msg1 := buildUpdateNotice("not-a-version", "v0.2.0")
+	msg2 := buildUpdateNotice("0.1.0", "not-a-version")
+	if msg1 != "" || msg2 != "" {
+		t.Errorf("expected no message for invalid versions, got: %q, %q", msg1, msg2)
 	}
 }


### PR DESCRIPTION
## Summary

  Closes #39

  On every CLI invocation, plumber fetches the latest release tag from
  GitHub and prints an upgrade notice to stderr when a newer version is
  available.

  ## Behaviour

  - Runs as `PersistentPreRunE` — fires before every subcommand
  - **Skipped in CI** (`CI` / `GITLAB_CI` env vars set) — Docker-embedded
    binaries have no upgrade path at runtime
  - **Skipped for dev builds** (`Version == "dev"`) — no meaningful comparison
  - **Fail-fast**: 3s timeout; any network/parse error is silently ignored
    so air-gapped environments are never impacted
  - Uses the existing indirect dependency `github.com/hashicorp/go-version`
    for robust semver comparison — **no new dependencies added**

  ## Example output
  A newer version of plumber is available: v0.2.0 (you have v0.1.0)
  Upgrade instructions: https://github.com/getplumber/plumber#-installation

  ## Test plan
  - [ ] `go test ./cmd/... -run TestCheck` — 6 cases pass
    - CI skip guard
    - dev build skip guard
    - upgrade notice printed with correct version + URL
    - silent when up-to-date
    - silent when current is newer (pre-release builds)
    - silent on malformed version strings (no panic)
