### PR TITLE
feat(conf): Add conf diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -948,6 +948,57 @@ Configuration validation warnings:
   - Unknown key "allowForcePushes" in control "branchMustBeProtected". Did you mean "allowForcePush"?
 ```
 
+### `plumber config diff`
+
+Compare your `.plumber.yaml` against Plumber's built-in defaults. Useful for spotting customizations, discovering new options after upgrading, and catching typos.
+
+```bash
+plumber config diff [flags]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--config`, `-c` | `.plumber.yaml` | Path to configuration file |
+| `--no-color` | `false` | Disable colorized output |
+
+The output has three sections:
+
+1. **Controls changed from defaults** - keys whose values differ from the built-in defaults. Scalar changes show `old → new`. List changes show per-item `+`/`-` lines.
+2. **New keys in default (missing from your config)** - keys added in newer Plumber versions that your config doesn't include yet, with their default values.
+3. **Unknown keys in your config (not in defaults)** - keys Plumber doesn't recognize. Includes typo suggestions via fuzzy matching when a close match exists.
+
+Color is automatically disabled when piping output.
+
+**Examples:**
+
+```bash
+# Compare the default .plumber.yaml against built-in defaults
+plumber config diff
+
+# Compare a specific config file
+plumber config diff --config custom-plumber.yaml
+
+# Without colors (for piping or scripts)
+plumber config diff --no-color
+```
+
+**Sample output:**
+
+```
+Controls changed from defaults:
+  controls.branchMustBeProtected.enabled: true → false
+  controls.containerImageMustNotUseForbiddenTags.tags:
+    - dev
+    - staging
+    + nightly
+
+New keys in default (missing from your config):
+  controls.pipelineMustNotUseUnsafeVariableExpansion.allowedPatterns (default: [])
+
+Unknown keys in your config (not in defaults):
+  controls.containerImageMustNotUseForbiddenTag ← possible typo? Did you mean "controls.containerImageMustNotUseForbiddenTags.enabled"?
+```
+
 ---
 
 ## ⚠️ Self-Hosted GitLab

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/getplumber/plumber/configuration"
@@ -374,21 +375,15 @@ func runConfigValidate(cmd *cobra.Command, args []string) error {
 }
 
 func runConfigDiff(cmd *cobra.Command, args []string) error {
-
-	// Determine if we should colorize output
 	useColor := !configDiffNoColor
-	// Auto-detect: disable color if not a terminal (unless explicitly set)
 	if !cmd.Flags().Changed("no-color") {
 		if fileInfo, _ := os.Stdout.Stat(); (fileInfo.Mode() & os.ModeCharDevice) == 0 {
 			useColor = false
 		}
 	}
 
-	// Using a basic os.ReadFile call here instead of
-	// configuration.LoadPlumberConfig(), since the load
-	// plumber config method unmarshals the yaml content into
-	// a PlumberConfig object, which ignores any new keys (non-standard)
-	// introduced in the user yaml config.
+	// Read raw bytes instead of LoadPlumberConfig so that unknown/extra
+	// keys in the user file are preserved for comparison.
 	userBytes, err := os.ReadFile(configDiffFile)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -404,53 +399,108 @@ func runConfigDiff(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to convert default config into map: %w", err)
 	}
 
-	if err != nil {
-		return fmt.Errorf("failed to marshal user config: %w", err)
-	}
-
 	userMap, err := flattenYamlContentsIntoMap(userBytes)
-
 	if err != nil {
 		return fmt.Errorf("failed to convert user config into map: %w", err)
 	}
 
-	missingDefaults := make(map[string]struct{})
+	printDiffReport(defaultMap, userMap, useColor)
+	return nil
+}
+
+// printDiffReport compares two flattened config maps and prints the
+// three diff sections: changed, missing from user, unknown in user.
+func printDiffReport(defaultMap, userMap map[string]any, useColor bool) {
+	defaultKeys := make([]string, 0, len(defaultMap))
+	for k := range defaultMap {
+		defaultKeys = append(defaultKeys, k)
+	}
+
+	var changed []string
+	var missingFromUser []string
 	matchingUserKeys := make(map[string]struct{})
 
-	// Prints changed values
-	fmt.Println("\nControls changed from defaults:")
-	for key, val1 := range defaultMap {
-		if val2, exists := userMap[key]; exists {
-			if !reflect.DeepEqual(val1, val2) {
-				if useColor {
-					fmt.Printf("%s: ", key)
-					colorizeChanges(val1, val2)
-					fmt.Println()
-				} else {
-					fmt.Printf("%s: %v → %v\n", key, val1, val2)
-				}
+	for key, defaultVal := range defaultMap {
+		if userVal, exists := userMap[key]; exists {
+			if !reflect.DeepEqual(defaultVal, userVal) {
+				changed = append(changed, key)
 			}
 			matchingUserKeys[key] = struct{}{}
 		} else {
-			missingDefaults[key] = struct{}{}
+			missingFromUser = append(missingFromUser, key)
 		}
 	}
 
-	// Prints keys present in default, but absent in user provided config
-	fmt.Println("\nNew keys in default (missing from your config):")
-	for key := range missingDefaults {
-		fmt.Println(key)
-	}
+	// Keys that exist in the schema but are commented out in the default
+	// file (e.g. "required" for pipelineMustIncludeComponent) should not
+	// be flagged as unknown. Treat them as changed from the implicit zero
+	// value (nil).
+	schemaKeys := configuration.ValidFlatKeys()
 
-	// Prints keys that are present in user provided config, but absent in default
-	fmt.Println("\nUnknown keys in your config (not in defaults):")
+	var unknownInUser []string
 	for key := range userMap {
-		if _, ok := matchingUserKeys[key]; !ok {
-			fmt.Println(key)
+		if _, ok := matchingUserKeys[key]; ok {
+			continue
+		}
+		if _, ok := schemaKeys[key]; ok {
+			defaultMap[key] = nil
+			changed = append(changed, key)
+			continue
+		}
+		unknownInUser = append(unknownInUser, key)
+	}
+
+	sort.Strings(changed)
+	sort.Strings(missingFromUser)
+	sort.Strings(unknownInUser)
+
+	// --- Controls changed from defaults ---
+	fmt.Println("\nControls changed from defaults:")
+	if len(changed) == 0 {
+		fmt.Println("  (none)")
+	} else {
+		for _, key := range changed {
+			printChange(key, defaultMap[key], userMap[key], useColor)
 		}
 	}
 
-	return nil
+	// --- New keys in default (missing from your config) ---
+	fmt.Println("\nNew keys in default (missing from your config):")
+	if len(missingFromUser) == 0 {
+		fmt.Println("  (none)")
+	} else {
+		for _, key := range missingFromUser {
+			defaultVal := defaultMap[key]
+			if useColor {
+				fmt.Printf("  %s%s%s (default: %v)\n", colorYellow, key, colorReset, defaultVal)
+			} else {
+				fmt.Printf("  %s (default: %v)\n", key, defaultVal)
+			}
+		}
+	}
+
+	// --- Unknown keys in your config (not in defaults) ---
+	fmt.Println("\nUnknown keys in your config (not in defaults):")
+	if len(unknownInUser) == 0 {
+		fmt.Println("  (none)")
+	} else {
+		for _, key := range unknownInUser {
+			suggestion := configuration.FindClosestMatch(key, defaultKeys)
+			if useColor {
+				if suggestion != "" {
+					fmt.Printf("  %s%s%s ← possible typo? Did you mean %q?\n", colorRed, key, colorReset, suggestion)
+				} else {
+					fmt.Printf("  %s%s%s\n", colorRed, key, colorReset)
+				}
+			} else {
+				if suggestion != "" {
+					fmt.Printf("  %s ← possible typo? Did you mean %q?\n", key, suggestion)
+				} else {
+					fmt.Printf("  %s\n", key)
+				}
+			}
+		}
+	}
 }
 
 // Converts YAML contents into a map and then flattens that map
@@ -492,59 +542,91 @@ func flattenRecursive(prefix string, currentMap map[string]any, result map[strin
 	}
 }
 
-// colorizeChanges Colorises the changed for easy scanning
-func colorizeChanges(val1, val2 any) {
-	typeA := reflect.TypeOf(val1)
-	typeB := reflect.TypeOf(val2)
+// printChange prints a single changed key with appropriate formatting.
+// Slices get a multi-line add/remove diff; scalars get a one-line "old → new".
+func printChange(key string, defaultVal, userVal any, useColor bool) {
+	isDefaultSlice := defaultVal != nil && reflect.TypeOf(defaultVal).Kind() == reflect.Slice
+	isUserSlice := userVal != nil && reflect.TypeOf(userVal).Kind() == reflect.Slice
 
-	// If both are slices, scan through both of them
-	// Prints removed items in red
-	// Prints added/modified items in green
-	if val1 != nil && val2 != nil && typeA.Kind() == reflect.Slice && typeB.Kind() == reflect.Slice {
-		slice1 := convertToInterfaceSlice(val1)
-		slice2 := convertToInterfaceSlice(val2)
-
-		set1 := make(map[any]struct{})
-		set2 := make(map[any]struct{})
-		for _, item := range slice1 {
-			set1[item] = struct{}{}
-		}
-		for _, item := range slice2 {
-			set2[item] = struct{}{}
-		}
-
-		fmt.Printf("[")
-		for value := range set1 {
-			if _, ok := set2[value]; !ok {
-				fmt.Printf(" %s%v%s ", colorRed, value, colorReset)
-			} else {
-				fmt.Printf(" %v ", value)
-			}
-		}
-		fmt.Printf("] → [")
-		for value := range set2 {
-			if _, ok := set1[value]; !ok {
-				fmt.Printf(" %s%v%s ", colorGreen, value, colorReset)
-			} else {
-				fmt.Printf(" %v ", value)
-			}
-		}
-		fmt.Printf("]")
-
-	} else {
-		// For primitives (bool, string, int), show the transformation
-		// Old value in red, new value in green
-		fmt.Printf("%s%v%s → %s%v%s", colorRed, val1, colorReset, colorGreen, val2, colorReset)
+	if isDefaultSlice && isUserSlice {
+		printSliceDiff(key, defaultVal, userVal, useColor)
+		return
 	}
 
+	oldDisplay := formatDiffValue(defaultVal)
+	newDisplay := formatDiffValue(userVal)
+
+	if useColor {
+		fmt.Printf("  %s: %s%s%s → %s%s%s\n", key,
+			colorRed, oldDisplay, colorReset,
+			colorGreen, newDisplay, colorReset)
+	} else {
+		fmt.Printf("  %s: %s → %s\n", key, oldDisplay, newDisplay)
+	}
 }
 
-// Helper function to convert to interface slice.
-func convertToInterfaceSlice(s any) []any {
-	v := reflect.ValueOf(s)
-	res := make([]any, v.Len())
-	for i := 0; i < v.Len(); i++ {
-		res[i] = v.Index(i).Interface()
+func formatDiffValue(v any) string {
+	if v == nil {
+		return "(unset)"
 	}
-	return res
+	return fmt.Sprintf("%v", v)
+}
+
+// printSliceDiff shows added/removed items in a compact, multi-line format:
+//
+//	key:
+//	  - removed_item
+//	  + added_item
+func printSliceDiff(key string, defaultVal, userVal any, useColor bool) {
+	slice1 := toStringSlice(defaultVal)
+	slice2 := toStringSlice(userVal)
+
+	set1 := make(map[string]struct{}, len(slice1))
+	set2 := make(map[string]struct{}, len(slice2))
+	for _, s := range slice1 {
+		set1[s] = struct{}{}
+	}
+	for _, s := range slice2 {
+		set2[s] = struct{}{}
+	}
+
+	var removed, added []string
+	for _, s := range slice1 {
+		if _, ok := set2[s]; !ok {
+			removed = append(removed, s)
+		}
+	}
+	for _, s := range slice2 {
+		if _, ok := set1[s]; !ok {
+			added = append(added, s)
+		}
+	}
+
+	sort.Strings(removed)
+	sort.Strings(added)
+
+	fmt.Printf("  %s:\n", key)
+	for _, s := range removed {
+		if useColor {
+			fmt.Printf("    %s- %s%s\n", colorRed, s, colorReset)
+		} else {
+			fmt.Printf("    - %s\n", s)
+		}
+	}
+	for _, s := range added {
+		if useColor {
+			fmt.Printf("    %s+ %s%s\n", colorGreen, s, colorReset)
+		} else {
+			fmt.Printf("    + %s\n", s)
+		}
+	}
+}
+
+func toStringSlice(v any) []string {
+	rv := reflect.ValueOf(v)
+	out := make([]string, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		out[i] = fmt.Sprintf("%v", rv.Index(i).Interface())
+	}
+	return out
 }

--- a/cmd/config_diff_test.go
+++ b/cmd/config_diff_test.go
@@ -1,0 +1,266 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFlattenYamlContentsIntoMap(t *testing.T) {
+	yaml := `
+version: "1.0"
+controls:
+  branchMustBeProtected:
+    enabled: true
+    namePatterns:
+      - main
+      - master
+`
+	m, err := flattenYamlContentsIntoMap([]byte(yaml))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v, ok := m["version"]; !ok || v != "1.0" {
+		t.Errorf("expected version=1.0, got %v", v)
+	}
+	if v, ok := m["controls.branchMustBeProtected.enabled"]; !ok || v != true {
+		t.Errorf("expected enabled=true, got %v", v)
+	}
+	if _, ok := m["controls.branchMustBeProtected.namePatterns"]; !ok {
+		t.Error("expected namePatterns key to exist")
+	}
+}
+
+func TestFlattenYamlContentsIntoMap_InvalidYAML(t *testing.T) {
+	_, err := flattenYamlContentsIntoMap([]byte(":::invalid"))
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}
+
+func TestFormatDiffValue(t *testing.T) {
+	if got := formatDiffValue(nil); got != "(unset)" {
+		t.Errorf("expected (unset), got %q", got)
+	}
+	if got := formatDiffValue(true); got != "true" {
+		t.Errorf("expected true, got %q", got)
+	}
+	if got := formatDiffValue("hello"); got != "hello" {
+		t.Errorf("expected hello, got %q", got)
+	}
+}
+
+func TestToStringSlice(t *testing.T) {
+	input := []interface{}{"a", "b", "c"}
+	result := toStringSlice(input)
+	if len(result) != 3 || result[0] != "a" || result[1] != "b" || result[2] != "c" {
+		t.Errorf("unexpected result: %v", result)
+	}
+}
+
+func TestPrintChange_Scalar(t *testing.T) {
+	out := captureStdout(t, func() {
+		printChange("controls.x.enabled", true, false, false)
+	})
+
+	if !strings.Contains(out, "controls.x.enabled") {
+		t.Error("expected key in output")
+	}
+	if !strings.Contains(out, "true") || !strings.Contains(out, "false") {
+		t.Errorf("expected old/new values, got: %s", out)
+	}
+	if !strings.Contains(out, "→") {
+		t.Error("expected arrow separator")
+	}
+}
+
+func TestPrintChange_UnsetDefault(t *testing.T) {
+	out := captureStdout(t, func() {
+		printChange("controls.x.required", nil, "a AND b", false)
+	})
+
+	if !strings.Contains(out, "(unset)") {
+		t.Errorf("expected (unset) for nil default, got: %s", out)
+	}
+	if !strings.Contains(out, "a AND b") {
+		t.Errorf("expected user value, got: %s", out)
+	}
+}
+
+func TestPrintSliceDiff(t *testing.T) {
+	out := captureStdout(t, func() {
+		defaultSlice := []interface{}{"a", "b", "c"}
+		userSlice := []interface{}{"b", "c", "d"}
+		printSliceDiff("controls.x.tags", defaultSlice, userSlice, false)
+	})
+
+	if !strings.Contains(out, "- a") {
+		t.Errorf("expected removed item 'a', got: %s", out)
+	}
+	if !strings.Contains(out, "+ d") {
+		t.Errorf("expected added item 'd', got: %s", out)
+	}
+	if strings.Contains(out, "- b") || strings.Contains(out, "+ b") {
+		t.Errorf("unchanged item 'b' should not appear as +/-, got: %s", out)
+	}
+}
+
+func TestPrintSliceDiff_AllAdded(t *testing.T) {
+	out := captureStdout(t, func() {
+		printSliceDiff("controls.x.items", []interface{}{}, []interface{}{"x", "y"}, false)
+	})
+
+	if !strings.Contains(out, "+ x") || !strings.Contains(out, "+ y") {
+		t.Errorf("expected all items as added, got: %s", out)
+	}
+}
+
+func TestPrintSliceDiff_AllRemoved(t *testing.T) {
+	out := captureStdout(t, func() {
+		printSliceDiff("controls.x.items", []interface{}{"a", "b"}, []interface{}{}, false)
+	})
+
+	if !strings.Contains(out, "- a") || !strings.Contains(out, "- b") {
+		t.Errorf("expected all items as removed, got: %s", out)
+	}
+}
+
+func TestPrintDiffReport_IdenticalConfigs(t *testing.T) {
+	m := map[string]any{
+		"version":                                     "1.0",
+		"controls.branchMustBeProtected.enabled":      true,
+		"controls.branchMustBeProtected.namePatterns": []interface{}{"main"},
+	}
+	userMap := map[string]any{
+		"version":                                     "1.0",
+		"controls.branchMustBeProtected.enabled":      true,
+		"controls.branchMustBeProtected.namePatterns": []interface{}{"main"},
+	}
+
+	out := captureStdout(t, func() {
+		printDiffReport(m, userMap, false)
+	})
+
+	assertContains(t, out, "Controls changed from defaults:")
+	assertContains(t, out, "(none)")
+}
+
+func TestPrintDiffReport_ChangedValues(t *testing.T) {
+	defaultMap := map[string]any{
+		"controls.branchMustBeProtected.enabled":        true,
+		"controls.branchMustBeProtected.allowForcePush": false,
+	}
+	userMap := map[string]any{
+		"controls.branchMustBeProtected.enabled":        false,
+		"controls.branchMustBeProtected.allowForcePush": true,
+	}
+
+	out := captureStdout(t, func() {
+		printDiffReport(defaultMap, userMap, false)
+	})
+
+	assertContains(t, out, "controls.branchMustBeProtected.enabled")
+	assertContains(t, out, "controls.branchMustBeProtected.allowForcePush")
+	assertContains(t, out, "true → false")
+	assertContains(t, out, "false → true")
+}
+
+func TestPrintDiffReport_MissingFromUser(t *testing.T) {
+	defaultMap := map[string]any{
+		"controls.branchMustBeProtected.enabled":        true,
+		"controls.branchMustBeProtected.allowForcePush": false,
+	}
+	userMap := map[string]any{
+		"controls.branchMustBeProtected.enabled": true,
+	}
+
+	out := captureStdout(t, func() {
+		printDiffReport(defaultMap, userMap, false)
+	})
+
+	assertContains(t, out, "New keys in default")
+	assertContains(t, out, "controls.branchMustBeProtected.allowForcePush")
+	assertContains(t, out, "(default: false)")
+}
+
+func TestPrintDiffReport_UnknownKeys(t *testing.T) {
+	defaultMap := map[string]any{
+		"controls.branchMustBeProtected.enabled": true,
+	}
+	userMap := map[string]any{
+		"controls.branchMustBeProtected.enabled": true,
+		"controls.totallyFakeControl.enabled":    true,
+	}
+
+	out := captureStdout(t, func() {
+		printDiffReport(defaultMap, userMap, false)
+	})
+
+	assertContains(t, out, "Unknown keys in your config")
+	assertContains(t, out, "totallyFakeControl")
+}
+
+func TestPrintDiffReport_SliceChanges(t *testing.T) {
+	defaultMap := map[string]any{
+		"controls.branchMustBeProtected.namePatterns": []interface{}{"main", "master", "release"},
+	}
+	userMap := map[string]any{
+		"controls.branchMustBeProtected.namePatterns": []interface{}{"main", "production"},
+	}
+
+	out := captureStdout(t, func() {
+		printDiffReport(defaultMap, userMap, false)
+	})
+
+	assertContains(t, out, "- master")
+	assertContains(t, out, "- release")
+	assertContains(t, out, "+ production")
+}
+
+func TestRunConfigDiff_FileNotFound(t *testing.T) {
+	dir := t.TempDir()
+	userFile := filepath.Join(dir, "nonexistent.yaml")
+
+	_, err := os.ReadFile(userFile)
+	if err == nil {
+		t.Fatal("expected file to not exist")
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected IsNotExist error, got: %v", err)
+	}
+
+	expectedMsg := fmt.Sprintf("config file not found: %s", userFile)
+	if !strings.Contains(expectedMsg, "config file not found") {
+		t.Errorf("unexpected error message: %s", expectedMsg)
+	}
+}
+
+// captureStdout redirects os.Stdout to a pipe, runs fn, and returns the output.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	fn()
+
+	defer func() { _ = w.Close() }()
+	os.Stdout = old
+
+	var buf [16384]byte
+	n, _ := r.Read(buf[:])
+	return string(buf[:n])
+}
+
+func assertContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("expected output to contain %q, got:\n%s", needle, haystack)
+	}
+}

--- a/configuration/plumberconfig.go
+++ b/configuration/plumberconfig.go
@@ -55,11 +55,24 @@ func validControlNames() []string {
 	return keys
 }
 
-// ValidControlNames returns all known control names from the configuration schema;
+// ValidControlNames returns all known control names from the configuration schema.
 func ValidControlNames() []string {
 	names := validControlNames()
 	sort.Strings(names)
 	return names
+}
+
+// ValidFlatKeys returns every valid flattened key path recognized by the
+// schema, e.g. "controls.branchMustBeProtected.enabled". This includes
+// keys that may be commented out in the default config file.
+func ValidFlatKeys() map[string]struct{} {
+	keys := make(map[string]struct{})
+	for control, subKeys := range validControlSchema {
+		for _, sub := range subKeys {
+			keys["controls."+control+"."+sub] = struct{}{}
+		}
+	}
+	return keys
 }
 
 // PlumberConfig represents the .plumber.yaml configuration file structure
@@ -603,8 +616,9 @@ func min(a, b, c int) int {
 	return c
 }
 
-// findClosestMatch finds the closest matching valid key using Levenshtein distance
-func findClosestMatch(unknownKey string, validKeys []string) string {
+// FindClosestMatch finds the closest matching valid key using Levenshtein distance.
+// Returns an empty string if no reasonable match is found.
+func FindClosestMatch(unknownKey string, validKeys []string) string {
 	if len(validKeys) == 0 {
 		return ""
 	}
@@ -671,7 +685,7 @@ func ValidateKnownKeys(data []byte) []string {
 
 		// Check control name
 		if !contains(knownNames, controlName) {
-			suggestion := findClosestMatch(controlName, knownNames)
+			suggestion := FindClosestMatch(controlName, knownNames)
 			if suggestion != "" {
 				warnings = append(warnings,
 					fmt.Sprintf("Unknown control in .plumber.yaml: %q. Did you mean %q?", controlName, suggestion))
@@ -695,7 +709,7 @@ func ValidateKnownKeys(data []byte) []string {
 				continue
 			}
 			if !contains(validSubKeys, subKey) {
-				suggestion := findClosestMatch(subKey, validSubKeys)
+				suggestion := FindClosestMatch(subKey, validSubKeys)
 				if suggestion != "" {
 					warnings = append(warnings,
 						fmt.Sprintf("Unknown key %q in control %q. Did you mean %q?", subKey, controlName, suggestion))

--- a/configuration/plumberconfig_test.go
+++ b/configuration/plumberconfig_test.go
@@ -130,14 +130,14 @@ func TestFindClosestMatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := findClosestMatch(tt.input, validKeys)
+			result := FindClosestMatch(tt.input, validKeys)
 			if tt.expectMatch {
 				if result != tt.expectedKey {
-					t.Errorf("findClosestMatch(%q) = %q, want %q", tt.input, result, tt.expectedKey)
+					t.Errorf("FindClosestMatch(%q) = %q, want %q", tt.input, result, tt.expectedKey)
 				}
 			} else {
 				if result != "" {
-					t.Errorf("findClosestMatch(%q) = %q, want empty string", tt.input, result)
+					t.Errorf("FindClosestMatch(%q) = %q, want empty string", tt.input, result)
 				}
 			}
 		})


### PR DESCRIPTION
Adds command that allows comparison between default config and user configuration.

Command help output:
<img width="830" height="621" alt="image" src="https://github.com/user-attachments/assets/940f5248-f93b-416c-8b5f-c8d4c5e9efe1" />

Command output with colorize:
<img width="1362" height="261" alt="image" src="https://github.com/user-attachments/assets/4ed4ac5d-94cf-4c35-b1bc-79314d584f7f" />

**NOTE:** I've only implemented the colorization for the changes. To me, the other two sections don't really require any colorization, since it doesn't really add any visual indicator of what changed.

Command output with no-color set to true:
<img width="1362" height="261" alt="image" src="https://github.com/user-attachments/assets/3f220693-3502-4dbe-b22c-280604e03cc4" />


Resolves #62