### PR TITLE
feat(controls): ship pull-request-target-with-head-checkout (ISSUE-804)

### DIFF
--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -681,6 +681,17 @@ github:
       enabled: true
 
     # ===========================================
+    # pull_request_target must not check out PR head
+    # ===========================================
+    # Flags a workflow triggered by `pull_request_target` that checks
+    # out the pull-request head (github.event.pull_request.head.sha or
+    # github.head_ref). Base-repo secrets and fork-controlled code then
+    # run together, which is the tj-actions / CVE-2025-30066 vector.
+    # Keep fork code under a plain `pull_request` trigger instead.
+    pullRequestTargetMustNotCheckoutHead:
+      enabled: true
+
+    # ===========================================
     # Workflows must declare permissions
     # ===========================================
     # Workflows without an explicit `permissions:` block fall back to

--- a/README.md
+++ b/README.md
@@ -1179,9 +1179,9 @@ Issue code: ISSUE-207.
 <details>
 <summary><b>8. Workflow must not use dangerous triggers</b></summary>
 
-Flags GitHub Actions trigger events that grant access to the **base** repository's secrets while being influenceable by an unprivileged caller. Combined with any user-content checkout, this becomes a direct exfiltration path (`pull_request_target` + `actions/checkout@... { ref: github.event.pull_request.head.sha }` is the textbook pattern). Use the standard `pull_request` trigger unless secrets are genuinely required.
+Flags GitHub Actions trigger events that grant access to the **base** repository's secrets while being influenceable by an unprivileged caller — combined with any user-content checkout, the trigger becomes a direct exfiltration path. The rule fires only on the exploitable combination (trigger + checkout of fork-controlled `ref:`) and abstains when a job-level `if:` restricts execution to same-repository pull requests.
 
-Detected events: `pull_request_target`, `workflow_run`, `issue_comment`, `pull_request_review`, `pull_request_review_comment`, `discussion_comment`, `discussion`, `gollum`, `fork`.
+Detected events: `workflow_run`, `issue_comment`, `pull_request_review`, `pull_request_review_comment`, `discussion_comment`, `discussion`, `gollum`, `fork`. The `pull_request_target` case is owned by `pullRequestTargetMustNotCheckoutHead` (ISSUE-804) below — same exploit class, dedicated rule.
 
 ```yaml
 github:
@@ -1191,6 +1191,22 @@ github:
 ```
 
 Issue code: ISSUE-802.
+
+</details>
+
+<details>
+<summary><b>8b. pull_request_target workflows must not check out the PR head</b></summary>
+
+Flags the precise vector behind the March 2025 tj-actions/changed-files compromise (CVE-2025-30066): a workflow triggered by `pull_request_target` that calls `actions/checkout` with a `ref:` pointing at the PR head (`github.event.pull_request.head.sha`, `github.head_ref`, `head.ref`). Base-repo secrets and fork-controlled code in the same run. The rule abstains when the job carries a same-repository `if:` guard.
+
+```yaml
+github:
+  controls:
+    pullRequestTargetMustNotCheckoutHead:
+      enabled: true
+```
+
+Issue code: ISSUE-804.
 
 </details>
 
