### PR TITLE
chore(score): show the badge nudge in CI too + simpler wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ More help:
 - GitLab guide: [getplumber.io/docs/cli/gitlab](https://getplumber.io/docs/cli/gitlab)
 - GitHub guide: [getplumber.io/docs/cli/github](https://getplumber.io/docs/cli/github)
 - Discord: [discord.gg/932xkSU24f](https://discord.gg/932xkSU24f)
+- Contact: [tech@getplumber.io](mailto:tech@getplumber.io)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <b>CI/CD compliance scanner for GitLab CI and GitHub Actions</b><br/>
+  <b>CI/CD security scanner for GitLab CI and GitHub Actions</b><br/>
   <sub>One CLI, one <code>.plumber.yaml</code>, one Rego policy engine.</sub>
 </p>
 
@@ -35,7 +35,7 @@
 
 ## What Is Plumber?
 
-Plumber scans CI/CD pipelines for risky patterns and compliance gaps.
+Plumber scans CI/CD pipelines for risky patterns and security gaps.
 
 - **GitLab CI:** reads `.gitlab-ci.yml`, resolved includes, and repository settings.
 - **GitHub Actions:** reads `.github/workflows/*.{yml,yaml}` locally or through the GitHub API.
@@ -317,8 +317,8 @@ More details:
 
 | Code | Meaning |
 |---|---|
-| `0` | Compliance is greater than or equal to `--threshold` |
-| `1` | Compliance is below `--threshold` |
+| `0` | The security score is greater than or equal to `--threshold` |
+| `1` | The security score is below `--threshold` |
 | `2` | Invalid usage, configuration, or a runtime / provider / auth / network failure |
 | `3` | A check could not be verified and `--fail-warnings` is set (e.g. an action version that could not be resolved) |
 

--- a/cmd/score_push.go
+++ b/cmd/score_push.go
@@ -299,12 +299,14 @@ func handleScorePublishingOnce(p providerPkg.Provider, conf *configuration.Confi
 	maybePushScore(p, conf, payload)
 }
 
-// maybeScoreNudge prints a one-time invitation to publish a live badge — only
-// in an interactive local run (a human is reading). Suppressed in CI, on a
-// non-TTY, and when terminal output is off, so it never spams logs.
+// maybeScoreNudge prints an invitation to publish a live badge whenever text
+// output is on — including in CI — so a run that isn't already publishing a
+// score still points the user at how to turn it on. Suppressed only when
+// terminal output is off (e.g. --silent / JSON-only) so it never spams
+// machine-readable output.
 func maybeScoreNudge() {
-	if !printOutput || !isInteractiveInit() {
+	if !printOutput {
 		return
 	}
-	fmt.Fprintln(os.Stderr, "💡 Publish a live Plumber Score badge for this repo: turn on score-push in your CI pipeline (the Plumber GitHub Action / GitLab component, or --score-push). Publishing runs only in CI. Learn more: https://getplumber.io/docs/plumber-score")
+	fmt.Fprintln(os.Stderr, "💡 Display a live Plumber Score badge for this repo: turn on score-push in your CI pipeline. Learn more: https://getplumber.io/docs/plumber-score")
 }


### PR DESCRIPTION
## What

Two small changes to the Plumber Score "publish a live badge" nudge (`cmd/score_push.go`, `maybeScoreNudge`):

1. **Show it in CI too.** It was gated behind `isInteractiveInit()` (TTY), so it was suppressed in CI — exactly where a run that isn't yet pushing a score is most worth nudging. Now it prints whenever text output is on; still suppressed for `--silent` / JSON-only so it never spams machine-readable output.
2. **Simpler wording:**

   Before:
   > 💡 Publish a live Plumber Score badge for this repo: turn on score-push in your CI pipeline (the Plumber GitHub Action / GitLab component, or --score-push). Publishing runs only in CI. Learn more: https://getplumber.io/docs/plumber-score

   After:
   > 💡 Display a live Plumber Score badge for this repo: turn on score-push in your CI pipeline. Learn more: https://getplumber.io/docs/plumber-score

The nudge still only fires when score-push is **not** enabled (so an actual publishing run is unaffected). `go vet` + `cmd` score tests pass.