### PR TITLE
fix(collector): fold Docker Hub registry-host aliases to docker.io

### DIFF
--- a/collector/dataCollectionGitlabPipelineImage.go
+++ b/collector/dataCollectionGitlabPipelineImage.go
@@ -17,6 +17,46 @@ const (
 	unknownRegistry = "unknown"
 )
 
+// dockerHubRegistryAliases are alternative hostnames that all resolve to
+// Docker Hub. Pipeline authors may write any of them, but the
+// image_authorized_sources policy does a literal glob match and performs no
+// host canonicalisation — so we fold them to the canonical dockerHubDomain
+// here, at parse time, so trustedUrls patterns written against docker.io/*
+// match regardless of which Hub hostname was used.
+var dockerHubRegistryAliases = map[string]string{
+	"index.docker.io":         dockerHubDomain,
+	"registry-1.docker.io":    dockerHubDomain,
+	"registry.hub.docker.com": dockerHubDomain,
+}
+
+// canonicalizeDockerHubRegistry maps any known Docker Hub registry-host alias
+// to the canonical "docker.io". Non-Hub hosts (and "", "unknown") pass through
+// unchanged.
+func canonicalizeDockerHubRegistry(host string) string {
+	if canon, ok := dockerHubRegistryAliases[host]; ok {
+		return canon
+	}
+	return host
+}
+
+// foldDockerHubAliasInName rewrites the leading registry-host segment of an
+// image name when that segment is a Docker Hub alias. GitHub Actions image
+// references are parsed without splitting out the registry (the host stays in
+// Name), so this operates on the name string rather than a separate registry
+// field. Names without a leading host segment (e.g. bare "alpine") are
+// returned unchanged.
+func foldDockerHubAliasInName(name string) string {
+	slash := strings.Index(name, "/")
+	if slash <= 0 {
+		return name
+	}
+	host := name[:slash]
+	if canon, ok := dockerHubRegistryAliases[host]; ok {
+		return canon + name[slash:]
+	}
+	return name
+}
+
 ////////////////////////////
 // DataCollection results //
 ////////////////////////////
@@ -560,7 +600,17 @@ func (i *GitlabPipelineImageInfo) handlePresenceOfVariables() {
 	i.Tag = ""
 }
 
