### PR TITLE
ci(release): stop persisting credentials in the pin-refs checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -461,12 +461,17 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
-          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
+      # The app token is supplied at push time through a credential helper
+      # that reads it from the step env (same pattern as the homebrew job):
+      # .git/config only ever stores the literal helper script, never the
+      # token, so no credential outlives this step.
       - name: Pin README SHA and template image digest
         env:
           VERSION: ${{ needs.release.outputs.new_release_version }}
           DIGEST: ${{ needs.docker.outputs.digest }}
+          RELEASE_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           # The release tag points at the chore(release) commit; pin to it so
@@ -479,6 +484,7 @@ jobs:
           fi
           git config user.name "plumber-release-bot[bot]"
           git config user.email "plumber-release-bot[bot]@users.noreply.github.com"
+          git config credential.helper '!f() { echo "username=x-access-token"; echo "password=${RELEASE_APP_TOKEN}"; }; f'
           git add README.md templates/plumber.yml
           git commit -m "ci(release): pin v${VERSION} refs [skip ci]"
           git push origin HEAD:main


### PR DESCRIPTION
## Why

The self-scan on #293 fails (94.7% < 100% threshold): the new `checkoutMustNotPersistCredentials` control (ISSUE-307) flags the `pin-refs` job in `release.yml` — the only checkout in the repo without `persist-credentials: false`. The GitHub App token was persisted into `.git/config` and survived for the rest of the job.

## What

- Add `persist-credentials: false` to the `pin-refs` checkout (and drop the now-unneeded `token:` input — the repo is public, fetch needs no auth).
- Supply the app token at push time through an env-based credential helper, the same pattern the `homebrew` job already uses: `.git/config` only ever stores the literal helper script, never the token, so no credential outlives the step.

## Verification

Built Plumber from #293's head and ran the self-scan against this branch with the control enabled:

```
│ Checkout must not persist credentials │ 100.0% │ 🟢 │
Status: PASSED ✓  (threshold 100, --fail-warnings)
```

Merging this first unblocks #293's Plumber gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)