### PR TITLE
fix(controls): treat moving major tags as a version span in advisory filter (ISSUE-703)

### DIFF
--- a/collector/github_metadata.go
+++ b/collector/github_metadata.go
@@ -224,6 +224,10 @@ func (c *GitHubMetadataClient) resolveUncached(owner, repo, ref string) GitHubMe
 // tag, commit SHA that does not point at a release), the filter
 // degrades to "keep advisories that reference this package at
 // all" — better a false positive than a silent miss on a real CVE.
+//
+// A moving major / major.minor tag (`v4`, `v4.1`) is matched against
+// the whole version span it can float across, not against its floor —
+// see _refCoveredByRange.
 func (c *GitHubMetadataClient) advisoriesForRef(owner, repo, ref string) []string {
 	infos := c.advisoriesForRepo(owner, repo)
 	if len(infos) == 0 {
@@ -239,7 +243,7 @@ func (c *GitHubMetadataClient) advisoriesForRef(owner, repo, ref string) []strin
 		if _, dup := seen[a.GhsaID]; dup {
 			continue
 		}
-		if refVersion == nil || _versionInRange(refVersion, a.VulnerableRange) {
+		if _refCoveredByRange(ref, refVersion, a.VulnerableRange) {
 			out = append(out, a.GhsaID)
 			seen[a.GhsaID] = struct{}{}
 		}
@@ -326,6 +330,51 @@ var _shaOnly = regexp.MustCompile(`^[0-9a-f]{40}$`)
 
 func _isCommitSha(ref string) bool {
 	return _shaOnly.MatchString(ref)
+}
+
+var (
+	_majorTagOnly      = regexp.MustCompile(`^v?([0-9]+)$`)
+	_majorMinorTagOnly = regexp.MustCompile(`^v?([0-9]+\.[0-9]+)$`)
+)
+
+// _partialTagBounds recognises a moving major (`v4`) or major.minor
+// (`v4.1`) tag and returns the inclusive version span it can resolve
+// to. ok is false for exact `vX.Y.Z` tags, commit SHAs and any
+// non-semver ref. The high bound uses a saturated patch (and minor)
+// component so no real release sorts above it.
+func _partialTagBounds(ref string) (floor, ceil *version.Version, ok bool) {
+	if m := _majorTagOnly.FindStringSubmatch(ref); m != nil {
+		floor, _ = version.NewVersion(m[1])
+		ceil, _ = version.NewVersion(m[1] + ".999999.999999")
+		return floor, ceil, floor != nil && ceil != nil
+	}
+	if m := _majorMinorTagOnly.FindStringSubmatch(ref); m != nil {
+		floor, _ = version.NewVersion(m[1])
+		ceil, _ = version.NewVersion(m[1] + ".999999")
+		return floor, ceil, floor != nil && ceil != nil
+	}
+	return nil, nil, false
+}
+
+// _refCoveredByRange reports whether an action ref should be treated
+// as affected by an advisory whose vulnerable range is rangeExpr.
+//
+// A moving major / major.minor tag (`v4`, `v4.1`) is not a fixed
+// version — it floats across a whole span of releases. Parsing it as
+// its floor (`v4` -> 4.0.0) and point-checking that floor false-
+// positives whenever an advisory only affects the start of the series,
+// because the tag actually points at the latest, patched release. Such
+// a tag is therefore reported only when the ENTIRE span it can float
+// across is vulnerable.
+//
+// Exact tags (`v4.1.0`) and SHA-resolved versions use a plain single-
+// version check; an unresolvable ref (refVersion nil) is kept
+// conservatively — better a false positive than a silent miss.
+func _refCoveredByRange(ref string, refVersion *version.Version, rangeExpr string) bool {
+	if floor, ceil, ok := _partialTagBounds(ref); ok {
+		return _versionInRange(floor, rangeExpr) && _versionInRange(ceil, rangeExpr)
+	}
+	return refVersion == nil || _versionInRange(refVersion, rangeExpr)
 }
 
 // resolveCommitToTag returns the release tag pointing at the given

--- a/collector/github_metadata_test.go
+++ b/collector/github_metadata_test.go
@@ -78,3 +78,67 @@ func Test_resolveRefToVersion_commitSHA(t *testing.T) {
 		t.Errorf("resolveRefToVersion(v4.3.0) = %v, want 4.3.0", v)
 	}
 }
+
+// Test_partialTagBounds locks the moving-tag recognition: only bare
+// major (`v4`) and major.minor (`v4.1`) tags resolve to a span;
+// exact tags, SHAs and non-semver refs do not.
+func Test_partialTagBounds(t *testing.T) {
+	cases := []struct {
+		ref               string
+		wantOK            bool
+		wantFloor, wantHi string
+	}{
+		{"v4", true, "4.0.0", "4.999999.999999"},
+		{"4", true, "4.0.0", "4.999999.999999"},
+		{"v44", true, "44.0.0", "44.999999.999999"},
+		{"v4.1", true, "4.1.0", "4.1.999999"},
+		{"v4.1.0", false, "", ""}, // exact version — not a moving tag
+		{"main", false, "", ""},
+		{"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", false, "", ""},
+	}
+	for _, c := range cases {
+		floor, ceil, ok := _partialTagBounds(c.ref)
+		if ok != c.wantOK {
+			t.Errorf("_partialTagBounds(%q) ok = %v, want %v", c.ref, ok, c.wantOK)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		wantFloor, _ := version.NewVersion(c.wantFloor)
+		wantHi, _ := version.NewVersion(c.wantHi)
+		if !floor.Equal(wantFloor) || !ceil.Equal(wantHi) {
+			t.Errorf("_partialTagBounds(%q) = (%s, %s), want (%s, %s)", c.ref, floor, ceil, c.wantFloor, c.wantHi)
+		}
+	}
+}
+
+// Test_refCoveredByRange is the ISSUE-195 regression: a moving major /
+// major.minor tag is reported for an advisory only when the whole span
+// it floats across is vulnerable, while exact pins keep the plain
+// single-version semantics.
+func Test_refCoveredByRange(t *testing.T) {
+	cases := []struct {
+		ref, rng, ver string
+		want          bool
+	}{
+		// Moving tags — partial: flagged only if the whole series is vulnerable.
+		{"v4", ">= 4.0.0, < 4.1.3", "", false},   // download-artifact@v4 vs GHSA-cxww — the FP this fixes
+		{"v44", "<= 45.0.7", "", true},           // all of v44.x is vulnerable
+		{"v4.1", ">= 4.0.0, < 4.1.3", "", false}, // moving minor tag — only 4.1.0-4.1.2 affected
+		{"v5", ">= 5, < 6.4.0", "", true},        // all of v5.x is vulnerable
+		// Exact pins / resolved SHAs — single-version check, unchanged.
+		{"v4.1.0", ">= 4.0.0, < 4.1.3", "4.1.0", true},  // exact in-range pin still fires
+		{"v4.3.0", ">= 4.0.0, < 4.1.3", "4.3.0", false}, // exact out-of-range stays silent
+	}
+	for _, c := range cases {
+		var rv *version.Version
+		if c.ver != "" {
+			rv, _ = version.NewVersion(c.ver)
+		}
+		got := _refCoveredByRange(c.ref, rv, c.rng)
+		if got != c.want {
+			t.Errorf("_refCoveredByRange(%q, %q) = %v, want %v", c.ref, c.rng, got, c.want)
+		}
+	}
+}

--- a/docs/GITHUB_ISSUES.md
+++ b/docs/GITHUB_ISSUES.md
@@ -485,6 +485,16 @@ CRIT  [ISSUE-703] job "build" references "tj-actions/changed-files@v45" —
 - uses: tj-actions/changed-files@<fixed-sha> # v46.0.1 or later
 ```
 
+**How the version check decides what to flag.** Exact tags (`@v45.2.0`)
+and SHA-resolved versions are point-checked against each advisory's
+`vulnerable_version_range`. Moving partial tags (`@v45`, `@v45.2`) are
+span-checked across the whole release series they can float across, so
+a partial tag fires only when the **entire** span is vulnerable — `@v4`
+floating to `v4.3.0` does not match an advisory covering
+`>= 4.0.0, < 4.1.3`. SHA pins are resolved through the repo's tag list
+to the most specific tag that points at the commit, so a moving major
+alias never shadows the exact release.
+
 Tip: `gh api "/advisories?ecosystem=actions&affects=tj-actions/changed-files"`
 lists every advisory known for an action, with the `vulnerable_version_range`
 and `patched_versions` fields.


### PR DESCRIPTION
## What

Fixes a false positive in `known-vulnerable-action` (`ISSUE-703`,
control `actionsMustNotCarryKnownCVEs`) on action references pinned to a
moving major / major.minor tag.

## Why

`collector.advisoriesForRef` parsed a tag like `v4` as its floor version
(`version.NewVersion("4")` → `4.0.0`) and point-checked that floor
against each advisory's vulnerable range. Any advisory covering the
start of a series then matched `@vN`, even though the moving tag floats
to the latest, patched release.

A sweep of the `outscale` org surfaced it: `actions/download-artifact@v4`
flagged for `GHSA-cxww-7g56-2vh6` (`>= 4.0.0, < 4.1.3`) while `v4`
resolves to `v4.3.0`. See #195.

Distinct from #180, which fixed commit-SHA resolution — `@v4` is a plain
tag reference, a different code path.

## How

A partial tag (`vN` or `vN.M` — fewer than three version segments) now
denotes the whole version span it can float across (`v4` →
`[4.0.0, 5.0.0)`). The advisory is kept only when **the entire span** is
vulnerable — floor and ceiling both inside the range. Exact tags
(`vX.Y.Z`) and SHA-resolved versions keep the plain single-version
check; an unresolvable ref is still kept conservatively.

## Validation

- `Test_partialTagBounds` and `Test_refCoveredByRange` added to
  `collector/github_metadata_test.go`.
- `make build && make test && make lint` all green.
- Verified against a fixture: `actions/download-artifact@v4` is no
  longer flagged, while the genuinely vulnerable `@v4.1.0` / `@v4.1.2`
  pins still fire.

Closes #195