@@ -1452,6 +1468,7 @@ Controls not selected are reported as **skipped** in the output. The `--controls
 | `workflowMustIncludeRequiredActions` | GitHub-only |
 | `workflowMustNotGrantPermissionsWriteAll` | GitHub-only |
 | `workflowMustNotInjectUserInputInScripts` | GitHub-only |
+| `pullRequestTargetMustNotCheckoutHead` | GitHub-only |
 | `workflowMustNotUseDangerousTriggers` | GitHub-only |
 | `workflowsMustDeclarePermissions` | GitHub-only |
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -37,15 +37,16 @@ const (
 
 	// GitHub-applicable composition checks (new). The cross-provider ones
 	// (security jobs, DinD) reuse compSecurity / compDinD above.
-	compActionPin           = "Require third-party actions pinned by commit SHA"
-	compDangerousTriggers   = "Flag dangerous workflow triggers (pull_request_target, workflow_run, …)"
-	compDeclarePermissions  = "Require workflows to declare an explicit permissions: block"
-	compReusableSecrets     = "Forbid reusable-workflow calls using secrets: inherit"
-	compTemplateInjection   = "Detect script-injection sinks (${{ github.event.* }} → run:)"
-	compWriteAllPerms       = "Forbid permissions: write-all in workflows"
-	compArchivedActions     = "Flag third-party actions from archived repositories"
-	compKnownCVEs           = "Flag third-party actions with known CVEs (GitHub Advisory DB)"
-	compDebugTraceGitHub    = "Flag Actions debug logging (ACTIONS_STEP_DEBUG / ACTIONS_RUNNER_DEBUG)"
+	compActionPin          = "Require third-party actions pinned by commit SHA"
+	compDangerousTriggers  = "Flag dangerous workflow triggers (pull_request_target, workflow_run, …)"
+	compPRTargetHead       = "Forbid pull_request_target workflows that check out the PR head"
+	compDeclarePermissions = "Require workflows to declare an explicit permissions: block"
+	compReusableSecrets    = "Forbid reusable-workflow calls using secrets: inherit"
+	compTemplateInjection  = "Detect script-injection sinks (${{ github.event.* }} → run:)"
+	compWriteAllPerms      = "Forbid permissions: write-all in workflows"
+	compArchivedActions    = "Flag third-party actions from archived repositories"
+	compKnownCVEs          = "Flag third-party actions with known CVEs (GitHub Advisory DB)"
+	compDebugTraceGitHub   = "Flag Actions debug logging (ACTIONS_STEP_DEBUG / ACTIONS_RUNNER_DEBUG)"
 )
 
 var (
@@ -698,6 +699,7 @@ func compositionOptionsForProviders(providers []string) []string {
 		out = append(out,
 			compActionPin,
 			compDangerousTriggers,
+			compPRTargetHead,
 			compDeclarePermissions,
 			compReusableSecrets,
 			compTemplateInjection,
@@ -1130,6 +1132,9 @@ func (st *initWizardState) toPlumberConfig() *configuration.PlumberConfig {
 			if compSelected(st, compDangerousTriggers) {
 				githubSection.Controls.WorkflowMustNotUseDangerousTriggers = &configuration.EnabledOnlyControlConfig{Enabled: boolPtrInit(true)}
 			}
+			if compSelected(st, compPRTargetHead) {
+				githubSection.Controls.PullRequestTargetMustNotCheckoutHead = &configuration.EnabledOnlyControlConfig{Enabled: boolPtrInit(true)}
+			}
 			if compSelected(st, compDeclarePermissions) {
 				githubSection.Controls.WorkflowsMustDeclarePermissions = &configuration.EnabledOnlyControlConfig{Enabled: boolPtrInit(true)}
 			}
@@ -1246,7 +1251,7 @@ func starterPlumberConfig() *configuration.PlumberConfig {
 		TrustedURLsText:        strings.Join(defaultTrustedURLs(), "\n"),
 		CompositionChoices: []string{
 			compHardcoded, compUpToDate, compForbidden, compSecurity, compScripts, compJobVars, compDinD,
-			compActionPin, compDangerousTriggers, compDeclarePermissions, compReusableSecrets, compTemplateInjection,
+			compActionPin, compDangerousTriggers, compPRTargetHead, compDeclarePermissions, compReusableSecrets, compTemplateInjection,
 			compWriteAllPerms, compArchivedActions, compKnownCVEs, compDebugTraceGitHub,
 		},
 		ActionPinTrustedOwnersMultiline:        strings.Join(defaultGitHubTrustedActionOwners(), "\n"),

--- a/configuration/plumberconfig.go
+++ b/configuration/plumberconfig.go
@@ -66,6 +66,9 @@ var validControlSchema = map[string][]string{
 	"workflowMustNotUseDangerousTriggers": {
 		"enabled",
 	},
+	"pullRequestTargetMustNotCheckoutHead": {
+		"enabled",
+	},
 	"workflowsMustDeclarePermissions": {
 		"enabled",
 	},
@@ -242,6 +245,13 @@ type ControlsConfig struct {
 	// WorkflowMustNotUseDangerousTriggers control configuration (GitHub Actions only).
 	// Config-free; toggle via `enabled`.
 	WorkflowMustNotUseDangerousTriggers *EnabledOnlyControlConfig `yaml:"workflowMustNotUseDangerousTriggers,omitempty"`
+
+	// PullRequestTargetMustNotCheckoutHead control configuration (GitHub
+	// Actions only). Flags a workflow triggered by `pull_request_target`
+	// that checks out the PR head ref, putting base-repo secrets and
+	// fork-controlled code in the same run (tj-actions / CVE-2025-30066).
+	// Config-free; toggle via `enabled`.
+	PullRequestTargetMustNotCheckoutHead *EnabledOnlyControlConfig `yaml:"pullRequestTargetMustNotCheckoutHead,omitempty"`
 
 	// WorkflowsMustDeclarePermissions control configuration (GitHub Actions only).
 	// Config-free; toggle via `enabled`.

--- a/configuration/plumberconfig_test.go
+++ b/configuration/plumberconfig_test.go
@@ -334,6 +334,7 @@ func TestValidControlNames(t *testing.T) {
 		"pipelineMustNotOverrideJobVariables",
 		"pipelineMustNotUseDockerInDocker",
 		"pipelineMustNotUseUnsafeVariableExpansion",
+		"pullRequestTargetMustNotCheckoutHead",
 		"reusableWorkflowsMustNotInheritSecrets",
 		"securityJobsMustNotBeWeakened",
 		"workflowMustIncludeRequiredActions",

--- a/configuration/registry.go
+++ b/configuration/registry.go
@@ -134,7 +134,6 @@ var benchedControls = map[string]map[string]struct{}{
 		"dockerfilesMustPinBaseImageByDigest":                 {},
 		"githubAppTokensMustBeRevokedOnExit":                  {},
 		"publishWorkflowsMustUseOidcTrustedPublishing":        {},
-		"pullRequestTargetMustNotCheckoutHead":                {},
 		"releaseWorkflowsMustNotRestoreUntrustedCache":        {},
 		"releaseWorkflowsMustSignArtefacts":                   {},
 		"repositoriesMustConfigureDependencyUpdates":          {},

--- a/control/catalog.go
+++ b/control/catalog.go
@@ -189,6 +189,11 @@ func GitHubControls(pc *configuration.PlumberConfig) []ControlEntry {
 		Skipped:     c.WorkflowMustNotUseDangerousTriggers == nil || !c.WorkflowMustNotUseDangerousTriggers.IsEnabled(),
 	})
 	entries = append(entries, ControlEntry{
+		DisplayName: "pull_request_target workflows must not check out the PR head",
+		ControlName: "pullRequestTargetMustNotCheckoutHead",
+		Skipped:     c.PullRequestTargetMustNotCheckoutHead == nil || !c.PullRequestTargetMustNotCheckoutHead.IsEnabled(),
+	})
+	entries = append(entries, ControlEntry{
 		DisplayName: "Workflows must declare permissions",
 		ControlName: "workflowsMustDeclarePermissions",
 		Skipped:     c.WorkflowsMustDeclarePermissions == nil || !c.WorkflowsMustDeclarePermissions.IsEnabled(),
@@ -313,6 +318,9 @@ func DisabledControlNames(c *configuration.ControlsConfig) map[string]bool {
 	}
 	if cfg := c.WorkflowMustNotUseDangerousTriggers; cfg == nil || !cfg.IsEnabled() {
 		out["workflowMustNotUseDangerousTriggers"] = true
+	}
+	if cfg := c.PullRequestTargetMustNotCheckoutHead; cfg == nil || !cfg.IsEnabled() {
+		out["pullRequestTargetMustNotCheckoutHead"] = true
 	}
 	if cfg := c.WorkflowsMustDeclarePermissions; cfg == nil || !cfg.IsEnabled() {
 		out["workflowsMustDeclarePermissions"] = true

--- a/control/codes.go
+++ b/control/codes.go
@@ -123,7 +123,9 @@ const (
 	CodeDockerInDockerUsage ErrorCode = "ISSUE-412"
 	// ISSUE-413: CI/CD job uses Docker-in-Docker with insecure daemon configuration
 	CodeDockerInDockerInsecure ErrorCode = "ISSUE-413"
-	// ISSUE-802: Workflow subscribes to a dangerous trigger (pull_request_target, workflow_run)
+	// ISSUE-802: Job reaches a dangerous trigger (workflow_run, issue_comment,
+	// pull_request_review*, discussion*, gollum, fork) AND checks out fork
+	// content. pull_request_target is owned by ISSUE-804.
 	CodeDangerousTriggers ErrorCode = "ISSUE-802"
 	// ISSUE-804: pull_request_target workflow explicitly checks out the PR head (tj-actions pattern)
 	CodePullRequestTargetWithHeadCheckout ErrorCode = "ISSUE-804"
@@ -629,8 +631,8 @@ var errorCodeRegistry = map[ErrorCode]ErrorCodeInfo{
 		Code:        CodeDangerousTriggers,
 		Severity:    SeverityCritical,
 		Title:       "Dangerous workflow trigger",
-		Description: "A GitHub Actions job is reachable via a trigger that runs with the base repository's secrets while being influenceable by an unprivileged caller (`pull_request_target`, `workflow_run`). Combined with any form of user-content checkout or template injection this becomes a direct secret-exfiltration path — the pattern behind the March 2025 tj-actions/changed-files supply-chain compromise (CVE-2025-30066).",
-		Remediation: "Prefer the standard `pull_request` trigger unless access to base-repo secrets is strictly required. If `pull_request_target` is necessary, never check out fork content and never render github.event.* / github.head_ref into shell commands. For `workflow_run`, keep the job restricted to non-secret-bearing steps.",
+		Description: "A GitHub Actions job is reachable via a trigger that runs with the base repository's secrets while being influenceable by an unprivileged caller (`workflow_run`, `issue_comment`, `pull_request_review`, `pull_request_review_comment`, `discussion`, `discussion_comment`, `gollum`, `fork`) AND it checks out fork-controlled code. The `pull_request_target` case is owned by ISSUE-804 (pull-request-target-with-head-checkout). This is the same exploit class as the March 2025 tj-actions/changed-files supply-chain compromise (CVE-2025-30066).",
+		Remediation: "Prefer the standard `pull_request` trigger unless access to base-repo secrets is strictly required. If a secret-bearing trigger is necessary, never check out fork content and never render github.event.* / github.head_ref into shell commands. For `workflow_run`, keep the job restricted to non-secret-bearing steps.",
 		DocURL:      docsBaseURL + string(CodeDangerousTriggers),
 		ControlName: "workflowMustNotUseDangerousTriggers",
 	},

--- a/control/mrcomment.go
+++ b/control/mrcomment.go
@@ -262,6 +262,7 @@ func writeIssueDetails(b *strings.Builder, result *AnalysisResult) {
 		{"workflowMustNotReEnableInsecureCommands", "Workflow must not re-enable insecure commands"},
 		{"checkoutMustNotPersistCredentials", "actions/checkout must not persist credentials"},
 		{"workflowMustNotUseDangerousTriggers", "Workflow must not use dangerous triggers"},
+		{"pullRequestTargetMustNotCheckoutHead", "pull_request_target must not check out the PR head"},
 		{"workflowMustNotGrantPermissionsWriteAll", "Workflow must not grant write-all permissions"},
 	}
 	for _, g := range order {

--- a/docs/GITHUB_ISSUES.md
+++ b/docs/GITHUB_ISSUES.md
@@ -1206,12 +1206,17 @@ into `evil.example.com/...`.
 **Severity:** `critical` • **Control:** `workflowMustNotUseDangerousTriggers`
 
 A job runs under a trigger that combines attacker-controlled input with
-the base repository's secrets — `pull_request_target`, `workflow_run`,
-`issue_comment`, `pull_request_review`, `pull_request_review_comment`,
-`discussion`, `discussion_comment`, `gollum`, `fork` — **and checks out
-fork-controlled code** (an `actions/checkout` whose `ref:` is the PR or
-workflow_run head). Untrusted code then executes with the base repo's
-secrets and token — the March 2025 tj-actions compromise (CVE-2025-30066).
+the base repository's secrets — `workflow_run`, `issue_comment`,
+`pull_request_review`, `pull_request_review_comment`, `discussion`,
+`discussion_comment`, `gollum`, `fork` — **and checks out fork-controlled
+code** (an `actions/checkout` whose `ref:` is the PR or workflow_run
+head). Untrusted code then executes with the base repo's secrets and
+token — the same exploit class as the March 2025 tj-actions compromise
+(CVE-2025-30066).
+
+The `pull_request_target` case is covered by [ISSUE-804](#issue-804--pull-request-target-with-head-checkout)
+(`pullRequestTargetMustNotCheckoutHead`) — same exploit class, dedicated
+rule, no double-firing.
 
 Subscribing to such a trigger is **not** flagged on its own: metadata
 jobs — labelling, milestones, comments, notifications — legitimately
@@ -1220,17 +1225,18 @@ only on the exploitable combination, and abstains when a job-level `if:`
 restricts execution to same-repository pull requests.
 
 ```yaml
