### PR TITLE
fix(controls): resolve SHA-pinned action refs in advisory filter

### DIFF
--- a/collector/github_metadata.go
+++ b/collector/github_metadata.go
@@ -293,24 +293,31 @@ func (c *GitHubMetadataClient) advisoriesForRepo(owner, repo string) []advisoryI
 }
 
 // resolveRefToVersion turns the ref string into a comparable semver
-// value: if the ref is already a tag, strip the leading "v"; if
-// it is a 40-char commit SHA, look it up in the repo's tag list and
-// use the matching tag. Returns nil when the version cannot be
-// determined — callers then fall back to "flag everything" so a
-// genuine CVE does not slip past because Plumber could not match
-// the SHA to a release.
+// value: a 40-char commit SHA is looked up in the repo's tag list and
+// the matching tag is parsed; any other ref is parsed directly as a
+// tag. Returns nil when the version cannot be determined — callers
+// then fall back to "flag everything" so a genuine CVE does not slip
+// past because Plumber could not match the SHA to a release.
+//
+// The SHA branch is tried first on purpose: hashicorp/go-version
+// parses a hex SHA that begins with a digit as a semver value
+// (e.g. "2d756ea…" -> 2.0.0-d756ea…, the leading digit becoming the
+// core and the rest a prerelease label). Parsing the ref as a tag
+// first would short-circuit the SHA lookup and, because a prerelease
+// version satisfies no plain constraint, silently drop every advisory.
 func (c *GitHubMetadataClient) resolveRefToVersion(owner, repo, ref string) *version.Version {
-	// Tag-shaped ref: parse directly.
-	if v, err := version.NewVersion(strings.TrimPrefix(ref, "v")); err == nil {
-		return v
-	}
-	// SHA-shaped ref: look up the tag.
+	// SHA-shaped ref: resolve through the repo's tag list.
 	if _isCommitSha(ref) {
 		if tag := c.resolveCommitToTag(owner, repo, ref); tag != "" {
 			if v, err := version.NewVersion(strings.TrimPrefix(tag, "v")); err == nil {
 				return v
 			}
 		}
+		return nil
+	}
+	// Tag-shaped ref: parse directly.
+	if v, err := version.NewVersion(strings.TrimPrefix(ref, "v")); err == nil {
+		return v
 	}
 	return nil
 }
@@ -339,11 +346,16 @@ func (c *GitHubMetadataClient) resolveCommitToTag(owner, repo, sha string) strin
 }
 
 // fetchAllTags walks the paginated `/repos/{owner}/{repo}/tags`
-// endpoint and returns a SHA → tag-name map. The map contains
-// every tag even when several tags share a SHA — the last tag wins,
-// which is acceptable for the version-comparison use case.
+// endpoint and returns a SHA → tag-name map. When several tags point
+// at the same commit — typically a moving major alias (`v4`) and the
+// exact release tag (`v4.3.0`) — the most specific tag wins, so the
+// advisory range filter compares against the real pinned version
+// rather than the alias.
 func (c *GitHubMetadataClient) fetchAllTags(owner, repo string) map[string]string {
 	out := map[string]string{}
+	if c.rest == nil {
+		return out
+	}
 	for page := 1; page <= 20; page++ { // hard cap 2000 tags
 		var resp []struct {
 			Name   string `json:"name"`
@@ -356,15 +368,51 @@ func (c *GitHubMetadataClient) fetchAllTags(owner, repo string) map[string]strin
 			break
 		}
 		for _, t := range resp {
-			if t.Name != "" && t.Commit.Sha != "" {
-				out[t.Commit.Sha] = t.Name
+			if t.Name == "" || t.Commit.Sha == "" {
+				continue
 			}
+			if prev, ok := out[t.Commit.Sha]; ok {
+				out[t.Commit.Sha] = _moreSpecificTag(prev, t.Name)
+				continue
+			}
+			out[t.Commit.Sha] = t.Name
 		}
 		if len(resp) < 100 {
 			break
 		}
 	}
 	return out
+}
+
+// _moreSpecificTag returns whichever of two tag names that point at the
+// same commit pins a version most precisely. A release commit is often
+// reachable from both a moving major alias ("v4") and the exact release
+// tag ("v4.3.0"); the advisory range filter must compare against the
+// exact release, otherwise "v4" parses as 4.0.0 and can fall inside a
+// vulnerable range the real version sits outside of. A semver tag beats
+// a non-semver one; among semver tags the one with more dotted segments
+// wins; an exact version comparison breaks any remaining tie.
+func _moreSpecificTag(a, b string) string {
+	av, aerr := version.NewVersion(strings.TrimPrefix(a, "v"))
+	bv, berr := version.NewVersion(strings.TrimPrefix(b, "v"))
+	switch {
+	case aerr == nil && berr != nil:
+		return a
+	case berr == nil && aerr != nil:
+		return b
+	case aerr != nil && berr != nil:
+		return a
+	}
+	if da, db := strings.Count(a, "."), strings.Count(b, "."); da != db {
+		if da > db {
+			return a
+		}
+		return b
+	}
+	if bv.GreaterThan(av) {
+		return b
+	}
+	return a
 }
 
 // _versionInRange parses the GitHub-advisory version range syntax

--- a/collector/github_metadata_test.go
+++ b/collector/github_metadata_test.go
@@ -39,3 +39,42 @@ func Test_versionInRange(t *testing.T) {
 		}
 	}
 }
