### PR TITLE
fix(template): avoid circular GITLAB_TOKEN/PLUMBER_TOKEN reference

### DIFF
--- a/templates/plumber.yml
+++ b/templates/plumber.yml
@@ -144,8 +144,10 @@ spec:
     entrypoint: [""]  # Override ENTRYPOINT to allow shell script execution
   variables:
     # Use intermediate variable to avoid self-reference when default is $GITLAB_TOKEN
+    # GITLAB_TOKEN is exported in script (not here) to avoid a circular variable
+    # reference: with the default, PLUMBER_TOKEN expands to $GITLAB_TOKEN, so
+    # defining GITLAB_TOKEN: $PLUMBER_TOKEN here cycles back on itself.
     PLUMBER_TOKEN: $[[ inputs.gitlab_token ]]
-    GITLAB_TOKEN: $PLUMBER_TOKEN
     PLUMBER_ANALYZE_CONFIG: $[[ inputs.config_file ]]
     PLUMBER_ANALYZE_GITLAB_URL: $[[ inputs.server_url ]]
     PLUMBER_ANALYZE_PROJECT: $[[ inputs.project_path ]]
@@ -166,6 +168,10 @@ spec:
     PLUMBER_ANALYZE_CI_CONFIG_PATH: $[[ inputs.ci_config_path ]]
     PLUMBER_ANALYZE_VERBOSE: $[[ inputs.verbose ]]
   script:
+    # Export GITLAB_TOKEN for the CLI here (runtime), where $PLUMBER_TOKEN is
+    # already expanded to the real token value, avoiding the circular reference
+    # that occurs if GITLAB_TOKEN is set from $PLUMBER_TOKEN in variables.
+    - export GITLAB_TOKEN="$PLUMBER_TOKEN"
     - plumber analyze
   artifacts:
     paths:


### PR DESCRIPTION
## Problem

The component template (`templates/plumber.yml`) defines both of these under `variables:`:

```yaml
variables:
  PLUMBER_TOKEN: $[[ inputs.gitlab_token ]]   # default → $GITLAB_TOKEN
  GITLAB_TOKEN:  $PLUMBER_TOKEN
```

GitLab resolves job `variables:` at expansion time, so with the default it follows `GITLAB_TOKEN → PLUMBER_TOKEN → GITLAB_TOKEN` and fails the pipeline with:

```
plumber: circular variable reference detected: ["PLUMBER_TOKEN", "GITLAB_TOKEN"]
```

This breaks the **documented, recommended setup** where users store their token in a CI/CD variable named `GITLAB_TOKEN`.

## Fix

Stop redefining `GITLAB_TOKEN` in `variables:`. Export it at runtime in `script:`, where `$PLUMBER_TOKEN` is already expanded to the real token value:

```yaml
variables:
  PLUMBER_TOKEN: $[[ inputs.gitlab_token ]]
  # ... PLUMBER_ANALYZE_* ...
script:
  - export GITLAB_TOKEN="$PLUMBER_TOKEN"
  - plumber analyze
```

No cycle, and the `gitlab_token` input override still works (this mirrors how the pre-env-var template handled the token).

### Verified scenarios
- **Default** (project CI/CD var `GITLAB_TOKEN`): `PLUMBER_TOKEN=$GITLAB_TOKEN`; export is redundant but harmless. ✅
- **Override** (`gitlab_token: $MY_TOKEN`): export maps the custom var onto `GITLAB_TOKEN` for the CLI. ✅
- **Both**: explicit override wins. ✅

> Already shipped in the GitLab component as `v0.3.6`; this ports the same fix upstream so future syncs stay consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)