-# ❌ before — pull_request_target checks out the PR head
+# ❌ before — workflow_run checks out the PR head from a chained workflow
 on:
-  pull_request_target:
-    types: [opened, synchronize]
+  workflow_run:
+    workflows: ["lint"]
+    types: [completed]
 jobs:
   preview:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
       - run: npm install && npm test
 ```
 
@@ -1238,17 +1244,17 @@ jobs:
 # ✅ after — same-repository guard: fork code never runs
 jobs:
   preview:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
       - run: npm install && npm test
 ```
 
-Alternative: run fork code under a plain `pull_request` trigger (no
-base-repo secrets), or drop the head checkout entirely.
+Alternative: drop the head checkout entirely and let the job operate
+only on the base repo's content.
 
 ---
 

--- a/docs/GITHUB_ISSUES.md
+++ b/docs/GITHUB_ISSUES.md
@@ -1290,6 +1290,12 @@ jobs:
       - run: gh pr edit --add-label auto-preview
 ```
 
+A job-level `if:` that restricts the job to same-repository pull
+requests — `github.event.pull_request.head.repo.full_name ==
+github.repository`, or a `head.repo.fork` check — is recognised as a
+valid mitigation: fork-controlled code never runs, so a job carrying
+such a guard is not flagged.
+
 ---
 
 ## ISSUE-803 — `excessive-permissions`

--- a/policies/dangerous_triggers.rego
+++ b/policies/dangerous_triggers.rego
@@ -22,16 +22,17 @@
 # abstains when a job-level `if:` restricts execution to same-
 # repository (non-fork) pull requests.
 #
-# This is the March 2025 tj-actions/changed-files vector
-# (CVE-2025-30066). ISSUE-804 reports the same head-checkout pattern
-# specifically for pull_request_target; this rule generalises it to
-# the whole dangerous-trigger family.
+# This is the same exploit class as the March 2025 tj-actions/changed-files
+# vector (CVE-2025-30066). The pull_request_target case is owned by
+# ISSUE-804 (pull-request-target-with-head-checkout), so it is excluded
+# from the event set below to avoid double-firing on the same job.
+# ISSUE-802 covers the remaining eight trigger families.
 package dangerous_triggers
 
 import rego.v1
 
 dangerous_events := {
-	"pull_request_target",
+	# pull_request_target is intentionally omitted — see ISSUE-804.
 	"workflow_run",
 	"issue_comment",
 	"pull_request_review",

--- a/policies/pull_request_target_head_checkout.rego
+++ b/policies/pull_request_target_head_checkout.rego
@@ -9,6 +9,10 @@
 # configuration where base-repo secrets AND fork-controlled code
 # coexist in the same run. The severity is critical and distinct so
 # an operator can prioritise it above the general trigger warning.
+#
+# A job-level `if:` that restricts execution to same-repository
+# (non-fork) pull requests neutralises the exploit — fork-controlled
+# code never runs — so a job carrying such a guard is not flagged.
 package pull_request_target_head_checkout
 
 import rego.v1
@@ -26,6 +30,7 @@ deny contains finding if {
 	some i, j
 	job := input.pipeline.jobs[i]
 	_under_pull_request_target(job)
+	not _has_fork_guard(job)
 	action := job.uses[j]
 	startswith(action.uses, "actions/checkout@")
 	ref := action.with.ref
@@ -48,4 +53,22 @@ _under_pull_request_target(job) if {
 _ref_points_at_pr_head(ref) if {
 	some p in fork_ref_patterns
 	regex.match(p, ref)
+}
+
+# fork_guard_patterns are `if:`-condition fragments that restrict a
+# job to same-repository (non-fork) pull requests. When any of the
+# job's conditions carries one, fork-controlled code never executes
+# under pull_request_target and the exploit does not apply.
+fork_guard_patterns := [
+	`head\.repo\.full_name\s*==\s*github\.repository`,
+	`github\.repository\s*==\s*[^=]*head\.repo\.full_name`,
+	`head\.repo\.fork\s*==\s*false`,
+	`head\.repo\.fork\s*!=\s*true`,
+	`!\s*github\.event\.pull_request\.head\.repo\.fork`,
+]
+
+_has_fork_guard(job) if {
+	some cond in job.conditions
+	some p in fork_guard_patterns
+	regex.match(p, cond)
 }

--- a/policies/rules_test.go
+++ b/policies/rules_test.go
@@ -415,9 +415,13 @@ func TestIssue414_DangerousTriggers(t *testing.T) {
 		fixture      string
 		expectedHits []string
 	}{
+		// pull_request_target exploits are owned by ISSUE-804
+		// (pull-request-target-with-head-checkout). ISSUE-802 must
+		// stay silent on this fixture to avoid double-firing on the
+		// same job; ISSUE-804's own test asserts the fire.
 		{
 			fixture:      "violation_pull_request_target.yml",
-			expectedHits: []string{"violation_pull_request_target/preview"},
+			expectedHits: nil,
 		},
 		{
 			fixture:      "violation_workflow_run.yml",

--- a/policies/rules_test.go
+++ b/policies/rules_test.go
@@ -3148,7 +3148,10 @@ func TestIssue415_PullRequestTargetWithHeadCheckout(t *testing.T) {
 		expectedHits []string
 	}{
 		{"violation_head_sha.yml", []string{"violation_head_sha/preview"}},
+		{"violation_head_ref.yml", []string{"violation_head_ref/preview"}},
 		{"clean_no_ref.yml", nil},
+		{"clean_pull_request.yml", nil},
+		{"clean_fork_guard.yml", nil},
 	}
 	runGitHubFixtureCases(t, "ISSUE-804", cases)
 }

--- a/policies/testdata/ISSUE-804/github/clean_fork_guard.yml
+++ b/policies/testdata/ISSUE-804/github/clean_fork_guard.yml
@@ -1,0 +1,18 @@
+# pull_request_target + checkout of the PR head, BUT the job carries
+# an `if:` guard that restricts execution to same-repository pull
+# requests. Fork-controlled code never runs under pull_request_target,
+# so the exploit does not apply. Expected: 0 findings.
+name: PR Preview
+on: [pull_request_target]
+
+jobs:
+  preview:
+    if: >
+      github.event_name != 'pull_request_target' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: npm install && npm test

--- a/policies/testdata/ISSUE-804/github/clean_pull_request.yml
+++ b/policies/testdata/ISSUE-804/github/clean_pull_request.yml
@@ -1,0 +1,15 @@
+# Plain pull_request trigger — the workflow has no access to
+# base-repo secrets, so checking out the PR head is the normal, safe
+# pattern. ISSUE-804 is pull_request_target-specific. Expected: 0
+# findings.
+name: PR Build
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: npm install && npm test

--- a/policies/testdata/ISSUE-804/github/violation_head_ref.yml
+++ b/policies/testdata/ISSUE-804/github/violation_head_ref.yml
@@ -1,0 +1,15 @@
+# pull_request_target + explicit checkout of github.head_ref (the
+# fork branch name). Same exposure as the head.sha variant: shell
+# steps after the checkout run fork-controlled code with base-repo
+# secrets. Expected: 1 finding.
+name: PR Preview
+on: [pull_request_target]
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - run: npm install && npm test


### PR DESCRIPTION
## What

Promotes `pullRequestTargetMustNotCheckoutHead` (rule
`pull-request-target-with-head-checkout`, `ISSUE-804`, severity
**critical**) from the dev bench to a shipping GitHub control.

## Why

The control flags the tj-actions / CVE-2025-30066 vector: a workflow
triggered by `pull_request_target` that checks out the pull-request
head, placing base-repo secrets and fork-controlled code in the same
run.

## How

- Un-benched in `configuration/registry.go`; wired through
  `plumberconfig` (validation schema + typed struct), `control/catalog.go`,
  `control/mrcomment.go`, the `config init` wizard and `.plumber.yaml`.
- The rule now **abstains when the job carries an `if:` guard** that
  restricts execution to same-repository pull requests
  (`head.repo.full_name == github.repository`, or a `head.repo.fork`
  check). Fork-controlled code never runs under such a guard, so
  flagging the job would be a false positive.

## Validation

- `TestIssue415` extended to 5 cases (2 violations, 3 clean — including
  the fork-guard case).
- `make build && make test && make lint` all green.
- Swept 20 popular OSS repositories: the only ISSUE-804 hit
  (`sveltejs/svelte`) is a guarded job — correctly silenced by the
  guard exclusion, while the unguarded head-checkout fixtures still
  fire.

Closes #181
