### PR TITLE
ci(grype): install pinned grype by checksum, drop scan-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,13 +120,28 @@ jobs:
       - name: Build Docker image
         run: docker build -t plumber:ci .
 
+      # Grype is installed directly from a pinned release and verified
+      # against a checksum committed to this repo, NOT via
+      # anchore/scan-action. The action, though pinnable by SHA, fetches
+      # and executes install.sh from anchore/grype@main at runtime — a
+      # moving ref that voids the immutability the SHA pin implies. The
+      # hash below is the only trust anchor; bump both together.
+      - name: Install grype (pinned + checksum-verified)
+        env:
+          GRYPE_VERSION: "0.114.0"
+          GRYPE_SHA256: "edda0968d8827daab01d32b3cd7de192ae0915005e7bbfcfef9e68e79bc43343"
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          curl -sSfL -o "$tmp/grype.tar.gz" \
+            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz"
+          echo "${GRYPE_SHA256}  $tmp/grype.tar.gz" | sha256sum -c -
+          tar -xzf "$tmp/grype.tar.gz" -C "$tmp" grype
+          sudo install "$tmp/grype" /usr/local/bin/grype
+          grype version
+
       - name: Grype image scan
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
-        with:
-          image: plumber:ci
-          fail-build: true
-          severity-cutoff: high
-          only-fixed: true
+        run: grype "plumber:ci" --fail-on high --only-fixed
 
   # trivy:
   #   name: Container Scan (Trivy)


### PR DESCRIPTION
## Problem

The `grype` container-scan job pins `anchore/scan-action` by commit SHA, which
*looks* immutable. It is not. At runtime the action fetches and executes an
install script from a **moving ref**:

```js
// anchore/scan-action — action.js
const installScriptUrl = `https://raw.githubusercontent.com/anchore/grype/main/install.sh`;
const installScriptPath = await tools.downloadTool(installScriptUrl);
// ...then executed
```

`anchore/grype@main` can change with no change to anything committed here, so the
SHA pin gives a false sense of immutability: the code actually executed in CI is
not pinned. This is the supply-chain gap that pin-by-SHA does **not** close when an
action pulls remote code.

## Fix

Install the pinned grype release directly and verify it against a SHA-256 that
lives in this workflow — the only trust anchor, immutable unless this file
changes — then run grype with the same gate:

```yaml
env:
  GRYPE_VERSION: "0.114.0"
  GRYPE_SHA256: "edda0968d8827daab01d32b3cd7de192ae0915005e7bbfcfef9e68e79bc43343"
run: |
  set -euo pipefail
  tmp="$(mktemp -d)"
  curl -sSfL -o "$tmp/grype.tar.gz" \
    "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz"
  echo "${GRYPE_SHA256}  $tmp/grype.tar.gz" | sha256sum -c -
  tar -xzf "$tmp/grype.tar.gz" -C "$tmp" grype
  sudo install "$tmp/grype" /usr/local/bin/grype
# scan
run: grype "plumber:ci" --fail-on high --only-fixed
```

To bump grype, update both `GRYPE_VERSION` and `GRYPE_SHA256` together (the hash
is published in the release's `checksums.txt`).

## Verification

Locally, against grype 0.114.0: download + `sha256sum -c` + extract + `grype
version` + `--fail-on high --only-fixed` all succeed. Same severity gate as
before (fail on fixable high+).

## Note

The general case — a pinned third-party action that fetches/executes mutable
remote code — is not something Plumber detects today (pin-by-SHA passes it).
That detection is worth a dedicated control and will be tracked separately.