### PR TITLE
fix(controls): scope template-injection to free-text github fields (ISSUE-207)

### DIFF
--- a/policies/rules_test.go
+++ b/policies/rules_test.go
@@ -510,7 +510,19 @@ func TestIssue206_TemplateInjection(t *testing.T) {
 			expectedHits: []string{"violation_head_ref/bad"},
 		},
 		{
+			fixture:      "violation_comment_body.yml",
+			expectedHits: []string{"violation_comment_body/bad"},
+		},
+		{
 			fixture:      "clean_env_var.yml",
+			expectedHits: nil,
+		},
+		{
+			fixture:      "clean_pr_number.yml",
+			expectedHits: nil,
+		},
+		{
+			fixture:      "clean_event_fork.yml",
 			expectedHits: nil,
 		},
 	}

--- a/policies/template_injection.rego
+++ b/policies/template_injection.rego
@@ -18,13 +18,36 @@ package template_injection
 
 import rego.v1
 
-# Regex patterns matching template expressions whose value is under
-# the control of an unprivileged PR author. Additional patterns can
-# be added here as the check evolves; the shared message keeps the
-# output simple regardless of which pattern matched.
+# Regex patterns matching template expressions whose value is
+# attacker-controlled FREE TEXT — the genuine template-injection
+# sinks. A pull-request author, issue/comment author or fork owner
+# can put arbitrary shell metacharacters in any of these.
+#
+# Numeric, boolean, enum and SHA fields (`pull_request.number`,
+# `*.commits`, `head.repo.fork`, `event_name`, `author_association`,
+# `*.sha`, `github.repository`, …) are deliberately NOT matched: they
+# cannot carry an injection payload, and flagging them drowns the
+# real signal in false positives.
+#
+# `[^}]*` keeps every match inside a single `${{ … }}` expression so
+# an unrelated safe expression on the same line cannot trigger one.
 unsafe_patterns := [
-	`\${{\s*github\.event\.`,
-	`\${{\s*github\.head_ref\s*}}`,
+	# Titles and bodies — issue, pull_request, comment, review,
+	# discussion.
+	`\${{[^}]*github\.event\.[^}]*\.(title|body)\b`,
+	# Branch / ref names controlled on the attacker's fork.
+	`\${{[^}]*github\.head_ref\b`,
+	`\${{[^}]*github\.event\.[^}]*\.head\.(ref|label)\b`,
+	`\${{[^}]*github\.event\.[^}]*head_branch\b`,
+	`\${{[^}]*github\.event\.[^}]*default_branch\b`,
+	# Commit messages.
+	`\${{[^}]*github\.event\.[^}]*\.message\b`,
+	# Repository metadata an attacker sets on their fork.
+	`\${{[^}]*github\.event\.[^}]*\.(description|homepage)\b`,
+	# Author / committer identity free text.
+	`\${{[^}]*github\.event\.[^}]*(author|committer)\.(name|email)\b`,
+	# GitHub Pages page name.
+	`\${{[^}]*github\.event\.[^}]*page_name\b`,
 ]
 
 deny contains finding if {

--- a/policies/testdata/ISSUE-207/github/clean_event_fork.yml
+++ b/policies/testdata/ISSUE-207/github/clean_event_fork.yml
@@ -1,0 +1,15 @@
+# head.repo.fork is a boolean and event_name a fixed enum — neither is
+# attacker-controllable free text, so neither is a template-injection
+# sink. Expected: 0 findings.
+name: Fork gate
+on: pull_request_target
+
+jobs:
+  ok:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [[ "${{ github.event_name }}" == "pull_request_target" \
+                && "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
+            echo "fork pull request"
+          fi

--- a/policies/testdata/ISSUE-207/github/clean_pr_number.yml
+++ b/policies/testdata/ISSUE-207/github/clean_pr_number.yml
@@ -1,0 +1,11 @@
+# The PR number is an integer — GitHub guarantees it carries no shell
+# metacharacters, so interpolating it into a run script is not a
+# template-injection sink. Expected: 0 findings.
+name: Comment on PR
+on: pull_request_target
+
+jobs:
+  ok:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh pr comment ${{ github.event.pull_request.number }} --body "thanks"

--- a/policies/testdata/ISSUE-207/github/violation_comment_body.yml
+++ b/policies/testdata/ISSUE-207/github/violation_comment_body.yml
@@ -1,0 +1,11 @@
+# Comment body is user-controlled free text pasted verbatim into a
+# shell command — a crafted comment runs arbitrary code. Expected:
+# 1 finding on bad.
+name: Injection via comment body
+on: issue_comment
+
+jobs:
+  bad:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "comment was ${{ github.event.comment.body }}"


### PR DESCRIPTION
## What

Fixes the false-positive flood in `template-injection` (`ISSUE-207`,
control `workflowMustNotInjectUserInputInScripts`).

## Why

`policies/template_injection.rego` matched the bare prefix
`${{ github.event. }}`, so it fired on every `github.event` field in a
`run:` script — including ones that cannot carry shell metacharacters:
integers (`pull_request.number`, `*.commits`), booleans
(`head.repo.fork`), enums (`event_name`, `author_association`), commit
SHAs, `github.repository`.

A sweep of 20 popular OSS repositories produced **42 critical ISSUE-207
findings**; 14 were verified by hand → 13 false positives, 1 borderline,
**0 true positives**. Details: getplumber/plumber#191.

## How

`unsafe_patterns` is now an **allowlist** of the `github` fields that
genuinely carry attacker-controlled free text:

- titles and bodies (issue, pull_request, comment, review, discussion)
- branch / ref names (`head_ref`, `head.ref`, `head.label`,
  `head_branch`, `default_branch`)
- commit messages
- repository `description` / `homepage` (set on the attacker's fork)
- author / committer `name` / `email`
- Pages `page_name`

`[^}]*` keeps every match inside a single `${{ … }}` expression.

## Validation

- `TestIssue206_TemplateInjection` extended to 6 cases — 3 violations
  (PR title, `head_ref`, comment body) and 3 clean (PR number, fork
  boolean, env-binding).
- `make build && make test && make lint` all green.
- Re-ran the sweep: ISSUE-207 drops to **0** on grafana, nodejs,
  pytorch, react and next.js — 28 prior false positives eliminated —
  while the violation fixtures still fire.

Closes #191
