### PR TITLE
chore(release): force-tag 0.3.64 (v0.3.63 burned by tag immutability)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,11 +65,35 @@ jobs:
       # new_release_version) are written by the @semantic-release/exec
       # successCmd in .releaserc.json — it runs only on a published
       # release — replacing the outputs the wrapper action used to set.
-      - name: Semantic Release
+      # ONE-OFF (reverted immediately after this release): v0.3.63 is
+      # permanently reserved by tag immutability, so semantic-release — which
+      # would compute 0.3.63 as the next patch from 0.3.62 — can never tag it.
+      # Force-tag v0.3.64 on the current main commit instead; every downstream
+      # job (binaries, attestation, docker, release, homebrew, pin-refs) runs
+      # unchanged, so the release keeps full SLSA provenance. The next normal
+      # release sees v0.3.64 and resumes automatically.
+      - name: Force release 0.3.64
         id: semantic
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: semantic-release
+        run: |
+          set -euo pipefail
+          VERSION=0.3.64
+          REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # Idempotent: if v0.3.64 was already tagged by an earlier run of this
+          # one-off step, skip with new_release_published=false so the job stays
+          # green and the downstream publish jobs (gated on 'true') are skipped.
+          # This keeps any main push before release.yml is reverted from failing
+          # on a duplicate-tag error.
+          if git ls-remote --exit-code --tags "$REMOTE" "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${VERSION} already exists; skipping."
+            echo "new_release_published=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git tag "v${VERSION}"
+          git push "$REMOTE" "refs/tags/v${VERSION}"
+          echo "new_release_published=true" >> "$GITHUB_OUTPUT"
+          echo "new_release_version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       # Release notes are extracted from the top section of CHANGELOG.md
       # (semantic-release/changelog wrote it during this same job) rather

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.3.63](https://github.com/getplumber/plumber/compare/v0.3.62...v0.3.63) (2026-06-18)
+## [0.3.64](https://github.com/getplumber/plumber/compare/v0.3.62...v0.3.64) (2026-06-18)
 
 
 ### ✨ Features

--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,8 @@ branding:
 
 inputs:
   version:
-    description: "Plumber release tag to install (e.g. v0.3.63). Downloaded from GitHub Releases and verified against checksums.txt and SLSA attestation"
-    default: "v0.3.63"
+    description: "Plumber release tag to install (e.g. v0.3.64). Downloaded from GitHub Releases and verified against checksums.txt and SLSA attestation"
+    default: "v0.3.64"
   verify-attestation:
     description: "Verify the downloaded binary's build-provenance attestation (sigstore/SLSA) against the getplumber/plumber release workflow, using the gh CLI. This anchors the binary to a trusted build regardless of the mutable release tag. Disable for air-gapped or GHES setups without attestation access."
     default: "true"


### PR DESCRIPTION
## Why

`v0.3.63` was created then deleted, and the repo's **tag-immutability** ruleset permanently reserves that name — it can never be re-created. semantic-release computes `0.3.63` as the next patch from `0.3.62`, so every release attempt fails trying to create the burned tag. The pipeline is stuck.

`0.3.64` is unreachable via semantic-release (it would need a `0.3.63` predecessor tag). So this is a **one-off**: force-tag `v0.3.64` directly, keeping the full pipeline.

## What

- **action.yml** — bump version to `v0.3.64`
- **CHANGELOG.md** — replace the never-released `0.3.63` section with `0.3.64`
- **release.yml** — replace the `semantic-release` step (for this run only) with a `Force release 0.3.64` step that tags the current main commit and sets the release outputs. **Every downstream job runs unchanged** — binaries + provenance attestation, docker build + attestation, GitHub release, Homebrew, pin-refs — so `0.3.64` keeps full SLSA provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)