### PR TITLE
ci(grype): install pinned grype by checksum, drop scan-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,13 +122,30 @@ jobs:
       - name: Build Docker image
         run: docker build -t plumber:ci .
 
+      # Grype is installed directly from a pinned release and verified
+      # against a checksum committed to this repo, NOT via
+      # anchore/scan-action. The action, though pinnable by SHA, fetches
+      # and executes install.sh from anchore/grype@main at runtime — a
+      # moving ref that voids the immutability the SHA pin implies. The
+      # hash below is the only trust anchor; bump both together.
+      - name: Install grype (pinned + checksum-verified)
+        env:
+          GRYPE_VERSION: "0.114.0"
+          GRYPE_SHA256: "edda0968d8827daab01d32b3cd7de192ae0915005e7bbfcfef9e68e79bc43343"
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          curl -sSfL -o "$tmp/grype.tar.gz" \
+            "https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz"
+          echo "${GRYPE_SHA256}  $tmp/grype.tar.gz" | sha256sum -c -
+          tar -xzf "$tmp/grype.tar.gz" -C "$tmp" grype
+          sudo install "$tmp/grype" /usr/local/bin/grype
+          grype version
+
       - name: Grype image scan
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
-        with:
-          image: plumber:ci
-          fail-build: true
-          severity-cutoff: high
-          only-fixed: true
+        env:
+          GRYPE_CHECK_FOR_APP_UPDATE: "false"
+        run: grype "plumber:ci" --fail-on high --only-fixed
 
   # trivy:
   #   name: Container Scan (Trivy)


### PR DESCRIPTION
Supersedes #294 by @stephrobert, recreated because the original fork branch has "Allow edits by maintainers" disabled and the author is currently unreachable, so the pending review suggestion could not be applied there. His change is included verbatim (credited as co-author on the commit) plus the one addition from the review.

## Problem

`anchore/scan-action`, though pinned by SHA, downloads and executes `install.sh` from `anchore/grype@main` at every run. That moving ref is not covered by the pin, so the code actually executed in CI could change with no change to this repo.

## Fix (from #294)

Install the pinned grype release directly and verify it against a sha256 committed in this workflow, then run the scan with the same severity gate as before (`--fail-on high --only-fixed`, matching the action's `fail-build: true` + `severity-cutoff: high` + `only-fixed: true`).

To bump grype: update `GRYPE_VERSION` and `GRYPE_SHA256` together (the hash is published in the release's `checksums.txt`; verifying that file with `cosign verify-blob` at bump time is a good habit).

## Added on top of #294

`GRYPE_CHECK_FOR_APP_UPDATE: "false"` on the scan step. The removed action set this; without it grype makes a phone-home update check on every scan.

## Verification

The pinned sha256 was verified independently: a fresh download of the official `grype_0.114.0_linux_amd64.tar.gz` release asset hashes to the committed value, matching the release's `checksums.txt`. The full chain (checksum OK, `grype version`, scan completing with the gate applied) already ran green on #294's CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)