+// parseImageLink parses the raw image reference into Registry/Name/Tag and
+// then folds any Docker Hub registry-host alias to the canonical docker.io.
+// Normalising once here (rather than at each of the ~19 registry-assignment
+// sites in parseImageReference/handlePresenceOfVariables) keeps the behaviour
+// consistent across every code path.
 func (i *GitlabPipelineImageInfo) parseImageLink(l *logrus.Entry) {
+	i.parseImageReference(l)
+	i.Registry = canonicalizeDockerHubRegistry(i.Registry)
+}
+
+func (i *GitlabPipelineImageInfo) parseImageReference(l *logrus.Entry) {
 	originalLink := i.Link
 
 	// Check if it contains any unresolved variables

--- a/collector/github_workflows.go
+++ b/collector/github_workflows.go
@@ -856,6 +856,11 @@ func parseGitHubContainer(v any) (ir.Image, bool) {
 }
 
 func splitImageRef(ref string) ir.Image {
+	// Fold Docker Hub registry-host aliases (registry.hub.docker.com,
+	// index.docker.io, registry-1.docker.io) to docker.io so trustedUrls
+	// patterns match regardless of which Hub hostname was used. GitHub refs
+	// keep the registry host inside Name, so we normalise the name string.
+	ref = foldDockerHubAliasInName(ref)
 	// Digest form takes precedence: "alpine@sha256:..."
 	if at := strings.Index(ref, "@"); at > 0 {
 		return ir.Image{Name: ref[:at], Digest: ref[at+1:]}

--- a/collector/registry_alias_normalization_test.go
+++ b/collector/registry_alias_normalization_test.go
@@ -1,0 +1,140 @@
+package collector
+
+// Tests for Docker Hub registry-host alias normalisation in the image
+// parsers (GitLab parseImageLink + GitHub splitImageRef) and end-to-end
+// through the image_authorized_sources policy. The fix lets a trustedUrls
+// entry written against docker.io/* match the same image referenced via any
+// Docker Hub alias hostname, without per-alias workaround patterns.
+
+import (
+	"context"
+	"testing"
+
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
+	"github.com/getplumber/plumber/internal/ir"
+	"github.com/getplumber/plumber/policies"
+	"github.com/sirupsen/logrus"
+)
+
+func TestCanonicalizeDockerHubRegistry(t *testing.T) {
+	cases := map[string]string{
+		"registry.hub.docker.com": "docker.io",
+		"index.docker.io":         "docker.io",
+		"registry-1.docker.io":    "docker.io",
+		"docker.io":               "docker.io",
+		"ghcr.io":                 "ghcr.io",
+		"registry.gitlab.com":     "registry.gitlab.com",
+		"":                        "",
+		"unknown":                 "unknown",
+	}
+	for in, want := range cases {
+		if got := canonicalizeDockerHubRegistry(in); got != want {
+			t.Errorf("canonicalizeDockerHubRegistry(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFoldDockerHubAliasInName(t *testing.T) {
+	cases := map[string]string{
+		"registry.hub.docker.com/library/node": "docker.io/library/node",
+		"index.docker.io/foo/bar":              "docker.io/foo/bar",
+		"ghcr.io/astral-sh/uv":                 "ghcr.io/astral-sh/uv",
+		"alpine":                               "alpine",
+		"library/node":                         "library/node",
+	}
+	for in, want := range cases {
+		if got := foldDockerHubAliasInName(in); got != want {
+			t.Errorf("foldDockerHubAliasInName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestParseImageLink_FoldsHubAliases(t *testing.T) {
+	log := logrus.NewEntry(logrus.New())
+	cases := []struct {
+		link             string
+		wantReg, wantNam string
+		wantTag          string
+	}{
+		{"registry.hub.docker.com/library/node:alpine", "docker.io", "library/node", "alpine"},
+		{"index.docker.io/python:3.12", "docker.io", "python", "3.12"},
+		{"registry-1.docker.io/library/golang:1.26", "docker.io", "library/golang", "1.26"},
+		// non-alias registries are untouched
+		{"ghcr.io/astral-sh/uv:latest", "ghcr.io", "astral-sh/uv", "latest"},
+	}
+	for _, tc := range cases {
+		info := GitlabPipelineImageInfo{Link: tc.link, Tag: defaultTag}
+		info.parseImageLink(log)
+		if info.Registry != tc.wantReg || info.Name != tc.wantNam || info.Tag != tc.wantTag {
+			t.Errorf("parseImageLink(%q) = {reg:%q name:%q tag:%q}, want {reg:%q name:%q tag:%q}",
+				tc.link, info.Registry, info.Name, info.Tag, tc.wantReg, tc.wantNam, tc.wantTag)
+		}
+	}
+}
+
+func TestSplitImageRef_FoldsHubAliases(t *testing.T) {
+	cases := []struct {
+		ref      string
+		wantName string
+		wantTag  string
+	}{
+		{"registry.hub.docker.com/library/node:alpine", "docker.io/library/node", "alpine"},
+		{"index.docker.io/python:3.12", "docker.io/python", "3.12"},
+		{"ghcr.io/astral-sh/uv:latest", "ghcr.io/astral-sh/uv", "latest"},
+		{"alpine:3.20", "alpine", "3.20"},
+	}
+	for _, tc := range cases {
+		got := splitImageRef(tc.ref)
+		if got.Name != tc.wantName || got.Tag != tc.wantTag {
+			t.Errorf("splitImageRef(%q) = {name:%q tag:%q}, want {name:%q tag:%q}",
+				tc.ref, got.Name, got.Tag, tc.wantName, tc.wantTag)
+		}
+	}
+}
+
+// TestAliasNormalization_E2E proves that with ONLY docker.io/library/* trusted
+// (no registry.hub.docker.com/* workaround pattern), a Hub-alias reference is
+// authorized for both providers — i.e. the collector fix removes the need for
+// the alias workaround in .plumber.yaml.
+func TestAliasNormalization_E2E(t *testing.T) {
+	engine := opaengine.New()
+	if err := engine.LoadFromFS(policies.FS); err != nil {
+		t.Fatalf("load policies: %v", err)
+	}
+	cfg := map[string]any{"imageAuthorizedSources": map[string]any{
+		"trustedUrls":            []string{"docker.io/library/*"},
+		"trustDockerHubOfficial": true,
+	}}
+	log := logrus.NewEntry(logrus.New())
+
+	eval := func(img ir.Image) bool {
+		pipeline := &ir.NormalizedPipeline{Provider: ir.ProviderGitLab, Jobs: []ir.Job{{Name: "build", Image: &img}}}
+		findings, err := engine.Evaluate(context.Background(), pipeline, cfg)
+		if err != nil {
+			t.Fatalf("evaluate: %v", err)
+		}
+		for _, f := range findings {
+			if f.Code == "ISSUE-101" {
+				return false
+			}
+		}
+		return true
+	}
+
+	// GitLab path through parseImageLink + imageFromInfo
+	info := GitlabPipelineImageInfo{Link: "registry.hub.docker.com/library/node:alpine", Tag: defaultTag}
+	info.parseImageLink(log)
+	if !eval(imageFromInfo(info)) {
+		t.Errorf("GitLab: registry.hub.docker.com/library/node:alpine should be authorized via docker.io/library/* after alias fold")
+	}
+
+	// GitHub path through splitImageRef
+	if !eval(splitImageRef("registry.hub.docker.com/library/node:alpine")) {
+		t.Errorf("GitHub: registry.hub.docker.com/library/node:alpine should be authorized via docker.io/library/* after alias fold")
+	}
+
+	// Negative control: a genuinely untrusted registry stays flagged.
+	if eval(ir.Image{Registry: "ghcr.io", Name: "evil/tool", Tag: "latest"}) {
+		t.Errorf("ghcr.io/evil/tool:latest must remain unauthorized")
+	}
+}


### PR DESCRIPTION
## Problem

The `image_authorized_sources` policy does a literal `go-wildcard` match and performs **no host canonicalisation**. The collectors kept explicit registry hosts verbatim, so an image referenced via a Docker Hub **alias** hostname was not matched by a `docker.io/*` `trustedUrls` pattern and got flagged `ISSUE-101` — even though it is the same image.

Example: `registry.hub.docker.com/library/node:alpine` was flagged despite `docker.io/library/*` being trusted.

Affected aliases (all resolve to Docker Hub):
- `registry.hub.docker.com`
- `index.docker.io`
- `registry-1.docker.io`

## Fix

Add a shared canonicalisation helper and apply it at parse time for **both** providers:

- **GitLab** (`parseImageLink`): now wraps the existing parser (renamed `parseImageReference`) and folds `i.Registry` once — covering all ~19 registry-assignment sites uniformly instead of editing each.
- **GitHub** (`splitImageRef`): folds the leading host segment of the image name (GitHub refs keep the registry inside `Name`).

Both providers share the same `image_authorized_sources.rego`, so this makes alias handling consistent across them.

## Impact

Users can drop `registry.hub.docker.com/*`-style alias workarounds from their trusted-registry config. Digest pins and bare/`library/` forms are unaffected — they were already covered by the `trustDockerHubOfficial` fast-path and `/*` patterns respectively.

## Tests

New `collector/registry_alias_normalization_test.go`:
- Unit tests for `canonicalizeDockerHubRegistry` and `foldDockerHubAliasInName`
- `parseImageLink` (GitLab) and `splitImageRef` (GitHub) fold aliases; non-Hub hosts untouched
- **E2E** through the OPA engine: with only `docker.io/library/*` trusted (no alias pattern), a Hub-alias ref is authorized for both providers; a genuinely untrusted registry stays flagged

`go test ./collector/ ./policies/` pass; `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)