### PR TITLE
fix(gitlab): handle scalar include in GitlabCIConf unmarshalling

### DIFF
--- a/gitlab/models.go
+++ b/gitlab/models.go
@@ -36,6 +36,38 @@ func (s *StringOrSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// IncludeList is a type that can unmarshal from either a scalar value or a slice.
+// GitLab CI accepts both forms:
+//   - include: "https://..."              (scalar string)
+//   - include:                            (sequence)
+//       - "https://..."
+//       - remote: "https://..."
+//       - project: foo
+//         file: bar.yml
+//
+// When GitLab serializes the merged CI configuration it may normalize a
+// single-item array into a scalar, which the plain []interface{} field cannot
+// handle. This type absorbs both representations transparently.
+type IncludeList []interface{}
+
+// UnmarshalYAML implements yaml.v2 Unmarshaler interface
+func (il *IncludeList) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// Try slice first (the common case)
+	var list []interface{}
+	if err := unmarshal(&list); err == nil {
+		*il = list
+		return nil
+	}
+
+	// Fall back to a single value (scalar string or single map)
+	var single interface{}
+	if err := unmarshal(&single); err != nil {
+		return err
+	}
+	*il = []interface{}{single}
+	return nil
+}
+
 // Data of a GitLab group
 type Group struct {
 	IdOnPlatform      int       `json:"idOnPlatform" validate:"required,number"`
@@ -176,7 +208,7 @@ type GitlabCIConf struct {
 	Default         CIConfDefault          `yaml:"default,omitempty"`
 	Spec            interface{}            `yaml:"spec,omitempty"`
 
-	Include    []interface{}          `yaml:"include,omitempty"` // Can be list of string or list of include
+	Include    IncludeList            `yaml:"include,omitempty"` // Can be list of string or list of include
 	GitlabJobs map[string]interface{} `yaml:",inline"`           // Can be a string or a map[string]GitlabJob
 	Workflow   interface{}            `yaml:"workflow,omitempty"`
 	Cache      interface{}            `yaml:"cache,omitempty"`

--- a/gitlab/models_test.go
+++ b/gitlab/models_test.go
@@ -1,6 +1,7 @@
 package gitlab
 
 import (
+	"reflect"
 	"testing"
 
 	"gopkg.in/yaml.v2"
@@ -8,28 +9,55 @@ import (
 
 func TestIncludeList_UnmarshalYAML(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		wantLen  int
-		wantNil  bool
+		name  string
+		input string
+		// want is the expected decoded Include. nil means the field must stay nil
+		// (absent or explicit null). An empty slice means an explicit empty list.
+		want []interface{}
 	}{
 		{
-			name:    "scalar string (GitLab merged config normalization)",
-			input:   `include: "https://example.com/template.yml"`,
-			wantLen: 1,
+			name:  "scalar string (GitLab merged config normalization)",
+			input: `include: "https://example.com/template.yml"`,
+			want:  []interface{}{"https://example.com/template.yml"},
+		},
+		{
+			name:  "scalar local template path",
+			input: `include: "/templates/build.yml"`,
+			want:  []interface{}{"/templates/build.yml"},
 		},
 		{
 			name: "array with string items",
 			input: `include:
   - "https://example.com/a.yml"
   - "https://example.com/b.yml"`,
-			wantLen: 2,
+			want: []interface{}{
+				"https://example.com/a.yml",
+				"https://example.com/b.yml",
+			},
 		},
 		{
 			name: "array with remote: object",
 			input: `include:
   - remote: "https://example.com/template.yml"`,
-			wantLen: 1,
+			want: []interface{}{
+				map[interface{}]interface{}{"remote": "https://example.com/template.yml"},
+			},
+		},
+		{
+			name: "array with local: object",
+			input: `include:
+  - local: "/templates/build.yml"`,
+			want: []interface{}{
+				map[interface{}]interface{}{"local": "/templates/build.yml"},
+			},
+		},
+		{
+			name: "array with template: object",
+			input: `include:
+  - template: "Jobs/SAST.gitlab-ci.yml"`,
+			want: []interface{}{
+				map[interface{}]interface{}{"template": "Jobs/SAST.gitlab-ci.yml"},
+			},
 		},
 		{
 			name: "array with project/file object",
@@ -37,12 +65,59 @@ func TestIncludeList_UnmarshalYAML(t *testing.T) {
   - project: "dev/templates"
     ref: master
     file: "/receipts/.php-api.yml"`,
-			wantLen: 1,
+			want: []interface{}{
+				map[interface{}]interface{}{
+					"project": "dev/templates",
+					"ref":     "master",
+					"file":    "/receipts/.php-api.yml",
+				},
+			},
 		},
 		{
-			name:   "absent include",
-			input:  `stages: [build]`,
-			wantNil: true,
+			name: "array with project/file where file is a list",
+			input: `include:
+  - project: "dev/templates"
+    file:
+      - "/a.yml"
+      - "/b.yml"`,
+			want: []interface{}{
+				map[interface{}]interface{}{
+					"project": "dev/templates",
+					"file":    []interface{}{"/a.yml", "/b.yml"},
+				},
+			},
+		},
+		{
+			name: "mixed array (strings + objects)",
+			input: `include:
+  - "https://example.com/a.yml"
+  - remote: "https://example.com/b.yml"
+  - template: "Jobs/SAST.gitlab-ci.yml"`,
+			want: []interface{}{
+				"https://example.com/a.yml",
+				map[interface{}]interface{}{"remote": "https://example.com/b.yml"},
+				map[interface{}]interface{}{"template": "Jobs/SAST.gitlab-ci.yml"},
+			},
+		},
+		{
+			name:  "explicit empty array",
+			input: `include: []`,
+			want:  []interface{}{},
+		},
+		{
+			name:  "absent include",
+			input: `stages: [build]`,
+			want:  nil,
+		},
+		{
+			name:  "explicit null include",
+			input: `include: null`,
+			want:  nil,
+		},
+		{
+			name:  "include key with no value",
+			input: `include:`,
+			want:  nil,
 		},
 	}
 
@@ -52,15 +127,57 @@ func TestIncludeList_UnmarshalYAML(t *testing.T) {
 			if err := yaml.Unmarshal([]byte(tt.input), &conf); err != nil {
 				t.Fatalf("unexpected unmarshal error: %v", err)
 			}
-			if tt.wantNil {
-				if conf.Include != nil {
-					t.Errorf("expected nil Include, got %v", conf.Include)
+
+			got := []interface{}(conf.Include)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("expected nil Include, got %#v", got)
 				}
 				return
 			}
-			if len(conf.Include) != tt.wantLen {
-				t.Errorf("expected %d include entries, got %d", tt.wantLen, len(conf.Include))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Include mismatch\n  got:  %#v\n  want: %#v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestIncludeList_UnmarshalYAML_MappingAtTopLevel pins the current lenient
+// behavior: a mapping at the include position (not valid per the GitLab spec,
+// which requires a scalar or sequence) is accepted by the scalar fallback and
+// wrapped as a single-element list. The fallback uses `var single interface{}`
+// which can hold any YAML value, so this branch never returns an error in
+// practice. If stricter validation is ever added, update this test.
+func TestIncludeList_UnmarshalYAML_MappingAtTopLevel(t *testing.T) {
+	input := `include:
+  remote: "https://example.com/template.yml"
+  ref: main`
+
+	var conf GitlabCIConf
+	if err := yaml.Unmarshal([]byte(input), &conf); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := IncludeList{
+		map[interface{}]interface{}{
+			"remote": "https://example.com/template.yml",
+			"ref":    "main",
+		},
+	}
+	if !reflect.DeepEqual(conf.Include, want) {
+		t.Errorf("mapping-at-include mismatch\n  got:  %#v\n  want: %#v", conf.Include, want)
+	}
+}
+
+// TestIncludeList_DirectUnmarshal asserts the custom type works on its own,
+// not only as a field of GitlabCIConf — guards against a future refactor
+// that drops the inline tag or renames the field.
+func TestIncludeList_DirectUnmarshal(t *testing.T) {
+	var il IncludeList
+	if err := yaml.Unmarshal([]byte(`"https://example.com/t.yml"`), &il); err != nil {
+		t.Fatalf("scalar direct unmarshal failed: %v", err)
+	}
+	want := IncludeList{"https://example.com/t.yml"}
+	if !reflect.DeepEqual(il, want) {
+		t.Errorf("direct scalar unmarshal mismatch\n  got:  %#v\n  want: %#v", il, want)
 	}
 }

--- a/gitlab/models_test.go
+++ b/gitlab/models_test.go
@@ -1,0 +1,66 @@
+package gitlab
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestIncludeList_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantLen  int
+		wantNil  bool
+	}{
+		{
+			name:    "scalar string (GitLab merged config normalization)",
+			input:   `include: "https://example.com/template.yml"`,
+			wantLen: 1,
+		},
+		{
+			name: "array with string items",
+			input: `include:
+  - "https://example.com/a.yml"
+  - "https://example.com/b.yml"`,
+			wantLen: 2,
+		},
+		{
+			name: "array with remote: object",
+			input: `include:
+  - remote: "https://example.com/template.yml"`,
+			wantLen: 1,
+		},
+		{
+			name: "array with project/file object",
+			input: `include:
+  - project: "dev/templates"
+    ref: master
+    file: "/receipts/.php-api.yml"`,
+			wantLen: 1,
+		},
+		{
+			name:   "absent include",
+			input:  `stages: [build]`,
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var conf GitlabCIConf
+			if err := yaml.Unmarshal([]byte(tt.input), &conf); err != nil {
+				t.Fatalf("unexpected unmarshal error: %v", err)
+			}
+			if tt.wantNil {
+				if conf.Include != nil {
+					t.Errorf("expected nil Include, got %v", conf.Include)
+				}
+				return
+			}
+			if len(conf.Include) != tt.wantLen {
+				t.Errorf("expected %d include entries, got %d", tt.wantLen, len(conf.Include))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #146

## Problem

When a project's `.gitlab-ci.yml` uses a scalar string for `include`, Plumber fails to parse the merged CI configuration returned by the GitLab GraphQL API:

```
yaml: unmarshal errors:
  line 5: cannot unmarshal !!str `https:/...` into []interface {}
```

## Root Cause

`GitlabCIConf.Include` is declared as `[]interface{}` in `gitlab/models.go`. When GitLab serializes the merged CI configuration it may normalize the `include` field to a scalar string, which the Go YAML unmarshaller cannot handle.

## Fix

Introduce `IncludeList`, a custom type implementing `yaml.Unmarshaler` that normalizes both scalar and sequence forms into `[]interface{}` — following the existing `StringOrSlice` pattern already used in `models.go`.

Supported forms after this fix:
- `include: "https://..."` (scalar string) ✅
- `include: - "https://..."` (single-item array with string) ✅
- `include: - remote: "https://..."` (object form) ✅

Tests covering all forms are included.