### PR TITLE
feat(config): trust getplumber/plumber action in default authorized sources

### DIFF
--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -608,6 +608,7 @@ github:
       # Allowlist of trusted action sources. Each entry is either an
       # exact `owner/repo` or an `owner/*` wildcard for a whole org.
       trustedGithubActions:
+        - getplumber/plumber # Plumber's own GitHub Action
         - docker/setup-qemu-action
         - docker/setup-buildx-action
         - docker/login-action


### PR DESCRIPTION
## What

Adds `getplumber/plumber` to the default `github.controls.githubActionMustComeFromAuthorizedSources.trustedGithubActions` allowlist — an exact `owner/repo` entry for Plumber's own GitHub Action, not the whole org.

Previously the getplumber org was only trusted for GitHub Actions when scanning a repo *inside* the org (via `trustSameOrgActions: true`). A third-party repo running the `getplumber/plumber` action would therefore be flagged as an untrusted action source under the shipped defaults. This trusts just that action out of the box.

## Where

- `.plumber.yaml` — shipped default config (source of truth). The embedded `internal/defaultconfig/default.yaml` is gitignored and regenerated by `make build`.

The action allowlist has no code mirror (the wizard leaves `trustedGithubActions` empty for the user to fill), so no `cmd/init.go` change is needed.

## Test

- `go test ./cmd/ ./policies/ ./configuration/` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)