### PR TITLE
chore: recreate the 0.3.62 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-## [0.3.62](https://github.com/getplumber/plumber/compare/v0.3.61...v0.3.62) (2026-06-17)
-
-
-### ✨ Features
-
-* **control:** add githubActionMustComeFromAuthorizedSources (ISSUE-713) ([74d60c6](https://github.com/getplumber/plumber/commit/74d60c64f8ffe1ff8103d419489cde736202ec34)), closes [#253](https://github.com/getplumber/plumber/issues/253)
-
 ## [0.3.61](https://github.com/getplumber/plumber/compare/v0.3.60...v0.3.61) (2026-06-17)
 
 

--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,8 @@ branding:
 
 inputs:
   version:
-    description: "Plumber release tag to install (e.g. v0.3.62). Downloaded from GitHub Releases and verified against checksums.txt and SLSA attestation"
-    default: "v0.3.62"
+    description: "Plumber release tag to install (e.g. v0.3.61). Downloaded from GitHub Releases and verified against checksums.txt and SLSA attestation"
+    default: "v0.3.61"
   verify-attestation:
     description: "Verify the downloaded binary's build-provenance attestation (sigstore/SLSA) against the getplumber/plumber release workflow, using the gh CLI. This anchors the binary to a trusted build regardless of the mutable release tag. Disable for air-gapped or GHES setups without attestation access."
     default: "true"


### PR DESCRIPTION
Recreates a clean **0.3.62** release after the original run failed.

## Why
The 0.3.62 `Release & Publish` run failed at *Create release with assets* (`gh` CLI lacked repo context — fixed in #258). **No artifacts were published** (no GitHub release, Docker cancelled, Homebrew skipped), and the `v0.3.62` tag was deleted manually.

## What
Reverts `52f852c` (`chore(release): 0.3.62`), resetting `action.yml` / `CHANGELOG.md` to the 0.3.61 baseline. Merging this pushes to main with `#258` already in place, so semantic-release recreates a clean **0.3.62** through the now-fixed pipeline (release → binaries → upload-release → docker → homebrew).

The commit/PR intentionally carry **no `[skip ci]`** so the merge triggers the release workflow.

## Order (already done)
1. ✅ #258 merged (GH_REPO fix on main)
2. ✅ `v0.3.62` tag deleted
3. ⏳ Merge this → triggers the clean 0.3.62 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)