### PR TITLE
ci: align self-scan workflow/job names to 'Plumber'

### DIFF
--- a/.github/workflows/plumber-action.yml
+++ b/.github/workflows/plumber-action.yml
@@ -6,7 +6,7 @@
 # Plumber is built from source so the gate tracks the code in this repo (the
 # released binary may lag behind --sarif and friends). Once a release with the
 # action exists, this can switch to `uses: getplumber/plumber@<sha>`.
-name: Plumber compliance
+name: Plumber
 
 on:
   push:
@@ -18,7 +18,7 @@ permissions: {}
 
 jobs:
   plumber:
-    name: Plumber analyze
+    name: Plumber
     runs-on: ubuntu-24.04
     permissions:
       contents: read


### PR DESCRIPTION
Renames the self-scan workflow and its job from "Plumber compliance" / "Plumber analyze" to just **Plumber**, matching the naming used in the example/consumer repos. Naming only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)