### PR TITLE
ci(release): fix gh release create repo context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,9 +176,13 @@ jobs:
       # are passed via an env var and a --notes-file (never interpolated
       # into the script body) so arbitrary commit text in the release
       # notes cannot inject shell commands.
+      # GH_REPO gives the gh CLI the repository context. This job does not
+      # check out the repo (it only consumes downloaded artifacts), so
+      # without GH_REPO gh would fail with "not a git repository".
       - name: Create release with assets
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           VERSION: ${{ needs.release.outputs.new_release_version }}
           NOTES: ${{ needs.release.outputs.new_release_notes }}
         run: |


### PR DESCRIPTION
The `Release & Publish` run [failed](https://github.com/getplumber/plumber/actions/runs/27697343626/job/81924377561) at **Create release with assets**:

\`\`\`
failed to run git: fatal: not a git repository (or any of the parent directories): .git
\`\`\`

The `upload-release` job has no `actions/checkout` step (it only downloads artifacts), so the `gh` CLI couldn't resolve the repository. Setting `GH_REPO: ${{ github.repository }}` gives gh the repo context without needing a checkout.

The rest of the semantic-release rewrite worked (version + notes were resolved correctly); only this step failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)