### PR TITLE
chore(release): reset changelog before re-minting 0.3.63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,3 @@
-## [0.3.63](https://github.com/getplumber/plumber/compare/v0.3.62...v0.3.63) (2026-06-18)
-
-
-### ✨ Features
-
-* **analyze,template:** add verbose env var and simplify CI template via env var delegation ([742487f](https://github.com/getplumber/plumber/commit/742487fd11d878c81269bec042de893ac6e43f35))
-* **analyze:** support environment variables ([cd47fcd](https://github.com/getplumber/plumber/commit/cd47fcd329d85a4f9f346bc16c72e1fb911cec42))
-
-
-### 🐛 Bug Fixes
-
-* **analyze:** document env vars and cover fallbacks with tests ([3a659f9](https://github.com/getplumber/plumber/commit/3a659f90e591b108ac0fedab33502a1e4dd7d7a6))
-* **lint:** replace spaces by tabs (gofmt) ([5a84933](https://github.com/getplumber/plumber/commit/5a849333836581b6ea2e0f91677125a9b1afd67b))
-
-## [0.3.63](https://github.com/getplumber/plumber/compare/v0.3.62...v0.3.63) (2026-06-18)
-
-
-### ✨ Features
-
-* **analyze,template:** add verbose env var and simplify CI template via env var delegation ([eb0f400](https://github.com/getplumber/plumber/commit/eb0f400b16801fc3a3e0cf12d17d545fc537798c))
-* **analyze:** support environment variables ([cd47fcd](https://github.com/getplumber/plumber/commit/cd47fcd329d85a4f9f346bc16c72e1fb911cec42))
-
-
-### 🐛 Bug Fixes
-
-* **lint:** replace spaces by tabs (gofmt) ([7ccc680](https://github.com/getplumber/plumber/commit/7ccc6806bc3450d2a4f6ac65ab18a4b47ecb9064))
-
 ## [0.3.62](https://github.com/getplumber/plumber/compare/v0.3.61...v0.3.62) (2026-06-17)
 
 


### PR DESCRIPTION
## What

Drops the two premature `0.3.63` CHANGELOG sections left on `main` by the earlier force-push (the original release commit + the bogus duplicate the failed release run pushed), so semantic-release re-mints a single clean `0.3.63` section.

## Why

The `v0.3.63` tag was orphaned by a force-push, which made semantic-release miscompute (it ignored the unreachable tag, recomputed `0.3.63`, and collided with the existing tag). The tag + GitHub release have now been deleted. Merging this re-triggers `release.yml`; with `v0.3.62` as the last reachable tag, semantic-release re-mints a clean **0.3.63** (correct template, env-capable image).

No source/behavior change — CHANGELOG-only cleanup.

## Note

Merge bypasses the normal review gate intentionally (release recovery). After it merges, `release.yml` runs and `pin-refs` will repin the README/template to the new 0.3.63 refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)