### PR TITLE
chore(action): revert GitHub Action name to "Plumber Score"

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ plumber analyze \
 
 ## GitHub Action
 
-1. Add [the official Plumber action](https://github.com/marketplace/actions/plumber-security) to `.github/workflows/plumber.yml`:
+1. Add [the official Plumber action](https://github.com/marketplace/actions/plumber-score) to `.github/workflows/plumber.yml`:
     ```yaml
     name: Plumber
 
@@ -365,7 +365,7 @@ Contributing guide: [`CONTRIBUTING.md`](./CONTRIBUTING.md)
 
 - Website: [getplumber.io](https://getplumber.io)
 - Documentation: [getplumber.io/docs/cli](https://getplumber.io/docs/cli)
-- GitHub Action listing: [Plumber Security](https://github.com/marketplace/actions/plumber-security)
+- GitHub Action listing: [Plumber Score](https://github.com/marketplace/actions/plumber-score)
 - GitLab component docs: [`COMPONENT_README.md`](./COMPONENT_README.md)
 - Security policy: [`SECURITY.md`](./SECURITY.md)
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "Plumber Security"
+name: "Plumber Score"
 description: "Plumber detects CI/CD security issues in your GitHub workflows and gives you a score."
 author: "Plumber (getplumber.io)"
 


### PR DESCRIPTION
## What

Reverts the GitHub Marketplace action name back to **"Plumber Score"** and points the listing links back at `https://github.com/marketplace/actions/plumber-score`.

This undoes the "Plumber Security" rename merged in #279 — we're keeping "Plumber Score".

## Changes

- `action.yml`: `name: "Plumber Security"` → `name: "Plumber Score"`.
- `README.md`: both Marketplace links (in *GitHub Action* setup and *Resources*) restored to `https://github.com/marketplace/actions/plumber-score`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)