### PR TITLE
feat(cmd): validating config file before analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ include:
 | `badge` | `false` | Create/update a Plumber compliance badge on the project (requires `api` scope; only runs on default branch) |
 | `controls` | — | Run only listed controls (comma-separated). Cannot be used with `skip_controls` |
 | `skip_controls` | — | Skip listed controls (comma-separated). Cannot be used with `controls` |
+| `fail_warnings` | `false` | Treat configuration warnings (unknown keys) as errors (exit 1) |
 
 </details>
 
@@ -741,6 +742,7 @@ plumber analyze [flags]
 | `--badge` | No | `false` | Create/update a Plumber compliance badge on the project (requires `api` scope; only runs on default branch) |
 | `--controls` | No | — | Run only listed controls (comma-separated). Cannot be used with `--skip-controls` |
 | `--skip-controls` | No | — | Skip listed controls (comma-separated). Cannot be used with `--controls` |
+| `--fail-warnings` | No | `false` | Treat configuration warnings (unknown keys) as errors (exit 1) |
 | `--verbose`, `-v` | No | `false` | Enable verbose/debug output for troubleshooting |
 
 > \* Auto-detected from git remote (`origin`) if not specified. Supports both SSH and HTTPS remote URLs.
@@ -823,8 +825,9 @@ plumber config validate [flags]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--config`, `-c` | `.plumber.yaml` | Path to configuration file |
+| `--fail-warnings` | `false` | Treat configuration warnings as errors (exit 1) |
 
-Warnings are printed to stderr so they don't interfere with scripted output.
+Warnings are printed to stderr so they don't interfere with scripted output. Use `--fail-warnings` to exit with code 1 when warnings are found (useful in CI).
 
 **Examples:**
 
@@ -834,6 +837,9 @@ plumber config validate
 
 # Validate a specific config file
 plumber config validate --config custom-plumber.yaml
+
+# Fail on warnings (for CI pipelines)
+plumber config validate --fail-warnings
 ```
 
 **Sample output with typos:**

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -65,6 +65,7 @@ Optional flags:
   --badge            Create/update a Plumber compliance badge on the project (requires api scope; only runs on default branch)
   --controls         Run only listed controls (comma-separated)
   --skip-controls    Skip listed controls (comma-separated)
+  --fail-warnings    Treat configuration warnings as errors (exit 1)
 
 Exit codes:
   0  Analysis passed (compliance >= threshold)
