### PR TITLE
feat(config): trust whole getplumber org in default authorized sources (images + actions)

### DIFF
--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -69,9 +69,8 @@ gitlab:
 
         # Common CI/CD tool images
         - docker.io/docker:*
-        - docker.io/getplumber/plumber:*
-        - getplumber/plumber:*
-        - docker.io/getplumber/plumber@sha256:*
+        - docker.io/getplumber/* # all Plumber org images on Docker Hub
+        - getplumber/* # docker.io implicit-prefix form
         # GitLab registry patterns
         - $CI_REGISTRY_IMAGE:*
         - $CI_REGISTRY_IMAGE/*

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -775,9 +775,8 @@ func defaultTrustedURLs() []string {
 	return []string{
 		// Common CI/CD tool images
 		"docker.io/docker:*",
-		"docker.io/getplumber/plumber:*",
-		"getplumber/plumber:*",
-		"docker.io/getplumber/plumber@sha256:*",
+		"docker.io/getplumber/*",
+		"getplumber/*",
 		// GitLab registry patterns
 		"$CI_REGISTRY_IMAGE:*",
 		"$CI_REGISTRY_IMAGE/*",


### PR DESCRIPTION
## What

Broadens the shipped default config to trust the entire **getplumber** org rather than only the `plumber` image/action. Two independent trust lists updated:

### Container images — `gitlab.controls.containerImageMustComeFromAuthorizedSources.trustedUrls`
- `getplumber/*` — docker.io implicit-prefix form
- `docker.io/getplumber/*` — Docker Hub images

Replaces the three narrower `getplumber/plumber:*` / `docker.io/getplumber/plumber:*` / `docker.io/getplumber/plumber@sha256:*` entries, which they fully subsume (`glob.match` uses null delimiters, so `*` spans `/`, `:` and `@`).

### GitHub Actions — `github.controls.githubActionMustComeFromAuthorizedSources.trustedGithubActions`
- `getplumber/*` — so consumers running Plumber's own `getplumber/plumber` action (and any other org action) aren't flagged as an untrusted source. Previously getplumber was only trusted for repos *inside* the org via `trustSameOrgActions`.

## Where

- `.plumber.yaml` — shipped default config (source of truth)
- `cmd/init.go` `defaultTrustedURLs()` — wizard image default, kept in lockstep with the embedded config via `TestDefaultTrustedURLsMatchEmbeddedDefault`

The action allowlist has no code mirror (the wizard leaves `trustedGithubActions` empty for the user to fill), so only `.plumber.yaml` needed the actions change. The embedded `internal/defaultconfig/default.yaml` is gitignored and regenerated by `make build`.

## Test

- `go test ./cmd/ ./policies/ ./configuration/` — all pass
- Lockstep test passes after `make embed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)