### PR TITLE
fix(gitleaks): disable secret scanning

### DIFF
--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -166,6 +166,7 @@ func buildProviderControlSummariesAndGroups(p provider.Provider, result *control
 			Title:      e.DisplayName,
 			Compliance: entryCompliance,
 			Skipped:    skipped,
+			SkipReason: e.SkipReason,
 			Stats:      stats,
 			Findings:   items,
 		})

--- a/control/catalog.go
+++ b/control/catalog.go
@@ -24,6 +24,25 @@ type ControlEntry struct {
 	Compliance float64
 }
 
+// leakSecretsControlEntry builds the catalog entry for
+// pipelineMustNotLeakSecretsInConfig (ISSUE-301). gitleaks secret scanning
+// is currently disabled, so the control never runs: it is always rendered as
+// skipped rather than reported as compliant, which would be a misleading
+// green for a security control that did not execute. When the config enables
+// it, SkipReason explains that scanning is off; otherwise the default
+// "disabled in configuration" reason applies.
+func leakSecretsControlEntry(displayName string, cfg *configuration.SecretDetectionControlConfig) ControlEntry {
+	e := ControlEntry{
+		DisplayName: displayName,
+		ControlName: "pipelineMustNotLeakSecretsInConfig",
+		Skipped:     true,
+	}
+	if cfg != nil && cfg.IsEnabled() {
+		e.SkipReason = "gitleaks secret scanning is temporarily disabled"
+	}
+	return e
+}
+
 func GitLabControls(pc *configuration.PlumberConfig) []ControlEntry {
 	if pc == nil {
 		return nil
@@ -102,11 +121,10 @@ func GitLabControls(pc *configuration.PlumberConfig) []ControlEntry {
 		ControlName: "pipelineMustNotExecuteUnverifiedScripts",
 		Skipped:     c.PipelineMustNotExecuteUnverifiedScripts == nil || !c.PipelineMustNotExecuteUnverifiedScripts.IsEnabled(),
 	})
-	entries = append(entries, ControlEntry{
-		DisplayName: "Pipeline must not leak secrets in configuration",
-		ControlName: "pipelineMustNotLeakSecretsInConfig",
-		Skipped:     c.PipelineMustNotLeakSecretsInConfig == nil || !c.PipelineMustNotLeakSecretsInConfig.IsEnabled(),
-	})
+	entries = append(entries, leakSecretsControlEntry(
+		"Pipeline must not leak secrets in configuration",
+		c.PipelineMustNotLeakSecretsInConfig,
+	))
 	entries = append(entries, ControlEntry{
 		DisplayName: "Pipeline must not override job variables",
 		ControlName: "pipelineMustNotOverrideJobVariables",
@@ -174,11 +192,10 @@ func GitHubControls(pc *configuration.PlumberConfig) []ControlEntry {
 		ControlName: "pipelineMustNotExecuteUnverifiedScripts",
 		Skipped:     c.PipelineMustNotExecuteUnverifiedScripts == nil || !c.PipelineMustNotExecuteUnverifiedScripts.IsEnabled(),
 	})
-	entries = append(entries, ControlEntry{
-		DisplayName: "Workflow must not leak secrets in configuration",
-		ControlName: "pipelineMustNotLeakSecretsInConfig",
-		Skipped:     c.PipelineMustNotLeakSecretsInConfig == nil || !c.PipelineMustNotLeakSecretsInConfig.IsEnabled(),
-	})
+	entries = append(entries, leakSecretsControlEntry(
+		"Workflow must not leak secrets in configuration",
+		c.PipelineMustNotLeakSecretsInConfig,
+	))
 	entries = append(entries, ControlEntry{
 		DisplayName: "Reusable workflows must not inherit secrets",
 		ControlName: "reusableWorkflowsMustNotInheritSecrets",

--- a/gitlab/gitleaks_scan.go
+++ b/gitlab/gitleaks_scan.go
@@ -36,10 +36,6 @@ import (
 // mistake) rather than as part of normal flow.
 const gitleaksTimeout = 30 * time.Second
 
-// defaultGitleaksBinary is the name plumber looks up on $PATH when
-// the user has not set gitleaksPath explicitly.
-const defaultGitleaksBinary = "gitleaks"
-
 // gitleaksReportEntry mirrors the JSON shape from
 // `gitleaks detect --report-format=json --report-path=-`. Only fields
 // plumber actually surfaces are decoded; gitleaks's Author / Commit /
@@ -226,30 +222,13 @@ func execGitleaks(binary string, cfg *configuration.SecretDetectionControlConfig
 	return parseGitleaksReport(report)
 }
 
-// resolveGitleaksBinary returns the path plumber should exec.
-//
-//   - cfg.GitleaksPath set → that path is the override. Resolvable →
-//     use it; unresolvable → error. We never fall back to $PATH when
-//     the user explicitly named a binary — that would silently mask a
-//     misconfigured sealed-CI deploy and run a different gitleaks than
-//     the operator asked for.
-//   - cfg.GitleaksPath unset → look up `gitleaks` on $PATH.
-//
-// Returns an error when the chosen path doesn't resolve; the caller
-// logs and abstains rather than failing the whole run.
-func resolveGitleaksBinary(cfg *configuration.SecretDetectionControlConfig) (string, error) {
-	if cfg != nil && cfg.GitleaksPath != "" {
-		path, err := exec.LookPath(cfg.GitleaksPath)
-		if err != nil {
-			return "", fmt.Errorf("gitleaks not found at configured gitleaksPath %q: %w", cfg.GitleaksPath, err)
-		}
-		return path, nil
-	}
-	path, err := exec.LookPath(defaultGitleaksBinary)
-	if err != nil {
-		return "", fmt.Errorf("gitleaks not found on PATH: %w", err)
-	}
-	return path, nil
+// resolveGitleaksBinary is intentionally disabled: gitleaks secret
+// scanning is turned off for now, so plumber resolves and executes no
+// external binary. Callers receive an error and abstain (ISSUE-301 does
+// not fire), exactly as they do for any other gitleaks failure. Full
+// context will be disclosed soon.
+func resolveGitleaksBinary(_ *configuration.SecretDetectionControlConfig) (string, error) {
+	return "", errors.New("gitleaks secret scanning is disabled")
 }
 
 // parseGitleaksReport decodes gitleaks's JSON report. gitleaks writes

--- a/gitlab/gitleaks_scan_test.go
+++ b/gitlab/gitleaks_scan_test.go
@@ -3,6 +3,8 @@ package gitlab
 import (
 	"strings"
 	"testing"
+
+	"github.com/getplumber/plumber/configuration"
 )
 
 // TestRedactPreview is the load-bearing safety test for ISSUE-301:
@@ -73,4 +75,17 @@ func TestParseGitleaksReport(t *testing.T) {
 			t.Fatal("expected decode error, got nil")
 		}
 	})
+}
+
+// TestGitleaksScanningDisabled pins the current state: gitleaks binary
+// resolution is turned off, so no external binary is ever resolved or run,
+// regardless of what a scanned repository's .plumber.yaml requests.
+func TestGitleaksScanningDisabled(t *testing.T) {
+	if _, err := resolveGitleaksBinary(nil); err == nil {
+		t.Fatal("gitleaks resolution should be disabled, got nil error")
+	}
+	cfg := &configuration.SecretDetectionControlConfig{GitleaksPath: "/bin/sh"}
+	if _, err := resolveGitleaksBinary(cfg); err == nil {
+		t.Fatal("gitleaks resolution should be disabled even with a configured path, got nil error")
+	}
 }


### PR DESCRIPTION
Temporarily disables gitleaks secret scanning: no external binary is resolved or executed, and the control abstains. Further details will be disclosed soon.