@@ -108,6 +109,7 @@ func init() {
 	analyzeCmd.Flags().BoolVar(&badge, "badge", false, "Create/update a Plumber compliance badge on the project (requires api scope; only runs on default branch)")
 	analyzeCmd.Flags().StringVar(&controlsFilter, "controls", "", "Run only listed controls (comma-separated)")
 	analyzeCmd.Flags().StringVar(&skipControls, "skip-controls", "", "Skip listed controls (comma-separated)")
+	analyzeCmd.Flags().BoolVar(&failWarnings, "fail-warnings", false, "Treat configuration warnings as errors (exit 1)")
 }
 
 func runAnalyze(cmd *cobra.Command, args []string) error {
@@ -178,20 +180,24 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	// Clean up URL
 	cleanGitlabURL := strings.TrimSuffix(gitlabURL, "/")
 
-	// Read raw config for unknown keys check
-	err = validateConfigFileWarnings(configFile)
-	if err != nil {
-		return fmt.Errorf("failed to validate configuration file: %w", err)
-	}
-
 	// Load Plumber configuration (required)
-	plumberConfig, configPath, err := configuration.LoadPlumberConfig(configFile)
+	plumberConfig, configPath, configWarnings, err := configuration.LoadPlumberConfig(configFile)
 	if err != nil {
-		// if err contains "config file not found", tell them they can generate a default config with `plumber config generate`
 		if strings.Contains(err.Error(), "config file not found") {
 			return fmt.Errorf("configuration file not found: %w. You can generate a default config with `plumber config generate`", err)
 		}
 		return fmt.Errorf("configuration error: %w", err)
+	}
+
+	if len(configWarnings) > 0 {
+		fmt.Fprintf(os.Stderr, "Configuration validation warnings:\n")
+		for _, warning := range configWarnings {
+			fmt.Fprintf(os.Stderr, "  - %s\n", warning)
+		}
+		if failWarnings {
+			return fmt.Errorf("configuration has %d warning(s) and --fail-warnings is set", len(configWarnings))
+		}
+		fmt.Fprintf(os.Stderr, "Please fix the warnings above for best results.\n\n")
 	}
 
 	// Print banner if output is enabled

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -57,8 +57,9 @@ Examples:
 }
 
 var configValidateCmd = &cobra.Command{
-	Use:   "validate",
-	Short: "Validate a configuration file",
+	Use:          "validate",
+	Short:        "Validate a configuration file",
+	SilenceUsage: true,
 	Long: `Validate a Plumber configuration file for correctness.
 
 This command checks the configuration file for:
@@ -111,6 +112,7 @@ func init() {
 
 	// config validate flags
 	configValidateCmd.Flags().StringVarP(&configValidateFile, "config", "c", ".plumber.yaml", "Path to configuration file")
+	configValidateCmd.Flags().BoolVar(&failWarnings, "fail-warnings", false, "Treat configuration warnings as errors (exit 1)")
 
 	// config view flags
 	configViewCmd.Flags().StringVarP(&configViewFile, "config", "c", ".plumber.yaml", "Path to configuration file")
@@ -136,8 +138,7 @@ func runConfigView(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Load the configuration
-	config, _, err := configuration.LoadPlumberConfig(configViewFile)
+	config, _, _, err := configuration.LoadPlumberConfig(configViewFile)
 	if err != nil {
 		return err
 	}
@@ -312,15 +313,15 @@ func runConfigGenerate(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func validateConfigFileWarnings(configFile string) error {
-	// Read raw config file for unknown key validation
-	rawData, err := os.ReadFile(configFile)
-	if err != nil {
-		return err
+func runConfigValidate(cmd *cobra.Command, args []string) error {
+	if !verbose {
+		logrus.SetLevel(logrus.WarnLevel)
 	}
 
-	// Check for unknown keys in raw YAML (before struct parsing loses them)
-	warnings := configuration.ValidateKnownKeys(rawData)
+	_, _, warnings, err := configuration.LoadPlumberConfig(configValidateFile)
+	if err != nil {
+		return fmt.Errorf("failed to validate configuration: %w", err)
+	}
 
 	if len(warnings) > 0 {
 		fmt.Fprintf(os.Stderr, "Configuration validation warnings:\n")
@@ -328,6 +329,9 @@ func validateConfigFileWarnings(configFile string) error {
 			fmt.Fprintf(os.Stderr, "  - %s\n", warning)
 		}
 		fmt.Fprintf(os.Stderr, "\nConfiguration loaded from: %s\n", configValidateFile)
+		if failWarnings {
+			return fmt.Errorf("configuration has %d warning(s) and --fail-warnings is set", len(warnings))
+		}
 		fmt.Fprintf(os.Stderr, "Please fix the warnings above for best results.\n")
 	} else {
 		fmt.Printf("Configuration %s is valid.\n", configValidateFile)
@@ -336,23 +340,3 @@ func validateConfigFileWarnings(configFile string) error {
 	return nil
 }
 
-func runConfigValidate(cmd *cobra.Command, args []string) error {
-	// Suppress debug logs for clean output (unless verbose)
-	if !verbose {
-		logrus.SetLevel(logrus.WarnLevel)
-	}
-
-	// Read raw config for unknown keys check
-	err := validateConfigFileWarnings(configValidateFile)
-	if err != nil {
-		return fmt.Errorf("failed to validate configuration file: %w", err)
-	}
-
-	// Validate the config parses correctly and passes structural validation
-	_, _, err = configuration.LoadPlumberConfig(configValidateFile)
-	if err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
-	}
-
-	return nil
-}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,8 +10,9 @@ import (
 
 var (
 	// Global flags
-	verbose   bool
-	updateMsg chan string
+	verbose      bool
+	updateMsg    chan string
+	failWarnings bool
 )
 
 var rootCmd = &cobra.Command{

--- a/configuration/plumberconfig.go
+++ b/configuration/plumberconfig.go
@@ -267,42 +267,44 @@ func (c *RequiredTemplatesControlConfig) GetResolvedRequiredGroups() ([][]string
 	return c.RequiredGroups, nil
 }
 
-// LoadPlumberConfig loads configuration from a file path
-// The config file path is required - returns error if empty or not found
-func LoadPlumberConfig(configPath string) (*PlumberConfig, string, error) {
+// LoadPlumberConfig loads configuration from a file path.
+// It reads the file once, validates for unknown keys, parses
+// the YAML into the config struct, and runs structural validation.
+// Returns the parsed config, the resolved path, any unknown-key
+// warnings, and an error if loading or validation failed.
+func LoadPlumberConfig(configPath string) (*PlumberConfig, string, []string, error) {
 	l := logrus.WithField("action", "LoadPlumberConfig")
 
 	if configPath == "" {
-		return nil, "", fmt.Errorf("config file path is required")
+		return nil, "", nil, fmt.Errorf("config file path is required")
 	}
 
 	l = l.WithField("configPath", configPath)
 	l.Info("Loading configuration from file")
 
-	// Read the file
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, configPath, fmt.Errorf("config file not found: %s", configPath)
+			return nil, configPath, nil, fmt.Errorf("config file not found: %s", configPath)
 		}
 		l.WithError(err).Error("Failed to read config file")
-		return nil, configPath, err
+		return nil, configPath, nil, err
 	}
 
-	// Parse YAML
+	warnings := ValidateKnownKeys(data)
+
 	config := &PlumberConfig{}
 	if err := yaml.Unmarshal(data, config); err != nil {
 		l.WithError(err).Error("Failed to parse config file")
-		return nil, configPath, err
+		return nil, configPath, warnings, err
 	}
 
-	// Validate expression fields early to catch syntax errors at load time
 	if err := config.validate(); err != nil {
-		return nil, configPath, fmt.Errorf("configuration validation error: %w", err)
+		return nil, configPath, warnings, fmt.Errorf("configuration validation error: %w", err)
 	}
 
 	l.WithField("config", config).Debug("Configuration loaded successfully")
-	return config, configPath, nil
+	return config, configPath, warnings, nil
 }
 
 // validate checks for configuration errors, including expression syntax

--- a/templates/plumber.yml
+++ b/templates/plumber.yml
@@ -76,6 +76,10 @@ spec:
     skip_controls:
       description: "Skip listed controls (comma-separated control names). Cannot be used with controls."
       default: ""
+    fail_warnings:
+      description: "Treat configuration warnings (unknown keys) as errors (exit 1)"
+      default: false
+      type: boolean
 
 ---
 
@@ -174,6 +178,10 @@ spec:
       if [ -n "$[[ inputs.skip_controls ]]" ]; then
         SKIP_CONTROLS_FLAG="--skip-controls $[[ inputs.skip_controls ]]"
       fi
+      FAIL_WARNINGS_FLAG=""
+      if [ "$[[ inputs.fail_warnings ]]" = "true" ]; then
+        FAIL_WARNINGS_FLAG="--fail-warnings"
+      fi
       /plumber analyze \
         --gitlab-url "$[[ inputs.server_url ]]" \
         --project "$[[ inputs.project_path ]]" \
@@ -188,7 +196,8 @@ spec:
         $MR_COMMENT_FLAG \
         $BADGE_FLAG \
         $CONTROLS_FLAG \
-        $SKIP_CONTROLS_FLAG
+        $SKIP_CONTROLS_FLAG \
+        $FAIL_WARNINGS_FLAG
   artifacts:
     paths:
       - $[[ inputs.output_file ]]


### PR DESCRIPTION
Closes #70

# Overview

- in `cmd/config.go`: Extracted unknown keys check in YAML, along with warnings reporting to a helper function `validateConfigFileWarnings`;
- Included a call to the created helper function in `cmd/analyze.go`, at the `runAnalyze` function, right between URL Cleanup and config file loading.

# Examples

## Non-existent .plumber.yaml

<img width="818" height="134" alt="Screenshot_2026-02-24-16-10-24_1440x900" src="https://github.com/user-attachments/assets/69091fbc-ce6b-4c64-a9c0-eec0d779d292" />

(also confirming exit code is '1')

## Invalid .plumber.yaml

<img width="833" height="318" alt="Screenshot_2026-02-24-16-01-11_1440x900" src="https://github.com/user-attachments/assets/5056217e-7966-4199-aaaa-0125dae532ce" />

## Valid .plumber.yaml

<img width="839" height="256" alt="Screenshot_2026-02-24-16-00-29_1440x900" src="https://github.com/user-attachments/assets/e3ce955e-cc38-4230-b268-c58abccab85f" />

## Observations

I couldn't figure out how would be exactly the best way to test this feature, i would appreciate some guidance if possible, thanks!.