### PR TITLE
fix(ci): Improve openssf scorecard score:

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,13 +13,15 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
-  security-events: write
   contents: read
 
 jobs:
   analyze:
     name: Analyze (Go)
     runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN cp .plumber.yaml internal/defaultconfig/default.yaml
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o plumber .
 
 # Final stage - Alpine (small, has shell for CI compatibility)
-FROM alpine:3.21
+FROM alpine:3.21@sha256:c3f8e73fdb79deaebaa2037150150191b9dcbfba68b4a46d70103204c53f4709
 
 # Install CA certificates for HTTPS API calls
 RUN apk --no-cache add ca-certificates

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <p align="center">
   <img src="assets/plumber.svg" alt="Plumber">
 </p>
@@ -5,6 +6,11 @@
 
 <p align="center">
   <b>CI/CD compliance scanner for GitLab pipelines</b>
+</p>
+<p align="center">
+  <a href="https://securityscorecards.dev/viewer/?uri=github.com/getplumber/plumber"><img src="https://img.shields.io/ossf-scorecard/github.com/getplumber/plumber?label=OpenSSF%20Scorecard&style=for-the-badge&labelColor=2b2d42&color=4a90d9" alt="OpenSSF Scorecard"></a>
+  &nbsp;&nbsp;
+  <a href="https://slsa.dev/spec/v1.0/levels#build-l3"><img src="https://img.shields.io/badge/SLSA-Level%203-4a90d9?style=for-the-badge&logo=slsa&logoColor=white&labelColor=2b2d42" alt="SLSA 3"></a>
 </p>
 
 <p align="center">
@@ -14,8 +20,6 @@
   <a href="https://github.com/getplumber/plumber/releases"><img src="https://img.shields.io/github/downloads/getplumber/plumber/total?label=Downloads" alt="GitHub Downloads"></a>
   <a href="https://hub.docker.com/r/getplumber/plumber"><img src="https://img.shields.io/docker/pulls/getplumber/plumber" alt="Docker Pulls"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MPL--2.0-blue" alt="License"></a>
-  <a href="https://securityscorecards.dev/viewer/?uri=github.com/getplumber/plumber"><img src="https://api.securityscorecards.dev/projects/github.com/getplumber/plumber/badge" alt="OpenSSF Scorecard"></a>
-  <a href="https://slsa.dev/spec/v1.0/levels#build-l3"><img src="https://slsa.dev/images/gh-badge-level3.svg" alt="SLSA 3"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
- Pin dockerfile image digest
- Use less permissive global permissions in workflows
- Highlight slsa and scorecard in readme