### PR TITLE
ci: pin runtime tool installs to immutable versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go-version: ['stable', 'oldstable']
+        # Exact patch versions: floating specs (stable/oldstable) resolve
+        # to a different toolchain over time without any workflow change.
+        go-version: ['1.26.4', '1.25.11']
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -45,7 +47,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: stable
+          go-version: '1.26.4'
 
       - name: Prepare embedded config
         run: cp .plumber.yaml internal/defaultconfig/default.yaml
@@ -70,7 +72,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: stable
+          go-version: '1.26.4'
 
       - name: Prepare embedded config
         run: cp .plumber.yaml internal/defaultconfig/default.yaml
@@ -95,7 +97,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: stable
+          go-version: '1.26.4'
 
       - name: Prepare embedded config
         run: cp .plumber.yaml internal/defaultconfig/default.yaml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: stable
+          go-version: '1.26.4'
 
       - name: Prepare embedded config
         run: cp .plumber.yaml internal/defaultconfig/default.yaml
@@ -38,6 +38,11 @@ jobs:
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: go
+          # Without this, the CodeQL bundle version is resolved from
+          # GitHub's live feature flags at run time, so the action SHA
+          # alone does not pin the toolchain. "linked" forces the
+          # bundle version shipped with the pinned action release.
+          tools: linked
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/plumber-action.yml
+++ b/.github/workflows/plumber-action.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: stable
+          go-version: '1.26.4'
 
       - name: Build Plumber from source
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: '20.20.2'
 
       # Run semantic-release directly instead of the third-party
       # cycjimmy/semantic-release-action wrapper. Top-level packages are
@@ -114,7 +114,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
 
       - name: Prepare embedded config
         run: cp .plumber.yaml internal/defaultconfig/default.yaml
@@ -211,9 +211,17 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        with:
+          # The action defaults to the mutable :latest tag for this
+          # privileged image; pin it by digest.
+          image: docker.io/tonistiigi/binfmt:qemu-v10.2.3@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          # The docker-container driver otherwise boots the mutable
+          # moby/buildkit:buildx-stable-1 tag; pin it by digest.
+          driver-opts: image=docker.io/moby/buildkit:v0.30.0@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
 
       - name: Login to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,6 +23,15 @@ jobs:
         with:
           persist-credentials: false
 
+      # KNOWN MUTABILITY GAP: this SHA pin does not pin the code that
+      # actually runs. The action's own action.yaml is a Docker action
+      # referencing ghcr.io/ossf/scorecard-action:v2.4.3 by mutable tag
+      # (no digest), so a re-pushed tag changes what executes here with
+      # no change to this file. We keep the official action anyway
+      # because publish_results (the OpenSSF badge in the README) only
+      # accepts results produced by it — scorecard.dev validates the
+      # workflow and OIDC claims. A solution is still to be found
+      # (upstream digest pin, or dropping the badge for a pinned CLI).
       - name: Run Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:


### PR DESCRIPTION
## Context

Our workflows already pin every action to a commit SHA, but an audit of each action's source (at the exact pinned SHAs) showed that several of them still **install software resolved at run time**, so the SHA pin alone does not pin what actually executes.

## What this changes

- **`codeql-action/init`: add `tools: linked`** — the biggest gap. Without it, the CodeQL bundle version is chosen by GitHub's live feature-flag API at run time (`src/feature-flags.ts`), and the version in the action's `defaults.json` is only a fallback. `linked` forces the bundle shipped with the pinned action release (2.25.6) — verified in source: `getCodeQLSource` reads `defaults.json` directly and never consults the feature-flag result (`src/setup-codeql.ts:514-521`). It auto-follows when the action SHA is bumped.
- **`setup-go`: exact patch versions** — `stable`, `oldstable`, and `'1.25'` all resolve to "latest matching" at run time. Now: `1.26.4` (stable today), matrix `['1.26.4', '1.25.11']`, release build `1.25.11` (same minor as before; `go.mod` requires 1.25.0).
- **`setup-node`: `20` → `20.20.2`** — same floating-resolution issue.
- **`setup-qemu-action`: pin `tonistiigi/binfmt` by digest** — the action defaults to the mutable `:latest` tag for an image it runs `--privileged`. Pinned to `qemu-v10.2.3@sha256:400a4873…`, which is exactly what `:latest` resolves to today.
- **`setup-buildx-action`: pin BuildKit by digest via `driver-opts`** — the default `docker-container` builder otherwise boots the mutable `moby/buildkit:buildx-stable-1` tag. Pinned to `v0.30.0@sha256:0168606b…`, exactly what that tag resolves to today.

Both digests match the current tag targets, so **behavior is unchanged** — only future drift is eliminated.

## Known residual gaps (not fixable via action inputs)

- `setup-go` / `setup-node` / `codeql-action` perform no checksum/signature verification of their downloads at these versions — the pins above make the *version* deterministic; content integrity rests on TLS + the publisher.
- `ossf/scorecard-action` runs `ghcr.io/ossf/scorecard-action:v2.4.3` by mutable tag inside its own `action.yaml`.
- `anchore/scan-action` fetches grype's `install.sh` from the `main` branch (Grype binary itself is pinned to v0.110.0 and sha256-verified) and downloads a fresh vulnerability DB per run (inherent to a scanner).
- `setup-buildx`'s `version:` input is deliberately left unset: on hosted runners the default uses the runner-preinstalled buildx, whereas pinning a version would force an unverified download from GitHub releases.

## Note for maintainers

Exact Go/Node patch pins mean security updates no longer arrive automatically — make sure Renovate/Dependabot is configured to bump these version strings (it likely only watches `uses:` SHAs today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)