+
+// Test_moreSpecificTag locks the SHA-collision tie-break: when one
+// commit carries both a moving major alias and the exact release tag,
+// the advisory range filter must resolve to the exact release so the
+// alias ("v4" -> 4.0.0) cannot drag the ref into a vulnerable range.
+func Test_moreSpecificTag(t *testing.T) {
+	cases := []struct {
+		a, b, want string
+	}{
+		{"v4", "v4.3.0", "v4.3.0"},     // exact release beats major alias
+		{"v4.3.0", "v4", "v4.3.0"},     // order-independent
+		{"v44", "v44.0.0", "v44.0.0"},  // alias vs exact, no patch segment
+		{"v4.3.0", "latest", "v4.3.0"}, // semver beats non-semver
+		{"latest", "v4.3.0", "v4.3.0"},
+		{"v4.3.0", "v4.3.1", "v4.3.1"}, // same precision -> higher version
+	}
+	for _, c := range cases {
+		if got := _moreSpecificTag(c.a, c.b); got != c.want {
+			t.Errorf("_moreSpecificTag(%q, %q) = %q, want %q", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// Test_resolveRefToVersion_commitSHA is the ISSUE-703 regression for a
+// commit SHA that starts with a digit. hashicorp/go-version parses
+// "2d756ea…" as 2.0.0-d756ea…; resolveRefToVersion must take the SHA
+// branch instead of returning that bogus value, otherwise every
+// advisory for the action is silently dropped. The client is offline
+// (see TestMain), so the SHA simply resolves to no tag -> nil.
+func Test_resolveRefToVersion_commitSHA(t *testing.T) {
+	c := NewGitHubMetadataClient()
+	sha := "2d756ea4c53f7f6b397767d8723b3a10a9f35bf2"
+	if v := c.resolveRefToVersion("tj-actions", "changed-files", sha); v != nil {
+		t.Errorf("resolveRefToVersion(%s) = %v, want nil (SHA must not parse as semver)", sha, v)
+	}
+	if v := c.resolveRefToVersion("actions", "download-artifact", "v4.3.0"); v == nil || v.String() != "4.3.0" {
+		t.Errorf("resolveRefToVersion(v4.3.0) = %v, want 4.3.0", v)
+	}
+}


### PR DESCRIPTION
## What

Fixes two bugs in the ISSUE-703 advisory range filter
(`actionsMustNotCarryKnownCVEs`) resolution of commit-SHA-pinned action
references. Tag-pinned refs were unaffected.

## Why

- **False negative** — `resolveRefToVersion` parsed the raw ref with
  `version.NewVersion` before the `_isCommitSha` check. `hashicorp/go-version`
  parses a hex SHA that starts with a digit as a semver value
  (`2d756ea…` → `2.0.0-d756ea…`), so the SHA→tag lookup was skipped and the
  bogus prerelease made every advisory drop out — a vulnerable action read as
  clean.
- **False positive** — `fetchAllTags` kept the last tag seen for a commit. A
  release commit reachable from both a moving major alias (`v4`) and the exact
  release tag (`v4.3.0`) could resolve to `v4` → `4.0.0` and fall inside a
  vulnerable range the real version sits outside of.

## How

- `resolveRefToVersion` checks `_isCommitSha` first, so a SHA always takes the
  tag-resolution path.
- `fetchAllTags` keeps the most specific tag (`_moreSpecificTag`) when several
  tags share a commit, so a moving alias never shadows the exact release tag.

## Tests

- `Test_moreSpecificTag` — SHA-collision tie-break.
- `Test_resolveRefToVersion_commitSHA` — digit-leading SHA regression.
- `make build && make test && make lint` all green.

Verified against a workflow set pinning real actions by SHA: the false
positive (`actions/download-artifact@d3f86a106…`, = v4.3.0) is gone and the
false negative (`tj-actions/changed-files@2d756ea…`, = v44,
GHSA-mrrh-fwg8-r2c3) is now detected.

Closes #179
