### PR TITLE
feat(init): Interactive configuration generation when no config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ Thumbs.db
 # Build output
 dist/
 build/
+plumber
 
 # Embedded config (copied from .plumber.yaml during build)
 internal/defaultconfig/default.yaml

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -9,12 +9,14 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
 	"github.com/getplumber/plumber/collector"
 	"github.com/getplumber/plumber/configuration"
 	"github.com/getplumber/plumber/control"
 	glabCI "github.com/getplumber/plumber/gitlab"
+	"github.com/getplumber/plumber/internal/defaultconfig"
 	"github.com/getplumber/plumber/pbom"
 	"github.com/getplumber/plumber/utils"
 	"github.com/sirupsen/logrus"
@@ -182,6 +184,70 @@ func printProviderDetection(provider, reason string) {
 	fmt.Fprintf(os.Stderr, "  To change: --provider github|gitlab, or --github-url <host> / --gitlab-url <url> to also target a specific host/remote.\n")
 }
 
+// loadConfigOrOffer loads the Plumber config file. When the file is missing and
+// the terminal is interactive, it prompts the user to generate a config on the
+// spot (via the wizard or the default template) and then reloads it so the
+// calling analyze command can continue uninterrupted.
+func loadConfigOrOffer(cfgFile string) (*configuration.PlumberConfig, string, []string, error) {
+	pc, path, warnings, err := configuration.LoadPlumberConfig(cfgFile)
+	if err == nil {
+		return pc, path, warnings, nil
+	}
+
+	if !strings.Contains(err.Error(), "config file not found") {
+		return nil, "", nil, fmt.Errorf("configuration error: %w", err)
+	}
+
+	// Config file not found — in non-interactive mode just show the hint.
+	if !isInteractiveInit() {
+		return nil, "", nil, fmt.Errorf("configuration file not found: %w. Create one with `plumber config generate` or `plumber config init`", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "\nNo configuration file found at %q.\n\n", cfgFile)
+
+	const (
+		choiceWizard   = "Interactive wizard  (plumber config init)"
+		choiceGenerate = "Default template    (plumber config generate)"
+		choiceNo       = "No, exit"
+	)
+
+	var choice string
+	if surveyErr := survey.AskOne(&survey.Select{
+		Message: "Would you like to generate a configuration file now?",
+		Options: []string{choiceWizard, choiceGenerate, choiceNo},
+		Default: choiceWizard,
+	}, &choice); surveyErr != nil || choice == choiceNo {
+		return nil, "", nil, fmt.Errorf("configuration file not found: %w. Create one with `plumber config generate` or `plumber config init`", err)
+	}
+
+	switch choice {
+	case choiceWizard:
+		state, wizErr := runInitWizard(true) // skip "run analyze after?" — we're already in analyze
+		if wizErr != nil {
+			return nil, "", nil, fmt.Errorf("config init failed: %w", wizErr)
+		}
+		cfg := state.toPlumberConfig()
+		if writeErr := writeInitConfig(cfg, cfgFile, false, true, "plumber analyze"); writeErr != nil {
+			return nil, "", nil, fmt.Errorf("config init failed: %w", writeErr)
+		}
+		printInitNextSteps(cfgFile, state.Providers)
+	case choiceGenerate:
+		if writeErr := os.WriteFile(cfgFile, defaultconfig.Get(), 0644); writeErr != nil {
+			return nil, "", nil, fmt.Errorf("failed to write config file: %w", writeErr)
+		}
+		fmt.Fprintf(os.Stderr, "Generated %s\n", cfgFile)
+	default:
+		return nil, "", nil, fmt.Errorf("configuration file not found: %w. Create one with `plumber config generate` or `plumber config init`", err)
+	}
+
+	// Reload after generation.
+	pc, path, warnings, err = configuration.LoadPlumberConfig(cfgFile)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("failed to reload config after generation: %w", err)
+	}
+	return pc, path, warnings, nil
+}
+
 func runAnalyze(cmd *cobra.Command, args []string) error {
 	// Set log level based on verbose flag
 	// Default: WarnLevel (quiet output, only show warnings/errors)
@@ -326,13 +392,10 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	// Clean up URL
 	cleanGitlabURL := strings.TrimSuffix(gitlabURL, "/")
 
-	// Load Plumber configuration (required)
-	plumberConfig, configPath, configWarnings, err := configuration.LoadPlumberConfig(configFile)
+	// Load Plumber configuration (required), offering to generate one if missing.
+	plumberConfig, configPath, configWarnings, err := loadConfigOrOffer(configFile)
 	if err != nil {
-		if strings.Contains(err.Error(), "config file not found") {
-			return fmt.Errorf("configuration file not found: %w. Create one with `plumber config generate` or `plumber config init`", err)
-		}
-		return fmt.Errorf("configuration error: %w", err)
+		return err
 	}
 
 	if len(configWarnings) > 0 {

--- a/cmd/analyze_github.go
+++ b/cmd/analyze_github.go
@@ -29,12 +29,9 @@ import (
 func runGitHubAnalyze(cmd *cobra.Command, info *utils.GitRemoteInfo, controlsFilterList, skipControlsList []string) error {
 	fmt.Fprintf(os.Stderr, "GitHub project: %s (local clone)\n", info.ProjectPath)
 
-	plumberConfig, configPath, configWarnings, err := configuration.LoadPlumberConfig(configFile)
+	plumberConfig, configPath, configWarnings, err := loadConfigOrOffer(configFile)
 	if err != nil {
-		if strings.Contains(err.Error(), "config file not found") {
-			return fmt.Errorf("configuration file not found: %w. Create one with `plumber config generate` or `plumber config init`", err)
-		}
-		return fmt.Errorf("configuration error: %w", err)
+		return err
 	}
 	if len(configWarnings) > 0 {
 		fmt.Fprintf(os.Stderr, "Configuration validation warnings:\n")
@@ -111,12 +108,9 @@ func runGitHubAnalyzeRemote(cmd *cobra.Command, host, project, ref string, contr
 	}
 	owner, repo := parts[0], parts[1]
 
-	plumberConfig, configPath, configWarnings, err := configuration.LoadPlumberConfig(configFile)
+	plumberConfig, configPath, configWarnings, err := loadConfigOrOffer(configFile)
 	if err != nil {
-		if strings.Contains(err.Error(), "config file not found") {
-			return fmt.Errorf("configuration file not found: %w. Create one with `plumber config generate` or `plumber config init`", err)
-		}
-		return fmt.Errorf("configuration error: %w", err)
+		return err
 	}
 	if len(configWarnings) > 0 {
 		fmt.Fprintf(os.Stderr, "Configuration validation warnings:\n")

--- a/cmd/analyze_test.go
+++ b/cmd/analyze_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// loadConfigOrOffer — non-interactive paths (no TTY in CI or test runner).
+//
+// The interactive survey branch cannot be unit-tested without mocking the
+// survey library; the paths below cover the three deterministic code paths:
+//  1. Config file exists → loaded successfully, no prompt.
+//  2. Config file missing, non-interactive → error with actionable hint.
+//  3. Config file present but invalid YAML → configuration error (not a
+//     "file not found" variant, so the offer logic is bypassed).
+
+func TestLoadConfigOrOffer_FileExists(t *testing.T) {
+	// Write a minimal valid .plumber.yaml to a temp dir.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".plumber.yaml")
+	content := "version: \"2.0\"\n"
+	if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	pc, path, warnings, err := loadConfigOrOffer(cfgPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pc == nil {
+		t.Fatal("expected non-nil PlumberConfig")
+	}
+	if path != cfgPath {
+		t.Fatalf("path: got %q, want %q", path, cfgPath)
+	}
+	_ = warnings // may be non-empty for a minimal config, that's fine
+}
+
+func TestLoadConfigOrOffer_MissingFile_NonInteractive(t *testing.T) {
+	// Ensure non-interactive mode: CI env var forces isInteractiveInit to false.
+	t.Setenv("CI", "true")
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "nonexistent.yaml")
+
+	_, _, _, err := loadConfigOrOffer(cfgPath)
+	if err == nil {
+		t.Fatal("expected an error for missing config file")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "configuration file not found") {
+		t.Errorf("error should mention 'configuration file not found', got: %s", msg)
+	}
+	if !strings.Contains(msg, "plumber config generate") || !strings.Contains(msg, "plumber config init") {
+		t.Errorf("error should include generation hint, got: %s", msg)
+	}
+}
+
+func TestLoadConfigOrOffer_InvalidYAML_NonInteractive(t *testing.T) {
+	t.Setenv("CI", "true")
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, ".plumber.yaml")
+	if err := os.WriteFile(cfgPath, []byte(":\tinvalid: yaml: [\n"), 0644); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	_, _, _, err := loadConfigOrOffer(cfgPath)
+	if err == nil {
+		t.Fatal("expected an error for invalid YAML")
+	}
+	// Must be a configuration error, not a "file not found" hint.
+	msg := err.Error()
+	if !strings.Contains(msg, "configuration error") {
+		t.Errorf("error should mention 'configuration error', got: %s", msg)
+	}
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -66,7 +66,7 @@ For the default template with comments (suitable for CI or scripts), run:
   plumber config generate -o .plumber.yaml`)
 	}
 
-	state, err := runInitWizard()
+	state, err := runInitWizard(false)
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func printInitSection(label string) {
 	fmt.Fprintf(os.Stderr, "\n── %s ──\n\n", label)
 }
 
-func runInitWizard() (*initWizardState, error) {
+func runInitWizard(skipAnalyzePrompt bool) (*initWizardState, error) {
 	fmt.Fprintln(os.Stderr, "Welcome to Plumber.")
 	fmt.Fprintln(os.Stderr, "This wizard creates a .plumber.yaml tailored to your project.")
 	fmt.Fprintln(os.Stderr, "Press Enter to accept defaults, Space to toggle, and Ctrl-C to quit.")
@@ -586,15 +586,17 @@ func runInitWizard() (*initWizardState, error) {
 		}
 	}
 
-	fmt.Fprintln(os.Stderr)
-	var runAnalyze bool
-	if err := survey.AskOne(&survey.Confirm{
-		Message: "Run 'plumber analyze' after writing? (" + runAnalyzeAuthHint(st.Providers) + ")",
-		Default: false,
-	}, &runAnalyze); err != nil {
-		return nil, err
+	if !skipAnalyzePrompt {
+		fmt.Fprintln(os.Stderr)
+		var runAnalyze bool
+		if err := survey.AskOne(&survey.Confirm{
+			Message: "Run 'plumber analyze' after writing? (" + runAnalyzeAuthHint(st.Providers) + ")",
+			Default: false,
+		}, &runAnalyze); err != nil {
+			return nil, err
+		}
+		st.runAnalyzeAfter = runAnalyze
 	}
-	st.runAnalyzeAfter = runAnalyze
 	return st, nil
 }
 


### PR DESCRIPTION
Rather than just display how to generate a config file when missing, propose user to do it