### PR TITLE
feat(controls): actionsMustNotExecuteMutableRemoteCode (ISSUE-714/715)

### DIFF
--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -999,6 +999,21 @@ github:
       enabled: true
 
     # ===========================================
+    # Actions must not execute mutable remote code
+    # ===========================================
+    # Flags a third-party action that, even pinned by commit SHA, fetches
+    # and executes a script from a MOVING ref (main/master/HEAD) of
+    # another repository at runtime. Pinning the action's own ref does
+    # not make its execution immutable: the fetched code can change with
+    # nothing committed where the pin can see it. The canonical case is
+    # anchore/scan-action, which runs `raw.githubusercontent.com/anchore/
+    # grype/main/install.sh`. Driven by the collector's per-action source
+    # analysis (needs API metadata enrichment). Config-free; toggle via
+    # `enabled`.
+    actionsMustNotExecuteMutableRemoteCode:
+      enabled: true
+
+    # ===========================================
     # Release workflows must not restore an untrusted cache
     # ===========================================
     # Flags a release/publish job that restores a build cache whose key

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -57,6 +57,7 @@ const (
 	compArchivedActions    = "Flag third-party actions from archived repositories"
 	compKnownCVEs          = "Flag third-party actions with known CVEs (GitHub Advisory DB)"
 	compImpostorCommit     = "Flag third-party actions pinned to a commit SHA absent upstream (impostor commit)"
+	compMutableRemoteExec  = "Flag actions that fetch+execute mutable remote code (SHA pin bypassed)"
 	compCachePoisoning     = "Flag release/publish jobs restoring an unscoped build cache"
 	compDebugTraceGitHub   = "Flag Actions debug logging (ACTIONS_STEP_DEBUG / ACTIONS_RUNNER_DEBUG)"
 )
@@ -716,6 +717,7 @@ func compositionOptionsForProviders(providers []string) []string {
 			compArchivedActions,
 			compKnownCVEs,
 			compImpostorCommit,
+			compMutableRemoteExec,
 			compCachePoisoning,
 			compDebugTraceGitHub,
 		)
@@ -1289,6 +1291,9 @@ func (st *initWizardState) toPlumberConfig() *configuration.PlumberConfig {
 			if compSelected(st, compImpostorCommit) {
 				gh.Controls.ActionRefsMustExistUpstream = &configuration.EnabledOnlyControlConfig{Enabled: boolPtrInit(true)}
 			}
+			if compSelected(st, compMutableRemoteExec) {
+				gh.Controls.ActionsMustNotExecuteMutableRemoteCode = &configuration.EnabledOnlyControlConfig{Enabled: boolPtrInit(true)}
+			}
 			if compSelected(st, compCachePoisoning) {
 				gh.Controls.ReleaseWorkflowsMustNotRestoreUntrustedCache = &configuration.CachePoisoningControlConfig{
 					Enabled:                      boolPtrInit(true),
@@ -1346,7 +1351,7 @@ func starterPlumberConfig() *configuration.PlumberConfig {
 		CompositionChoices: []string{
 			compHardcoded, compUpToDate, compForbidden, compRefCollision, compSecurity, compScripts, compJobVars, compDinD,
 			compActionPin, compAuthorizedActions, compDangerousTriggers, compPRTargetHead, compDeclarePermissions, compReusableSecrets, compOverprovSecrets, compTemplateInjection,
-			compEnvInjection, compWriteAllPerms, compRefConfusion, compArchivedActions, compKnownCVEs, compImpostorCommit, compCachePoisoning, compDebugTraceGitHub,
+			compEnvInjection, compWriteAllPerms, compRefConfusion, compArchivedActions, compKnownCVEs, compImpostorCommit, compMutableRemoteExec, compCachePoisoning, compDebugTraceGitHub,
 		},
 		ActionPinTrustedOwnersMultiline:        strings.Join(defaultGitHubTrustedActionOwners(), "\n"),
 		SecurityJobPatternsGitHubMultiline:     strings.Join(defaultGitHubSecurityJobPatterns(), "\n"),

--- a/cmd/legacy_json_github.go
+++ b/cmd/legacy_json_github.go
@@ -63,6 +63,8 @@ func buildLegacyResultGitHub(e control.ControlEntry, result *control.AnalysisRes
 		return "impostorCommitResult", buildImpostorCommitBlock(common, result, findings)
 	case "actionsMustNotCarryKnownCVEs":
 		return "knownVulnerableActionsResult", buildKnownVulnerableActionsBlock(common, result, findings)
+	case "actionsMustNotExecuteMutableRemoteCode":
+		return "mutableRemoteExecResult", buildMutableRemoteExecBlock(common, result, findings)
 	case "releaseWorkflowsMustNotRestoreUntrustedCache":
 		return "cachePoisoningResult", buildCachePoisoningBlock(common, result, findings)
 	case "pipelineMustNotEnableDebugTrace":
@@ -629,6 +631,28 @@ func buildArchivedActionsBlock(c legacyCommon, result *control.AnalysisResult, f
 		"metrics": map[string]any{
 			"actionRefsTotal":    s.ActionRefsTotal,
 			"actionRefsArchived": len(findings),
+		},
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
+	}
+}
+
+// buildMutableRemoteExecBlock — ISSUE-714/715/716. Surfaces each action
+// whose own source fetches and runs mutable remote code (plus the
+// producer-side self-action signal) with its code/job/uses/url, so the
+// JSON export carries the finding and its location rather than only a
+// plumberScore.codeLosses line. Denominator is the action-ref count
+// scanned; numerator is the finding count across all three tiers
+// (obfuscated / exec / unverified).
+func buildMutableRemoteExecBlock(c legacyCommon, result *control.AnalysisResult, findings []opaengine.Finding) map[string]any {
+	s := statsOf(result)
+	return map[string]any{
+		"issues": projectFindings(_sortedFindings(findings), "job"),
+		"metrics": map[string]any{
+			"actionRefsTotal":              s.ActionRefsTotal,
+			"actionsWithMutableRemoteExec": len(findings),
 		},
 		"version":   "0.1.0",
 		"ciValid":   c.CiValid,

--- a/cmd/legacy_json_github_test.go
+++ b/cmd/legacy_json_github_test.go
@@ -207,3 +207,77 @@ func TestImpostorCommitJSONBlock(t *testing.T) {
 		t.Errorf("clean block must not carry compliance (#320), got %v", cm["compliance"])
 	}
 }
+
+// TestMutableRemoteExecJSONBlock locks the ISSUE-714/715/716 JSON export
+// for actionsMustNotExecuteMutableRemoteCode: the dispatch must return a
+// mutableRemoteExecResult block whose issues[] carry each finding's
+// code/job/uses/url, not just a plumberScore.codeLosses line. This is the
+// same dropped-findings regression the sibling blocks guard against — the
+// PR shipped the control's rego + collector but no JSON wiring, so every
+// mutable-exec finding was silently absent from --output.
+func TestMutableRemoteExecJSONBlock(t *testing.T) {
+	entry := control.ControlEntry{
+		DisplayName: "Actions must not execute mutable remote code",
+		ControlName: "actionsMustNotExecuteMutableRemoteCode",
+	}
+	findings := []opaengine.Finding{{
+		Code: "ISSUE-714",
+		Job:  "ci/scan",
+		File: ".github/workflows/ci.yml",
+		Line: 9,
+		URL:  ".github/workflows/ci.yml:9",
+		Data: map[string]any{"uses": "anchore/scan-action@229edc86a0f0a8c34ea883607b5fa8310b1c35d8"},
+	}}
+	result := &control.AnalysisResult{
+		CiValid:     true,
+		GitHubStats: &control.GitHubAnalysisStats{ActionRefsTotal: 5},
+	}
+
+	name, block := buildLegacyResultGitHub(entry, result, nil, findings)
+	if name != "mutableRemoteExecResult" {
+		t.Fatalf("block name = %q, want mutableRemoteExecResult", name)
+	}
+	m, ok := block.(map[string]any)
+	if !ok {
+		t.Fatalf("block is %T, want map[string]any", block)
+	}
+	issues, ok := m["issues"].([]map[string]any)
+	if !ok || len(issues) != 1 {
+		t.Fatalf("issues = %v, want exactly 1 entry", m["issues"])
+	}
+	if issues[0]["code"] != "ISSUE-714" {
+		t.Errorf("issue code = %v, want ISSUE-714", issues[0]["code"])
+	}
+	if issues[0]["job"] != "ci/scan" {
+		t.Errorf("issue job = %v, want ci/scan", issues[0]["job"])
+	}
+	if issues[0]["uses"] != "anchore/scan-action@229edc86a0f0a8c34ea883607b5fa8310b1c35d8" {
+		t.Errorf("issue must carry the offending uses, got %v", issues[0]["uses"])
+	}
+	if issues[0]["url"] == nil {
+		t.Errorf("issue must carry a url (file:line link), got %v", issues[0])
+	}
+	metrics := m["metrics"].(map[string]any)
+	if metrics["actionsWithMutableRemoteExec"] != 1 {
+		t.Errorf("actionsWithMutableRemoteExec = %v, want 1", metrics["actionsWithMutableRemoteExec"])
+	}
+	if metrics["actionRefsTotal"] != 5 {
+		t.Errorf("actionRefsTotal = %v, want 5", metrics["actionRefsTotal"])
+	}
+	if _, present := m["compliance"]; present {
+		t.Errorf("per-control compliance was removed (#320); block still carries %v", m["compliance"])
+	}
+
+	// Clean run: no findings → empty issues, zero numerator.
+	cleanName, cleanBlock := buildLegacyResultGitHub(entry, result, nil, nil)
+	if cleanName != "mutableRemoteExecResult" {
+		t.Fatalf("clean block name = %q", cleanName)
+	}
+	cm := cleanBlock.(map[string]any)
+	if ci, _ := cm["issues"].([]map[string]any); len(ci) != 0 {
+		t.Errorf("clean issues = %v, want empty", cm["issues"])
+	}
+	if cmm := cm["metrics"].(map[string]any); cmm["actionsWithMutableRemoteExec"] != 0 {
+		t.Errorf("clean actionsWithMutableRemoteExec = %v, want 0", cmm["actionsWithMutableRemoteExec"])
+	}
+}

--- a/cmd/render_details.go
+++ b/cmd/render_details.go
@@ -427,6 +427,11 @@ func buildGitHubControlStats(controlName string, stats *control.GitHubAnalysisSt
 			{Label: statActionRefsChecked, Value: fmt.Sprintf("%d", stats.ActionRefsTotal+stats.ActionRefsExempt)},
 			{Label: "Refs With Advisories", Value: fmt.Sprintf("%d", stats.ActionRefsVulnerable)},
 		}
+	case "actionsMustNotExecuteMutableRemoteCode":
+		return []statLine{
+			{Label: statActionRefsChecked, Value: fmt.Sprintf("%d", stats.ActionRefsTotal)},
+			{Label: "Mutable Remote Exec Found", Value: fmt.Sprintf("%d", len(findings))},
+		}
 	case "releaseWorkflowsMustNotRestoreUntrustedCache":
 		return []statLine{
 			{Label: "Workflows Scanned", Value: fmt.Sprintf("%d", stats.WorkflowsTotal)},
@@ -697,6 +702,15 @@ func buildGitLabControlStats(controlName string, result *control.AnalysisResult,
 		return []statLine{
 			{Label: statActionRefsChecked, Value: fmt.Sprintf("%d", actionRefs)},
 			{Label: "Refs With Advisories", Value: fmt.Sprintf("%d", findingsCount)},
+		}
+	case "actionsMustNotExecuteMutableRemoteCode":
+		actionRefs := 0
+		if result.GitHubStats != nil {
+			actionRefs = result.GitHubStats.ActionRefsTotal
+		}
+		return []statLine{
+			{Label: statActionRefsChecked, Value: fmt.Sprintf("%d", actionRefs)},
+			{Label: "Mutable Remote Exec Found", Value: fmt.Sprintf("%d", findingsCount)},
 		}
 	case "branchMustBeProtected":
 		total, toProtect, protected, unprotected := _branchProtectionCounts(result, pc)

--- a/configuration/plumberconfig.go
+++ b/configuration/plumberconfig.go
@@ -104,6 +104,9 @@ var validControlSchema = map[string][]string{
 	"actionsMustNotCarryKnownCVEs": {
 		"enabled",
 	},
+	"actionsMustNotExecuteMutableRemoteCode": {
+		"enabled",
+	},
 	"releaseWorkflowsMustNotRestoreUntrustedCache": {
 		"enabled", "publishActions", "cacheActions", "publishScriptPatterns", "publishScriptExcludePatterns", "allowedJobs",
 	},
@@ -354,6 +357,14 @@ type ControlsConfig struct {
 	// action API metadata enriched at collect time. Config-free; toggle
 	// via `enabled`.
 	ActionsMustNotCarryKnownCVEs *EnabledOnlyControlConfig `yaml:"actionsMustNotCarryKnownCVEs,omitempty"`
+
+	// ActionsMustNotExecuteMutableRemoteCode control configuration (GitHub
+	// Actions only). Flags a third-party action whose own source fetches
+	// and executes a script from a moving ref at runtime, so a SHA pin on
+	// the action does not make its execution immutable. Driven by the
+	// collector's per-action source analysis. Config-free; toggle via
+	// `enabled`.
+	ActionsMustNotExecuteMutableRemoteCode *EnabledOnlyControlConfig `yaml:"actionsMustNotExecuteMutableRemoteCode,omitempty"`
 
 	// ReleaseWorkflowsMustNotRestoreUntrustedCache control configuration (GitHub
 	// Actions only). Flags a release/publish job that restores a build cache

--- a/configuration/plumberconfig_test.go
+++ b/configuration/plumberconfig_test.go
@@ -337,6 +337,7 @@ func TestValidControlNames(t *testing.T) {
 		"actionsMustBePinnedByCommitSha",
 		"actionsMustNotBeArchived",
 		"actionsMustNotCarryKnownCVEs",
+		"actionsMustNotExecuteMutableRemoteCode",
 		"branchMustBeProtected",
 		"containerImageMustComeFromAuthorizedSources",
 		"containerImageMustNotUseForbiddenTags",

--- a/configuration/registry.go
+++ b/configuration/registry.go
@@ -54,6 +54,7 @@ var controlsMeta = map[string]ControlMeta{
 	"actionsMustNotBeArchived":                            {Providers: []string{ProviderGitHub}},
 	"actionsMustNotCarryKnownCVEs":                        {Providers: []string{ProviderGitHub}},
 	"actionsMustNotDuplicateRunnerBuiltins":               {Providers: []string{ProviderGitHub}},
+	"actionsMustNotExecuteMutableRemoteCode":              {Providers: []string{ProviderGitHub}},
 	"checkoutMustNotPersistCredentials":                   {Providers: []string{ProviderGitHub}},
 	"containerCredentialsMustComeFromSecrets":             {Providers: []string{ProviderGitHub}},
 	"dependabotEcosystemsMustHaveCooldown":                {Providers: []string{ProviderGitHub}},
@@ -211,6 +212,7 @@ var actionMetadataConsumers = []string{
 	"actionsMustNotBeArchived",
 	"actionsMustNotCarryKnownCVEs",
 	"actionsMustNotDuplicateRunnerBuiltins",
+	"actionsMustNotExecuteMutableRemoteCode",
 	"githubActionMustComeFromAuthorizedSources",
 }
 

--- a/control/catalog.go
+++ b/control/catalog.go
@@ -235,6 +235,11 @@ func GitHubControls(pc *configuration.PlumberConfig) []ControlEntry {
 		Skipped:     c.ActionsMustNotCarryKnownCVEs == nil || !c.ActionsMustNotCarryKnownCVEs.IsEnabled(),
 	})
 	entries = append(entries, ControlEntry{
+		DisplayName: "Actions must not execute mutable remote code",
+		ControlName: "actionsMustNotExecuteMutableRemoteCode",
+		Skipped:     c.ActionsMustNotExecuteMutableRemoteCode == nil || !c.ActionsMustNotExecuteMutableRemoteCode.IsEnabled(),
+	})
+	entries = append(entries, ControlEntry{
 		DisplayName: "Release workflows must not restore an untrusted cache",
 		ControlName: "releaseWorkflowsMustNotRestoreUntrustedCache",
 		Skipped:     c.ReleaseWorkflowsMustNotRestoreUntrustedCache == nil || !c.ReleaseWorkflowsMustNotRestoreUntrustedCache.IsEnabled(),
@@ -376,6 +381,9 @@ func DisabledControlNames(c *configuration.ControlsConfig) map[string]bool {
 	}
 	if cfg := c.ActionsMustNotCarryKnownCVEs; cfg == nil || !cfg.IsEnabled() {
 		out["actionsMustNotCarryKnownCVEs"] = true
+	}
+	if cfg := c.ActionsMustNotExecuteMutableRemoteCode; cfg == nil || !cfg.IsEnabled() {
+		out["actionsMustNotExecuteMutableRemoteCode"] = true
 	}
 	if cfg := c.ReleaseWorkflowsMustNotRestoreUntrustedCache; cfg == nil || !cfg.IsEnabled() {
 		out["releaseWorkflowsMustNotRestoreUntrustedCache"] = true

--- a/control/codes.go
+++ b/control/codes.go
@@ -49,6 +49,12 @@ const (
 	CodeReleaseWorkflowUnsigned ErrorCode = "ISSUE-712"
 	// ISSUE-713: Third-party GitHub Action comes from an unauthorized source
 	CodeActionUnauthorizedSource ErrorCode = "ISSUE-713"
+	// ISSUE-714: Action fetches and runs remote code from a mutable ref, in the open (no integrity check)
+	CodeActionMutableRemoteExec ErrorCode = "ISSUE-714"
+	// ISSUE-715: Action OBFUSCATES a remote code fetch/exec (decode-then-run)
+	CodeActionObfuscatedRemoteExec ErrorCode = "ISSUE-715"
+	// ISSUE-716: Action source could not be verified (fetch failed) — not a pass
+	CodeActionRemoteExecUnverified ErrorCode = "ISSUE-716"
 )
 
 // Issue codes for CI/CD variable controls (2xx)
@@ -293,6 +299,33 @@ var errorCodeRegistry = map[ErrorCode]ErrorCodeInfo{
 		Remediation: "Use an action from an authorized source. Configure the allowlist in .plumber.yaml under githubActionMustComeFromAuthorizedSources: keep trustGithubOfficialActions on for actions/* and github/*, add trusted owners or actions to trustedGithubActions (exact `owner/repo` or `owner/*`), and optionally set minimumStars to require a popularity threshold. Vendoring the action into a local `./.github/actions/…` directory removes the external dependency entirely.",
 		DocURL:      docsBaseURL + string(CodeActionUnauthorizedSource),
 		ControlName: "githubActionMustComeFromAuthorizedSources",
+	},
+	CodeActionMutableRemoteExec: {
+		Code:        CodeActionMutableRemoteExec,
+		Severity:    SeverityHigh,
+		Title:       "Action fetches and runs remote code from a mutable ref (in the open)",
+		Description: "A third-party action's own source fetches and executes a script from a MOVING ref (a branch such as main/master, not a tag or SHA) of another repository at runtime, and does not verify the download against a checksum. Pinning the action by commit SHA does not reach this: the fetched code can change with nothing committed where the pin can see it, so a compromise or retag of that upstream branch runs arbitrary code in the job with its token and secrets. The canonical example is anchore/scan-action, which fetches `raw.githubusercontent.com/anchore/grype/main/install.sh` and runs it. This is a static, text-level match on the action's source: it catches the in-the-open shape, not an author who deliberately hides the fetch (see ISSUE-715), so a clean result asserts 'no known pattern seen', not 'safe'.",
+		Remediation: "Prefer an action that pins its downloads to an immutable ref AND verifies a checksum. Otherwise install the tool yourself from a pinned release, verify it against a checksum committed to your repo, and run it directly; or vendor the action and pin its internal fetch. A fetch that already verifies a pinned checksum is content-pinned and is not flagged here.",
+		DocURL:      docsBaseURL + string(CodeActionMutableRemoteExec),
+		ControlName: "actionsMustNotExecuteMutableRemoteCode",
+	},
+	CodeActionObfuscatedRemoteExec: {
+		Code:        CodeActionObfuscatedRemoteExec,
+		Severity:    SeverityCritical,
+		Title:       "Action obfuscates a remote code fetch/exec",
+		Description: "The action's own source decodes and then executes code: `base64 -d | sh`, `eval \"$(… | base64 -d)\"`, `eval(atob(…))`, `new Function(atob(x))`, a hex/xxd decode piped to a shell, and similar. No legitimate action needs to hide what it runs at runtime, so obfuscation-then-execute is treated as the strongest signal regardless of the host, ref, or encoding used. This deliberately does NOT chase every possible encoding (an unbounded space); it flags the act of hiding itself, which is what makes a clean result meaningful here.",
+		Remediation: "Remove the obfuscation. If the action is a dependency, drop or vendor it and replace the hidden fetch with an explicit, pinned, checksum-verified install. An action that must decode data at runtime should not feed that decoded value into a shell or eval.",
+		DocURL:      docsBaseURL + string(CodeActionObfuscatedRemoteExec),
+		ControlName: "actionsMustNotExecuteMutableRemoteCode",
+	},
+	CodeActionRemoteExecUnverified: {
+		Code:        CodeActionRemoteExecUnverified,
+		Severity:    SeverityLow,
+		Title:       "Action source could not be verified",
+		Description: "Plumber could not fetch the action's own source (a network error, API rate limit, GitHub Enterprise Server host, private repo, or a Docker-image action) so it could not confirm whether the action fetches mutable remote code at runtime. This is surfaced as an explicit could-not-verify finding rather than a silent pass, because a silent pass would let the same repository score differently across CI environments and would over-claim safety on an unchecked dependency.",
+		Remediation: "Re-run where the action source is reachable (authenticated token, network access) to get a definitive result, or vendor the action so its source is local and auditable. This finding is informational: it flags an unchecked dependency, not a confirmed problem.",
+		DocURL:      docsBaseURL + string(CodeActionRemoteExecUnverified),
+		ControlName: "actionsMustNotExecuteMutableRemoteCode",
 	},
 	CodeImpostorCommit: {
 		Code:        CodeImpostorCommit,

--- a/control/task.go
+++ b/control/task.go
@@ -32,6 +32,29 @@ const opaEvaluateTimeout = 2 * time.Minute
 // Rego engine. Every other control is config-driven end-to-end through
 // the catalog in catalog.go.
 const controlBranchMustBeProtected = "branchMustBeProtected"
+const controlMutableRemoteExec = "actionsMustNotExecuteMutableRemoteCode"
+
+// shouldScanMutableExec reports whether the collector should fetch and
+// scan action source for actionsMustNotExecuteMutableRemoteCode
+// (ISSUE-714/715). The scan is expensive (up to ~7 sequential HTTP
+// requests per unique action), so it runs only when the control is
+// actually active: not benched in code, enabled in .plumber.yaml, and
+// not excluded by --controls / --skip-controls. When false the collector
+// skips the fetch entirely, so disabling the control removes its
+// scan-time and rate-limit cost — not just its findings.
+func shouldScanMutableExec(conf *configuration.Configuration) bool {
+	if conf == nil || conf.PlumberConfig == nil {
+		return false
+	}
+	if configuration.IsBenched("github", controlMutableRemoteExec) {
+		return false
+	}
+	cfg := conf.PlumberConfig.ControlsFor("github").ActionsMustNotExecuteMutableRemoteCode
+	if cfg == nil || !cfg.IsEnabled() {
+		return false
+	}
+	return shouldRunControl(controlMutableRemoteExec, conf)
+}
 
 // shouldRunControl applies --controls / --skip-controls filtering for a control.
 // If --controls is set, only listed controls are eligible.

--- a/control/task_github.go
+++ b/control/task_github.go
@@ -146,6 +146,7 @@ func RunGitHubAnalysis(conf *configuration.Configuration) (*AnalysisResult, erro
 		conf.GitRepoRoot,
 		conf.GithubAPIHost,
 		configuration.ProviderNeedsActionMetadata("github"),
+		shouldScanMutableExec(conf),
 		progressFn,
 	)
 	if err != nil {
@@ -250,6 +251,7 @@ func RunGitHubAnalysisRemote(conf *configuration.Configuration, owner, repo, ref
 		conf.GithubAPIHost,
 		owner, repo, ref,
 		configuration.ProviderNeedsActionMetadata("github"),
+		shouldScanMutableExec(conf),
 		progressFn,
 	)
 	if err != nil {

--- a/control/task_mutable_exec_gate_test.go
+++ b/control/task_mutable_exec_gate_test.go
@@ -1,0 +1,71 @@
+package control
+
+import (
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+)
+
+// The action-source scan behind actionsMustNotExecuteMutableRemoteCode
+// (ISSUE-714/715) is expensive — up to ~7 sequential HTTP requests per
+// unique action. shouldScanMutableExec must return true only when the
+// control is actually active, so disabling it removes the scan cost and
+// its environment-dependent rate-limit findings, not just the surfaced
+// output (#299 review, blocker 3).
+func TestShouldScanMutableExec(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	cfgWith := func(c *configuration.EnabledOnlyControlConfig) *configuration.Configuration {
+		pc := &configuration.PlumberConfig{
+			GitHub: &configuration.ProviderConfig{
+				Controls: configuration.ControlsConfig{
+					ActionsMustNotExecuteMutableRemoteCode: c,
+				},
+			},
+		}
+		return &configuration.Configuration{PlumberConfig: pc}
+	}
+
+	t.Run("enabled control scans", func(t *testing.T) {
+		if !shouldScanMutableExec(cfgWith(&configuration.EnabledOnlyControlConfig{Enabled: boolPtr(true)})) {
+			t.Fatal("expected scan when the control is enabled")
+		}
+	})
+
+	t.Run("disabled control does not scan", func(t *testing.T) {
+		if shouldScanMutableExec(cfgWith(&configuration.EnabledOnlyControlConfig{Enabled: boolPtr(false)})) {
+			t.Fatal("expected no scan when the control is disabled")
+		}
+	})
+
+	t.Run("absent control block does not scan", func(t *testing.T) {
+		if shouldScanMutableExec(cfgWith(nil)) {
+			t.Fatal("expected no scan when the control is absent from config")
+		}
+	})
+
+	t.Run("nil config does not scan", func(t *testing.T) {
+		if shouldScanMutableExec(nil) {
+			t.Fatal("expected no scan when conf is nil")
+		}
+		if shouldScanMutableExec(&configuration.Configuration{}) {
+			t.Fatal("expected no scan when PlumberConfig is nil")
+		}
+	})
+
+	t.Run("--skip-controls excludes the control", func(t *testing.T) {
+		conf := cfgWith(&configuration.EnabledOnlyControlConfig{Enabled: boolPtr(true)})
+		conf.SkipControlsFilter = []string{controlMutableRemoteExec}
+		if shouldScanMutableExec(conf) {
+			t.Fatal("expected no scan when the control is in --skip-controls")
+		}
+	})
+
+	t.Run("--controls without the control excludes it", func(t *testing.T) {
+		conf := cfgWith(&configuration.EnabledOnlyControlConfig{Enabled: boolPtr(true)})
+		conf.ControlsFilter = []string{"branchMustBeProtected"}
+		if shouldScanMutableExec(conf) {
+			t.Fatal("expected no scan when --controls omits the control")
+		}
+	})
+}

--- a/docs/RESEARCH_ACTIONS_DETECTION.md
+++ b/docs/RESEARCH_ACTIONS_DETECTION.md
@@ -1,0 +1,272 @@
+# Detecting malicious code & dubious practices in GitHub Actions
+
+Research reference for Plumber's GitHub Actions control catalog. It crosses a
+**threat taxonomy** (what to look for) with **detection methods** (how to find
+it), states **what static analysis can and cannot reach**, and maps the
+landscape of existing tools and their gaps.
+
+Grounded in real 2024–2026 incidents, CVEs, OWASP CICD-SEC and SLSA. Snapshot
+date: 2026-07-06. Rule counts and "who covers what" drift — treat them as
+approximate.
+
+---
+
+## 0. The core lesson
+
+The highest-impact 2025–2026 incidents all combined the same three ingredients:
+**mutable-ref re-pointing + fetch-and-execute of remote code + a
+privileged-trigger misconfiguration.** A static scanner is strong on the first
+and third and on injection sinks; it is structurally blind to the second at
+runtime. So the catalog must:
+
+1. **Never let a clean result assert "safe"** — only "no known pattern seen".
+2. **Treat obfuscation-then-exec as the strongest signal** (nothing legitimate
+   hides what it runs) rather than chasing every encoding.
+3. **Emit "could-not-verify"** (a distinct, non-passing state) when the pinned
+   action source cannot be resolved to immutable execution — never a silent
+   green that changes with the CI environment.
+4. Position itself as **one complementary layer**: a Jan-2026 study of nine
+   scanners found *no single tool covers all ten weakness categories*
+   (arXiv 2601.14455v2).
+
+---
+
+## 1. The ten-weakness backbone (arXiv 2601.14455v2)
+
+The academic taxonomy to map every control against:
+
+| # | Category | Static? |
+|---|----------|---------|
+| 1 | Unpinned Dependency | ✅ |
+| 2 | Excessive Permission | ✅ |
+| 3 | Injection (untrusted → sink) | ✅ (taint > pattern) |
+| 4 | Secrets Exposure | ⚠️ partial (runtime leaks invisible) |
+| 5 | Privileged Trigger | ✅ |
+| 6 | Artifact Integrity / Provenance | ✅ config, ❌ actual attestation |
+| 7 | Known Vulnerable Component | ✅ (advisory DB) |
+| 8 | Control Flow | ⚠️ |
+| 9 | Runner Compatibility / self-hosted | ✅ (explicit labels only) |
+| 10 | Hardening Gap | ✅ |
+
+---
+
+## 2. Threat / dubious-practice catalog
+
+### A. Supply chain of the actions themselves
+- **Unpinned action** (mutable tag/branch). *Static YAML.* The `tj-actions/
+  changed-files` compromise (**CVE-2025-30066**) retroactively re-pointed **all**
+  version tags to one malicious commit, so even tag-pinned users ran attacker
+  code that did `curl … memdump.py | sudo python3` and double-base64'd secrets
+  into world-readable logs. → **SHA pinning, not tag pinning, is the mitigation.**
+- **Action fetches + executes MUTABLE remote code at runtime.** *Static source
+  fetch + obfuscation detection.* A SHA-pinned action that pulls a script from a
+  moving ref (e.g. `anchore/scan-action` → `raw.githubusercontent.com/anchore/
+  grype/main/install.sh`). **Not covered well by any surveyed tool** — the
+  whitespace Plumber targets. Evasions: host swap (`github.com/<o>/<r>/raw/…`,
+  gist), download-then-run vs pipe-to-shell, base64/hex/concat + `eval`/`atob`,
+  non-standard branch names.
+- **Transitive / dependency-of-dependency compromise.** The tj-actions
+  compromise was *potentially enabled by* `reviewdog/action-setup@v1`
+  (**CVE-2025-30154**). Surveyed static tools examine only the **first level** of
+  action reuse — deeper reuse is an open gap.
+- **Impostor commit** — pinned SHA that does not belong to the named repo (GitHub
+  does not validate the SHA↔repo binding). *API ref resolution.*
+- **Typosquatting** of a known action name. *Edit distance + reputation.*
+- **Archived / abandoned action repo.** *API.*
+- **Action with a known CVE/advisory** (GitHub Advisory DB, `actions` ecosystem).
+  *API.*
+- **Ref confusion** — ref resolving to both a tag and a branch. *API.*
+- **Comment-vs-SHA mismatch** (`@<sha> # v4` where the SHA ≠ v4). *API.*
+- **Unauthorized source / low reputation** (random owner, few stars, young repo).
+  *API + allowlist.*
+- **Docker-image action** (`runs.using: docker`) on a mutable image, or a
+  `Dockerfile` with `RUN curl … | sh`. *Static source (blind spot today).*
+- **Living Off The Pipeline (LOTP)** — RCE-by-design dev tools (`npm ci` scripts,
+  `go generate`, `make`, `pre-commit`) invoked on untrusted code. *Taint.*
+- **Reusable-workflow call unpinned / `secrets: inherit`.** *Static YAML.*
+
+### B. Obfuscation & generic malware signals (in fetched action source)
+Treat these as **high/critical in their own right** — a legitimate action has no
+reason to hide:
+- `base64 -d | sh`, `openssl enc -d | sh`, `xxd -r`, `eval "$(… | base64 -d)"`.
+- `eval(atob(…))`, `new Function(atob(x))`, `exec(Buffer.from(x,'base64'))`.
+- Download-then-run (`curl -o /tmp/x; sh /tmp/x`), host swaps.
+- High-entropy / large encoded blobs; suspicious minification of a normally
+  readable action; `dist/` that does not match source (non-reproducible build).
+- Env/secret harvesting (`printenv | curl`, `.git/config` read), egress to
+  non-GitHub hosts, cryptominer signatures, anti-analysis / time-bombs.
+
+### C. Pipeline injection & Poisoned Pipeline Execution (OWASP CICD-SEC-4)
+- **Template/script injection** — `${{ github.event.* }}` (and other untrusted
+  contexts) interpolated into `run:` are substituted **as code before** the shell
+  runs. GitHub's own high-risk fields end in: `body`, `default_branch`, `email`,
+  `head_ref`, `label`, `message`, `name`, `page_name`, `ref`, `title`. Payloads
+  use quote-breakout (`a"; ls …`) or backticks in PR/issue titles. **The
+  highest-value static rule surface** — bind through `env:` then reference `$VAR`.
+- **Pwn requests** — `pull_request_target` / `workflow_run` run with a read/write
+  repo token *in memory, available to any running program even without
+  referencing secrets*; combined with a checkout of untrusted PR head → repo
+  compromise. Exploited March 2026 against `aquasecurity/trivy-action` to
+  backdoor **LiteLLM** on PyPI. *Static: trigger + checkout-ref pattern.*
+- **`$GITHUB_ENV` / `$GITHUB_PATH` injection** from untrusted content. *Taint.*
+- **`allow-unsafe-pr-checkout: true`** under a privileged trigger. *Static.*
+- **Insecure commands** (`ACTIONS_ALLOW_UNSECURE_COMMANDS`). *Static.*
+- **Unsafe context dump** (`toJSON(github)` into a log). *Static.*
+- **Spoofable actor / unsound conditions** (`github.actor`, bot checks,
+  unanchored `contains()`). *Static.*
+- **Unverified script execution** (`curl … | bash` in the user's own `run:`).
+  *Static.*
+
+### D. Secret / token exfiltration
+- **artipacked** — `actions/checkout` without `persist-credentials: false`
+  leaves the `GITHUB_TOKEN` in `.git/config`; exploitable when `.git` is uploaded
+  as an artifact or a later untrusted step runs.
+- Secrets hard-coded in YAML; secrets `echo`'d into logs; **debug-trace** dumps
+  (`ACTIONS_STEP_DEBUG`); secrets baked into public artifacts.
+- **Over-broad / undeclared `GITHUB_TOKEN` permissions**, `write-all`.
+- **`secrets: inherit`** to reusable workflows; `toJSON(secrets)` export;
+  dynamic secret indexing `secrets[expr]`.
+- Long-lived PAT / cloud creds reachable by a low-privilege (fork) actor.
+- **Missing OIDC trusted publishing** (a PAT where OIDC would do).
+- App token not revoked at job end.
+
+### E. Runners & execution
+- **Self-hosted runner on a public repo** reachable by fork PRs → attacker code
+  on your infra. *Static (explicit labels).*
+- Docker-in-Docker / mounted Docker socket; deploy job with no `environment`
+  gate; weakened security jobs (`allow_failure`, `when: manual` on SAST).
+
+### F. Integrity & provenance
+- Unsigned/unattested published artifacts (Sigstore/cosign); **no SLSA
+  provenance**; install without checksum verification; Docker base image not
+  pinned by digest; container tag mutable (`latest`); **cache poisoning** (a
+  low-privilege job seeds a cache a privileged job restores).
+- Note: **artifact attestations prove build origin, not that the code is safe** —
+  provenance ≠ safety.
+
+### G. Repository posture
+- Missing/weak branch protection; no `SECURITY.md`; no SAST; no dependency
+  updates (Dependabot/Renovate); **no quarantine/cooldown** on dependency updates
+  (`minimumReleaseAge`); no `concurrency`.
+
+---
+
+## 3. Detection methods — strengths & limits
+
+| Method | Catches | Limit |
+|--------|---------|-------|
+| **Static YAML pattern** | triggers, permissions, `run:`, `uses:` shapes | textual evasion; a pass asserts little |
+| **Taint / dataflow** | injection (untrusted source → sink) | best-in-class for injection: the research ARGUS system (USENIX Security '23) found injections **>7×** more than pattern scanners; GitHub CodeQL taint for Actions GA Apr 2025. Pattern rules are a *floor* |
+| **Action-source fetch + scan** | mutable-remote-exec, obfuscation, in-action malware | blind spots: subpath/composite, Docker-image actions, GHES/private, API rate limits, **non-determinism across CI environments** |
+| **API / metadata enrichment** | impostor commit, archived repo, CVE, stars, ref confusion, comment↔SHA | rate limits, offline, GHES |
+| **Obfuscation / entropy** | hidden payloads | encoding space is unbounded → flag *the act of hiding*, don't decode everything |
+| **Provenance / integrity** (SHA pin, checksum, cosign, SLSA, Scorecard) | unpinned, unattested, unverified installs | **SHA pin ≠ immutable execution**; adoption partial |
+| **Runtime / behavioral** (egress + file + process baseline, eBPF, honeytokens) | what static cannot: runtime fetch-exec, execution-time secret leaks | needs infra; not shift-left; egress detection itself bypassable (e.g. `sendto`/`sendmsg`) |
+| **Reputation / diffing / anomaly** | dubious accounts, tampered `dist/` | noise |
+
+**Runtime is the counterpart to the static blind spots.** Behavioral agents that
+baseline per-job egress detected tj-actions (CVE-2025-30066), the axios npm RAT
+(2026), and the NX "s1ngularity" compromise (2025) *at runtime* — cases a static
+scanner cannot observe.
+
+---
+
+## 4. The fundamental limit of static detection (and what to do)
+
+`fetch-and-run mutable remote code` is an **unbounded** expression space: host
+swaps, download-then-run, arbitrary encodings, URLs assembled from env/secrets.
+No fixed allowlist of hosts/refs/extensions closes it. Two documented static
+blind spots (arXiv 2601.14455v2): (1) **no runtime observation** → execution-time
+leaks and runtime fetch-exec are invisible; (2) **first-level reuse only** →
+transitive risk missed.
+
+Design principles that follow:
+1. A **clean result = "no known in-the-open pattern seen"**, never "safe".
+2. **In-the-open fetch-exec = high** (a heads-up); **obfuscation-then-exec =
+   critical**. This tracks *intent to hide*, so it does not punish the honest
+   author who writes `curl … | sh` in plain sight while the obfuscator scores
+   well — the inverse of a naive severity model.
+3. A **checksum-verified** fetch of a mutable-ref script is materially safer than
+   an unverified one → use "mutable ref + no checksum" as the discriminating
+   signal to separate legitimate installers from noise.
+4. Emit **"could-not-verify"** (tri-state, never a pass) when the source cannot
+   be fetched (offline/GHES/private/rate-limited/subpath/Docker-image).
+5. **Complement, don't replace, runtime egress monitoring** for the residual.
+
+---
+
+## 5. Tooling landscape & gaps
+
+- **OPA/Rego static supply-chain scanner (BoostSecurity Poutine)** — closest
+  architectural analog to Plumber's engine. Rules for unpinnable actions,
+  injection / arbitrary code execution from untrusted changes, self-hosted
+  runner exposure on PRs, unverified-creator actions, untrusted-checkout-exec,
+  unverified-script-exec. **Lacks a mutable-remote-exec rule.**
+- **The reference open-source Actions auditor** — broadest static coverage of the
+  ten categories; strong on the `dangerous-triggers` and `template-injection`
+  classes. (Named check identifiers are usable; the tool name is intentionally
+  omitted here.)
+- **`octoscan`** (Synacktiv) — deep static, requires fetching action definitions
+  via the GitHub API.
+- **ARGUS / CodeQL** — taint/dataflow, the state of the art for injection.
+- **OpenSSF Scorecard** — repo-level signals (pinning, permissions, dangerous
+  workflow patterns).
+- **Harden-Runner (StepSecurity)** — the runtime counterpart (egress/file/process
+  baseline).
+- **`actionlint`, Semgrep, Snyk/Trivy, GitHub secret/dependency scanning** —
+  partial, complementary layers.
+
+**Gaps no tool covers well:** (a) an action that fetches **mutable remote code**
+at runtime; (b) **obfuscated** fetch-and-exec; (c) **transitive** (2nd-level+)
+action compromise. (a) and (b) are Plumber's differentiation.
+
+---
+
+## 6. Mapping to Plumber controls
+
+| Threat | Plumber | Status |
+|--------|---------|--------|
+| Unpinned action | `actionsMustBePinnedByCommitSha` (ISSUE-701) | shipped |
+| Mutable remote exec (in the open) | `actionsMustNotExecuteMutableRemoteCode` (ISSUE-714) | in PR |
+| Obfuscated remote exec | same control (ISSUE-715, critical) | in PR |
+| Could-not-verify | same control (info) | planned |
+| Impostor commit | ISSUE-707 | shipped |
+| Archived repo | ISSUE-702 | shipped |
+| Known CVE | ISSUE-703 | shipped |
+| Ref confusion | ISSUE-402 | shipped |
+| Unauthorized source | ISSUE-713 | shipped |
+| Template injection | ISSUE-207 (narrow, free-text fields) | shipped |
+| Injection via vars/inputs | ISSUE-215 (+ `github.event.inputs`) | shipped / extending |
+| Pwn request | ISSUE-802 / ISSUE-804 | shipped |
+| artipacked | ISSUE-307 | shipping |
+| Debug trace | ISSUE-203 | shipped |
+| Unverified script exec | ISSUE-411 | shipped |
+| Dependency-update cooldown | (issue) | proposed |
+| **Docker-image action fetch-exec** | — | gap |
+| **Transitive action compromise** | — | gap (needs graph + API) |
+| **Runtime exfil / egress** | — | out of scope (runtime tool territory) |
+
+---
+
+## Sources
+
+Primary incidents & advisories:
+- CISA — tj-actions/changed-files (CVE-2025-30066) & reviewdog (CVE-2025-30154):
+  https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066-and-reviewdogaction
+- GitHub Advisory GHSA-mrrh-fwg8-r2c3: https://github.com/advisories/ghsa-mrrh-fwg8-r2c3
+
+Concepts & mechanisms:
+- GitHub Security Lab — Preventing pwn requests: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+- GitHub docs — Script injections: https://docs.github.com/en/actions/concepts/security/script-injections
+- GitHub Security blog — Catching workflow injections: https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/
+- SHA-pinning is not immutable execution: https://www.vaines.org/posts/2026-03-24-the-comforting-lie-of-sha-pinning/
+- GitHub Actions SHA-pinning policy: https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/
+
+Detection methods & tooling:
+- Nine-scanner systematic study (arXiv 2601.14455v2): https://arxiv.org/html/2601.14455v2
+- ARGUS — staged static taint analysis (USENIX Security '23): https://par.nsf.gov/biblio/10516034-argus-framework-staged-static-taint-analysis-github-workflows-actions
+- Harden-Runner: https://github.com/step-security/harden-runner
+- Poutine: https://github.com/boostsecurityio/poutine
+- octoscan: https://github.com/synacktiv/octoscan
+- Action-scanner comparison & API-fetch constraint: https://datosh.github.io/post/github_action_scanner/
+- Artifact attestations / SLSA scope: https://tenki.cloud/blog/github-actions-artifact-attestations-slsa

--- a/github/action_source.go
+++ b/github/action_source.go
@@ -80,6 +80,11 @@ var (
 	reRef = regexp.MustCompile(ghContent + `/(` + movingRefAlt + `)/`)
 	// reMain extracts the node entrypoint from an action.yml `main:`.
 	reMain = regexp.MustCompile(`(?m)^\s*main:\s*['"]?([^\s'"]+)`)
+	// reUsing / reImage read the action.yml `runs:` block. A docker action
+	// (`using: docker`) executes a container, so its code lives in a
+	// Dockerfile or a docker:// image rather than a JS entrypoint.
+	reUsing = regexp.MustCompile(`(?m)^\s*using:\s*['"]?([A-Za-z0-9]+)`)
+	reImage = regexp.MustCompile(`(?m)^\s*image:\s*['"]?([^\s'"]+)`)
 )
 
 // entrypointCandidates are the usual hand-written and bundled source
@@ -199,6 +204,83 @@ func contains(s []string, v string) bool {
 	return false
 }
 
+// scanActionDefinition scans an action given its action.yml text and a
+// function that fetches a sibling file (path relative to the action's
+// directory). It handles all three action flavors:
+//
+//   - JS / composite: the declared entrypoint plus the `run:` steps in
+//     action.yml.
+//   - docker with `image: docker://<ref>`: a pre-built image. A tag not
+//     pinned by digest is mutable code (the SHA pin on the action does
+//     not reach it) → exec. A digest-pinned image is immutable → ok.
+//   - docker with `image: Dockerfile`: the RUN lines of the Dockerfile
+//     are scanned with the same logic (curl|sh, obfuscation, …).
+func scanActionDefinition(actionYML, ymlKey string, fetchRel func(rel string) (string, bool)) *ir.MutableRemoteExec {
+	files := map[string]string{ymlKey: actionYML}
+	dir := path.Dir(ymlKey) // "" for a root action, the subpath for a nested one
+	key := func(rel string) string {
+		if dir == "." || dir == "" {
+			return rel
+		}
+		return path.Join(dir, rel)
+	}
+
+	if u := reUsing.FindStringSubmatch(actionYML); len(u) == 2 && strings.EqualFold(u[1], "docker") {
+		img := ""
+		if m := reImage.FindStringSubmatch(actionYML); len(m) == 2 {
+			img = m[1]
+		}
+		if rest, ok := strings.CutPrefix(img, "docker://"); ok {
+			if tier := dockerImageTier(rest); tier != "" {
+				return &ir.MutableRemoteExec{Tier: tier, URL: img, File: ymlKey}
+			}
+			return nil // digest-pinned image is immutable
+		}
+		df := img
+		if df == "" || strings.EqualFold(df, "dockerfile") {
+			df = "Dockerfile"
+		}
+		if src, ok := fetchRel(df); ok {
+			files[key(df)] = src
+		}
+		return ScanActionSource(files)
+	}
+
+	for _, p := range entrypointPaths(actionYML) {
+		if src, ok := fetchRel(p); ok {
+			files[key(p)] = src
+		}
+	}
+	return ScanActionSource(files)
+}
+
+// dockerImageTier grades a `docker://` image reference by how immutable the
+// content it pulls actually is. A digest (`@sha256:…`) is content-addressed and
+// immutable -> "" (clean). A moving tag (`latest`, none, or any non-version
+// tag) can be re-pointed at will -> "exec" (high). A semver-style version tag
+// is conventionally frozen but the registry still lets the publisher re-push it
+// -> "data" (low, recorded but not surfaced as high), consistent with how the
+// script tiers treat a checksum-verified fetch.
+func dockerImageTier(rest string) string {
+	if strings.Contains(rest, "@sha256:") {
+		return ""
+	}
+	tag := ""
+	if i := strings.LastIndex(rest, ":"); i > strings.LastIndex(rest, "/") {
+		tag = rest[i+1:]
+	}
+	if tag == "" || strings.EqualFold(tag, "latest") {
+		return "exec"
+	}
+	if reVersionTag.MatchString(tag) {
+		return "data"
+	}
+	return "exec"
+}
+
+// reVersionTag matches a conventional semver-ish image tag (v1, 1.2.3, v8.7.0).
+var reVersionTag = regexp.MustCompile(`^v?\d+(?:\.\d+)*$`)
+
 // fetchStatus distinguishes "file absent" (not an action / subpath) from
 // "could not reach it" (network, rate limit) so the caller can emit an
 // explicit could-not-verify finding instead of a silent pass whose
@@ -286,14 +368,10 @@ func analyzeActionMutableExec(fetch rawFetcher, owner, repo, ref, subpath string
 			return nil // missing (not an action / subpath) or offline → silent
 		}
 	}
-	files := map[string]string{ymlPath: actionYML}
-	for _, p := range entrypointPaths(actionYML) {
-		full := path.Join(subpath, p)
-		if src, st := fetch(owner, repo, ref, full); st == fetchOK {
-			files[full] = src
-		}
-	}
-	return ScanActionSource(files)
+	return scanActionDefinition(actionYML, ymlPath, func(rel string) (string, bool) {
+		src, st := fetch(owner, repo, ref, path.Join(subpath, rel))
+		return src, st == fetchOK
+	})
 }
 
 // ScanLocalSelfAction checks whether the scanned repository is itself a
@@ -310,13 +388,9 @@ func ScanLocalSelfAction(rootDir string) *ir.MutableRemoteExec {
 			return nil
 		}
 	}
-	files := map[string]string{"action.yml": actionYML}
-	for _, p := range entrypointPaths(actionYML) {
-		if src, ok := readLocalFile(rootDir, p); ok {
-			files[p] = src
-		}
-	}
-	return ScanActionSource(files)
+	return scanActionDefinition(actionYML, "action.yml", func(rel string) (string, bool) {
+		return readLocalFile(rootDir, rel)
+	})
 }
 
 func readLocalFile(rootDir, rel string) (string, bool) {

--- a/github/action_source.go
+++ b/github/action_source.go
@@ -51,7 +51,16 @@ var (
 	// URL requirement keeps this off legitimate installers that download a
 	// versioned release asset (e.g. releases/download/<version>/…) and
 	// verify a checksum — those are not mutable-remote-exec.
-	reDownloadRun = regexp.MustCompile(`(?s)(?:curl|wget)\b[^\n]*` + ghContent + `/(?:` + movingRefAlt + `)/[^\n]*\s-[oO]\b.*?(?:\n|;)[^\n;]*(?:` + interp + `\s+\S|chmod\s+\+x)`)
+	//
+	// The run clause is anchored to a statement start — a separator
+	// (`\n`, `;`, `&&`, `|`), optional `sudo …`, then an interpreter with
+	// a `\b` word boundary and an argument, OR `source`/`./x`/`chmod +x`.
+	// Without the anchor and boundary the old `interp\s+\S` matched the
+	// "sh" inside `git push` on any line after the download (`\s` also
+	// crossed newlines), so a `-o versions.json` fetch followed by
+	// `git push` was mis-reported as exec. The gap is bounded (`.{0,400}?`)
+	// so the fetch and the run must be near each other.
+	reDownloadRun = regexp.MustCompile(`(?s)(?:curl|wget)\b[^\n]*` + ghContent + `/(?:` + movingRefAlt + `)/[^\n]*\s-[oO]\b.{0,400}?(?:\n|;|&&|\|)[ \t]*(?:sudo\s+(?:-\S+\s+)*)?(?:` + interp + `\b[ \t]+\S|source[ \t]+\S|\./\S|chmod[ \t]+\+x)`)
 
 	// --- obfuscated tier: the fetch/exec is hidden (base64/decode + run) ---
 	// No legitimate action needs to obfuscate what it runs, so this is
@@ -63,7 +72,13 @@ var (
 	reObfPipe = regexp.MustCompile(`(?:base64\s+(?:-d|-D|--decode)|openssl\s+(?:base64|enc)\b[^\n]*-d|xxd\s+-r|rev\b)[^\n|]*\|\s*(?:sudo\s+)?` + interp + `\b`)
 	// reObfEval: eval/exec of a decoded string (eval "$(… base64 -d …)",
 	// eval(atob(…)), new Function(atob(…)), exec(Buffer.from(x,'base64')).
-	reObfEval = regexp.MustCompile(`(?:eval|new\s+Function|child_process[^\n]{0,40}exec)\s*\(?[^\n]{0,60}(?:atob\s*\(|Buffer\.from\s*\([^)]*['"]base64|base64\s+(?:-d|--decode))`)
+	// The window between the sink and the decode is `[^)\n]{0,40}` — it
+	// must stay INSIDE the sink's argument list (no `)`), so the decode is
+	// an argument of the sink, not merely an adjacent statement. A wider
+	// `[^\n]{0,60}` window raised a critical on benign minified bundles
+	// where standard `new Function("return this")()` boilerplate sits next
+	// to a routine `Buffer.from(x,"base64")` input decode on one line.
+	reObfEval = regexp.MustCompile(`(?:eval|new\s+Function|child_process[^\n]{0,40}exec)\s*\(?[^)\n]{0,40}(?:atob\s*\(|Buffer\.from\s*\([^)]*['"]base64|base64\s+(?:-d|--decode))`)
 	reEvalSub = regexp.MustCompile(`\beval\b[^\n]{0,20}\$\([^\n]*(?:base64\s+(?:-d|--decode)|xxd\s+-r)`)
 
 	// reChecksum: an integrity check on a downloaded artifact. Its
@@ -72,6 +87,23 @@ var (
 	// otherwise-flagged exec is downgraded. Best-effort: the check may
 	// cover a different file, but it signals the author cares.
 	reChecksum = regexp.MustCompile(`(?i)\b(?:sha(?:256|512)sum\s+(?:-c|--check)|shasum\s+-a\s+(?:256|512)|openssl\s+dgst\s+-sha(?:256|512)|cosign\s+verify|gpg\s+--verify|--checksum\b|slsa-verifier\s+verify)`)
+
+	// reInterpLocalScript matches a pipe whose interpreter runs a LOCAL
+	// script file as its first argument (`… | python3 scripts/gen.py`).
+	// There the fetched remote content is the interpreter's stdin (data),
+	// and the code actually executed is the committed local script — not
+	// remote exec. `sh -s`, `python3 -`, `| sh` (no arg) do NOT match, so
+	// a genuine `curl … | sh` stays exec.
+	reInterpLocalScript = regexp.MustCompile(`\|\s*(?:sudo\s+(?:-\S+\s+)*)?` + interp + `[ \t]+(?:-\S+[ \t]+)*([^\s|]+\.(?:sh|bash|py|rb|pl|js))\b`)
+	// rePinnedSource matches a fetch URL path segment that pins the
+	// CONTENT: a 40-hex commit SHA, `refs/tags/…`, a `releases/download/…`
+	// asset, or a dotted version segment (`/v1.2.3/`). A bare `/v2/` is NOT
+	// matched — on raw content it is ref-ambiguous with a branch named
+	// `v2` (ISSUE-402), so it stays exec. A pinned pipe is downgraded to
+	// the low `data` tier: it is exactly what the ISSUE-714 remediation
+	// recommends, so surfacing it as high would contradict the fix, and
+	// re-pushable tags/assets stay recorded rather than clean.
+	rePinnedSource = regexp.MustCompile(`(?i)/(?:[0-9a-f]{40}|refs/tags/|releases/download/|v?\d+(?:\.\d+)+)/`)
 
 	// reDataMoving: a DATA manifest pulled from a moving ref that steers
 	// a later binary download (docker/actions-toolkit release manifest).
@@ -123,9 +155,17 @@ func ScanActionSource(files map[string]string) *ir.MutableRemoteExec {
 	// block), the content is pinned, so downgrade to the low "data" tier.
 	// Proximity matters: a `sha256` string elsewhere in a large bundled
 	// dist/index.js is library noise, not integrity of THIS fetch.
+	//
+	// The `curl … | interp` pipe is classified by the URL and the
+	// interpreter's arguments (see classifyPipeMatch): a pipe whose remote
+	// source is content-pinned drops to `data`, and a pipe that merely
+	// feeds a local committed script is skipped entirely.
 	for _, name := range names {
 		content := files[name]
-		for _, re := range []*regexp.Regexp{reExecMoving, rePipeShell, reDownloadRun} {
+		if hit := scanPipeShell(content, name); hit != nil {
+			return hit
+		}
+		for _, re := range []*regexp.Regexp{reExecMoving, reDownloadRun} {
 			loc := re.FindStringIndex(content)
 			if loc == nil {
 				continue
@@ -145,6 +185,57 @@ func ScanActionSource(files map[string]string) *ir.MutableRemoteExec {
 		}
 	}
 	return nil
+}
+
+// scanPipeShell finds the first `curl … | interp` pipe in content that
+// represents remote execution and returns its finding, or nil when every
+// pipe is either a local-script feed (skipped) — the executed code is
+// committed, not remote. A pipe from a content-pinned source, or one
+// verified by a nearby checksum, is downgraded to the low `data` tier;
+// otherwise it is `exec`. FindAll is used so a benign local-script pipe
+// earlier in the file does not mask a real remote-exec pipe after it.
+func scanPipeShell(content, name string) *ir.MutableRemoteExec {
+	for _, loc := range rePipeShell.FindAllStringIndex(content, -1) {
+		line := enclosingLine(content, loc[0])
+		if pipeExecutesLocalScript(line) {
+			continue // remote content is stdin; the run target is a local file
+		}
+		m := content[loc[0]:loc[1]]
+		tier := "exec"
+		if pipeSourcePinned(line) || checksumNear(content, loc[0], loc[1]) {
+			tier = "data"
+		}
+		return &ir.MutableRemoteExec{Tier: tier, URL: snippet(m), Ref: matchedRef(m), File: name}
+	}
+	return nil
+}
+
+// enclosingLine returns the text of the line containing byte index idx,
+// without the surrounding newlines. Used to classify a pipe by its whole
+// command (the URL before the pipe and the interpreter args after it),
+// not just the fragment rePipeShell matched.
+func enclosingLine(content string, idx int) string {
+	start := strings.LastIndexByte(content[:idx], '\n') + 1
+	rest := content[idx:]
+	if end := strings.IndexByte(rest, '\n'); end >= 0 {
+		return content[start : idx+end]
+	}
+	return content[start:]
+}
+
+// pipeExecutesLocalScript reports whether a `… | interp <local-script>`
+// pipe runs a committed local script (the fetched content is data on the
+// interpreter's stdin). A remote script argument (`http…`) does not count.
+func pipeExecutesLocalScript(line string) bool {
+	m := reInterpLocalScript.FindStringSubmatch(line)
+	return m != nil && !strings.Contains(m[1], "://")
+}
+
+// pipeSourcePinned reports whether the fetch URL on this line pins its
+// content (SHA / refs/tags / release asset / dotted version), so piping
+// it to a shell is not MUTABLE remote exec.
+func pipeSourcePinned(line string) bool {
+	return rePinnedSource.MatchString(line)
 }
 
 // checksumNear reports whether an integrity check appears within a small

--- a/github/action_source.go
+++ b/github/action_source.go
@@ -1,0 +1,394 @@
+package github
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/getplumber/plumber/internal/ir"
+)
+
+// This file analyses a third-party action's OWN source to decide
+// whether the action fetches and runs mutable remote code at runtime.
+// Pinning the action by commit SHA (ISSUE-701) does not cover this: the
+// pinned action can still pull an install script from `main` of another
+// repo, so the code actually executed changes with nothing committed
+// where the pin can see it (the anchore/scan-action → grype case).
+
+// movingRefAlt is the alternation of ref names whose content changes over
+// time (as opposed to a version tag `vX.Y` or a 40-hex commit SHA). It is
+// not exhaustive — an author can name a branch anything — but it covers
+// the common cases plus the "rename around the list" evasions.
+const movingRefAlt = `main|master|HEAD|develop|trunk|latest|stable|release|dev|edge|nightly|canary|next|snapshot`
+
+var (
+	// ghContent matches the GitHub hosts that serve raw per-ref file
+	// BYTES (fetchable and pipe-able). github.com/<o>/<r>/raw is the same
+	// mutable content as raw.githubusercontent.com — swapping host was the
+	// first reported bypass. `blob` is deliberately excluded: it is the
+	// HTML page, not the raw bytes, so a blob URL is a doc link, not a
+	// fetch source (it caused a comment-link false positive).
+	ghContent = `(?:raw\.githubusercontent\.com/[^/\s"']+/[^/\s"']+|github\.com/[^/\s"']+/[^/\s"']+/raw|gist\.githubusercontent\.com/[^/\s"']+/[^/\s"']+)`
+	pathChars = `[^\s"'),;>]*`
+	scriptExt = `\.(?:sh|bash|zsh|py|pl|rb|ps1)\b`
+	interp    = `(?:(?:ba|z)?sh|python[0-9.]*|ruby|perl|pwsh|node)`
+
+	// --- exec tier: remote code fetched from a moving ref and run, in the open ---
+
+	// reExecMoving: a SCRIPT fetched from a moving ref on any github
+	// content host — the extension implies it is executed.
+	reExecMoving = regexp.MustCompile(ghContent + `/(?:` + movingRefAlt + `)/` + pathChars + scriptExt)
+	// rePipeShell: a remote fetch piped straight into an interpreter.
+	rePipeShell = regexp.MustCompile(`(?:curl|wget)\b[^\n|]*\|\s*(?:sudo\s+)?` + interp + `\b`)
+	// reDownloadRun: fetch a MUTABLE-ref content URL to a file, then run
+	// it (the download-then-run bypass of the pipe form). The moving-ref
+	// URL requirement keeps this off legitimate installers that download a
+	// versioned release asset (e.g. releases/download/<version>/…) and
+	// verify a checksum — those are not mutable-remote-exec.
+	reDownloadRun = regexp.MustCompile(`(?s)(?:curl|wget)\b[^\n]*` + ghContent + `/(?:` + movingRefAlt + `)/[^\n]*\s-[oO]\b.*?(?:\n|;)[^\n;]*(?:` + interp + `\s+\S|chmod\s+\+x)`)
+
+	// --- obfuscated tier: the fetch/exec is hidden (base64/decode + run) ---
+	// No legitimate action needs to obfuscate what it runs, so this is
+	// treated as the strongest signal (critical). Requires a decode
+	// feeding an execution sink, not a bare base64 (which is often a
+	// legitimate token/file encode).
+
+	// reObfPipe: a decode piped into an interpreter (base64 -d | sh).
+	reObfPipe = regexp.MustCompile(`(?:base64\s+(?:-d|-D|--decode)|openssl\s+(?:base64|enc)\b[^\n]*-d|xxd\s+-r|rev\b)[^\n|]*\|\s*(?:sudo\s+)?` + interp + `\b`)
+	// reObfEval: eval/exec of a decoded string (eval "$(… base64 -d …)",
+	// eval(atob(…)), new Function(atob(…)), exec(Buffer.from(x,'base64')).
+	reObfEval = regexp.MustCompile(`(?:eval|new\s+Function|child_process[^\n]{0,40}exec)\s*\(?[^\n]{0,60}(?:atob\s*\(|Buffer\.from\s*\([^)]*['"]base64|base64\s+(?:-d|--decode))`)
+	reEvalSub = regexp.MustCompile(`\beval\b[^\n]{0,20}\$\([^\n]*(?:base64\s+(?:-d|--decode)|xxd\s+-r)`)
+
+	// reChecksum: an integrity check on a downloaded artifact. Its
+	// presence means the author pinned the CONTENT (a mutable-ref fetch
+	// that verifies a hash aborts if the upstream changes), so an
+	// otherwise-flagged exec is downgraded. Best-effort: the check may
+	// cover a different file, but it signals the author cares.
+	reChecksum = regexp.MustCompile(`(?i)\b(?:sha(?:256|512)sum\s+(?:-c|--check)|shasum\s+-a\s+(?:256|512)|openssl\s+dgst\s+-sha(?:256|512)|cosign\s+verify|gpg\s+--verify|--checksum\b|slsa-verifier\s+verify)`)
+
+	// reDataMoving: a DATA manifest pulled from a moving ref that steers
+	// a later binary download (docker/actions-toolkit release manifest).
+	reDataMoving = regexp.MustCompile(ghContent + `/(?:` + movingRefAlt + `)/` + pathChars + `\.(?:json|ya?ml|txt|xml)\b`)
+	// reRef extracts the moving ref token from a matched URL.
+	reRef = regexp.MustCompile(ghContent + `/(` + movingRefAlt + `)/`)
+	// reMain extracts the node entrypoint from an action.yml `main:`.
+	reMain = regexp.MustCompile(`(?m)^\s*main:\s*['"]?([^\s'"]+)`)
+)
+
+// entrypointCandidates are the usual hand-written and bundled source
+// locations to inspect in addition to the declared `main:`.
+var entrypointCandidates = []string{"action.js", "index.js", "dist/index.js", "src/index.js"}
+
+// ScanActionSource inspects an action's fetched source files (path →
+// content) and returns the strongest mutable-remote-exec signal, or nil
+// when nothing mutable is found. Tiers, strongest first:
+//
+//	obfuscated — decode-then-exec / eval(atob): hiding is the finding (critical)
+//	exec       — a script fetched from a moving ref and run, no checksum (high)
+//	data       — a mutable manifest, OR an exec that DOES verify a checksum
+//	             (content-pinned, materially safer) — recorded, not surfaced
+//
+// Files are scanned in sorted order so the reported hit is deterministic.
+func ScanActionSource(files map[string]string) *ir.MutableRemoteExec {
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	// Pass 0 — obfuscated tier (decode/eval-then-exec). Highest signal:
+	// nothing legitimate needs to hide what it runs.
+	for _, name := range names {
+		content := files[name]
+		for _, re := range []*regexp.Regexp{reObfPipe, reEvalSub, reObfEval} {
+			if m := re.FindString(content); m != "" {
+				return &ir.MutableRemoteExec{Tier: "obfuscated", URL: snippet(m), File: name}
+			}
+		}
+	}
+	// Pass 1 — exec tier (fetch a script from a moving ref and run it).
+	// If a checksum verification appears NEAR the fetch (same short shell
+	// block), the content is pinned, so downgrade to the low "data" tier.
+	// Proximity matters: a `sha256` string elsewhere in a large bundled
+	// dist/index.js is library noise, not integrity of THIS fetch.
+	for _, name := range names {
+		content := files[name]
+		for _, re := range []*regexp.Regexp{reExecMoving, rePipeShell, reDownloadRun} {
+			loc := re.FindStringIndex(content)
+			if loc == nil {
+				continue
+			}
+			m := content[loc[0]:loc[1]]
+			tier := "exec"
+			if checksumNear(content, loc[0], loc[1]) {
+				tier = "data"
+			}
+			return &ir.MutableRemoteExec{Tier: tier, URL: snippet(m), Ref: matchedRef(m), File: name}
+		}
+	}
+	// Pass 2 — data tier (mutable manifest steering a download).
+	for _, name := range names {
+		if m := reDataMoving.FindString(files[name]); m != "" {
+			return &ir.MutableRemoteExec{Tier: "data", URL: m, Ref: matchedRef(m), File: name}
+		}
+	}
+	return nil
+}
+
+// checksumNear reports whether an integrity check appears within a small
+// window around the fetch at [start,end) — close enough to plausibly
+// verify that fetch, not a stray `sha256` elsewhere in a bundle.
+func checksumNear(content string, start, end int) bool {
+	const window = 300
+	lo := start - window
+	if lo < 0 {
+		lo = 0
+	}
+	hi := end + window
+	if hi > len(content) {
+		hi = len(content)
+	}
+	return reChecksum.MatchString(content[lo:hi])
+}
+
+// snippet trims and caps a matched fragment for the reported URL field.
+func snippet(m string) string {
+	m = strings.TrimSpace(m)
+	if len(m) > 120 {
+		m = m[:120]
+	}
+	return m
+}
+
+func matchedRef(url string) string {
+	if sm := reRef.FindStringSubmatch(url); len(sm) == 2 {
+		return sm[1]
+	}
+	return ""
+}
+
+// entrypointPaths returns the source paths worth inspecting for an
+// action, given its action.yml: the declared node entrypoint plus the
+// usual hand-written/bundled locations.
+func entrypointPaths(actionYML string) []string {
+	paths := []string{}
+	if sm := reMain.FindStringSubmatch(actionYML); len(sm) == 2 {
+		paths = append(paths, sm[1])
+	}
+	for _, c := range entrypointCandidates {
+		if !contains(paths, c) {
+			paths = append(paths, c)
+		}
+	}
+	return paths
+}
+
+func contains(s []string, v string) bool {
+	for _, e := range s {
+		if e == v {
+			return true
+		}
+	}
+	return false
+}
+
+// fetchStatus distinguishes "file absent" (not an action / subpath) from
+// "could not reach it" (network, rate limit) so the caller can emit an
+// explicit could-not-verify finding instead of a silent pass whose
+// result would vary by CI environment.
+type fetchStatus int
+
+const (
+	fetchOK       fetchStatus = iota // content returned
+	fetchMissing                     // 404: the file is not there
+	fetchError                       // network / rate limit / HTTP error
+	fetchDisabled                    // offline switch: abstain silently
+)
+
+// rawFetcher fetches a single file's text from an action repo at a ref.
+type rawFetcher func(owner, repo, ref, path string) (text string, status fetchStatus)
+
+// firstPartyOwners are the action owners trusted as extensions of the
+// platform itself; their source is not fetched (saves network, and a
+// GitHub-owned action fetching from GitHub is not the threat here).
+var firstPartyOwners = map[string]bool{"actions": true, "github": true}
+
+// resolveMutableExec returns the mutable-remote-exec signal for a
+// third-party action, memoised per `uses:` value so an action reused
+// across jobs is fetched once. First-party and unparseable refs are
+// skipped (nil).
+func resolveMutableExec(uses string, cache map[string]*ir.MutableRemoteExec) *ir.MutableRemoteExec {
+	if v, ok := cache[uses]; ok {
+		return v
+	}
+	var mre *ir.MutableRemoteExec
+	if owner, repo, subpath, ref, ok := splitActionRefWithSubpath(uses); ok && !firstPartyOwners[strings.ToLower(owner)] {
+		mre = analyzeActionMutableExec(httpRawFetcher, owner, repo, ref, subpath)
+	}
+	cache[uses] = mre
+	return mre
+}
+
+// splitActionRefWithSubpath parses `owner/repo[/subpath]@ref`. subpath is
+// the in-repo directory of a composite/nested action ("" for a root
+// action). Reusable-workflow calls (`…/.github/workflows/x.yml@ref`) and
+// local/docker refs are rejected (ok=false) — they are not actions whose
+// source we scan.
+func splitActionRefWithSubpath(uses string) (owner, repo, subpath, ref string, ok bool) {
+	if strings.HasPrefix(uses, "./") || strings.HasPrefix(uses, "docker://") {
+		return "", "", "", "", false
+	}
+	at := strings.Index(uses, "@")
+	if at < 0 {
+		return "", "", "", "", false
+	}
+	head, tail := uses[:at], uses[at+1:]
+	parts := strings.SplitN(head, "/", 3)
+	if len(parts) < 2 {
+		return "", "", "", "", false
+	}
+	if len(parts) == 3 {
+		subpath = parts[2]
+	}
+	if strings.HasSuffix(subpath, ".yml") || strings.HasSuffix(subpath, ".yaml") {
+		return "", "", "", "", false // reusable workflow call, not an action
+	}
+	return parts[0], parts[1], subpath, tail, true
+}
+
+// analyzeActionMutableExec fetches an action's action.yml and entrypoint
+// at the pinned ref and scans them. subpath is the action's in-repo
+// directory ("" for a root action); action.yml and the declared
+// entrypoint are resolved relative to it, so composite/nested actions
+// (github/codeql-action/init, home-assistant/actions/hassfest) are
+// covered too. Returns nil when the action has no action.yml
+// (Docker-Hub action) or nothing mutable is found.
+func analyzeActionMutableExec(fetch rawFetcher, owner, repo, ref, subpath string) *ir.MutableRemoteExec {
+	ymlPath := path.Join(subpath, "action.yml")
+	actionYML, st := fetch(owner, repo, ref, ymlPath)
+	if st == fetchError {
+		return &ir.MutableRemoteExec{Tier: "unverified", File: ymlPath}
+	}
+	if st != fetchOK {
+		ymlPath = path.Join(subpath, "action.yaml")
+		actionYML, st = fetch(owner, repo, ref, ymlPath)
+		if st == fetchError {
+			return &ir.MutableRemoteExec{Tier: "unverified", File: ymlPath}
+		}
+		if st != fetchOK {
+			return nil // missing (not an action / subpath) or offline → silent
+		}
+	}
+	files := map[string]string{ymlPath: actionYML}
+	for _, p := range entrypointPaths(actionYML) {
+		full := path.Join(subpath, p)
+		if src, st := fetch(owner, repo, ref, full); st == fetchOK {
+			files[full] = src
+		}
+	}
+	return ScanActionSource(files)
+}
+
+// ScanLocalSelfAction checks whether the scanned repository is itself a
+// GitHub Action (root action.yml/action.yaml) whose own source fetches
+// mutable remote code, reading the action definition and entrypoint from
+// the local checkout. Returns nil when the repo is not an action or
+// nothing mutable is found. This is the producer-side check: scanning an
+// action's own repo must flag the action it publishes.
+func ScanLocalSelfAction(rootDir string) *ir.MutableRemoteExec {
+	actionYML, ok := readLocalFile(rootDir, "action.yml")
+	if !ok {
+		actionYML, ok = readLocalFile(rootDir, "action.yaml")
+		if !ok {
+			return nil
+		}
+	}
+	files := map[string]string{"action.yml": actionYML}
+	for _, p := range entrypointPaths(actionYML) {
+		if src, ok := readLocalFile(rootDir, p); ok {
+			files[p] = src
+		}
+	}
+	return ScanActionSource(files)
+}
+
+func readLocalFile(rootDir, rel string) (string, bool) {
+	b, err := os.ReadFile(filepath.Join(rootDir, filepath.FromSlash(rel)))
+	if err != nil {
+		return "", false
+	}
+	return string(b), true
+}
+
+// ScanRemoteSelfAction is the remote counterpart of ScanLocalSelfAction:
+// it fetches the scanned repo's own root action.yml + entrypoint over raw
+// content and scans them. Used on the --project (upstream-fetch) path.
+func ScanRemoteSelfAction(owner, repo, ref string) *ir.MutableRemoteExec {
+	return analyzeActionMutableExec(httpRawFetcher, owner, repo, ref, "")
+}
+
+// httpRawFetcher reads file text from raw.githubusercontent.com. It
+// serves github.com-hosted public actions; GitHub Enterprise Server
+// hosts and private repos are out of scope for this first iteration and
+// simply return ok=false (the control abstains rather than guesses).
+var rawHTTPClient = &http.Client{Timeout: 20 * time.Second}
+
+// rawFetchToken returns a GitHub token for raw content reads, using the
+// same precedence as the metadata client's env inputs. Empty when none
+// is set (anonymous read).
+func rawFetchToken() string {
+	for _, k := range []string{EnvMetadataToken, "GH_TOKEN", "GITHUB_TOKEN"} {
+		if v := strings.TrimSpace(os.Getenv(k)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func httpRawFetcher(owner, repo, ref, path string) (string, fetchStatus) {
+	// Respect the offline switch the test suite (and air-gapped runs)
+	// use to keep the collector network-free.
+	if v := os.Getenv(EnvDisableGitHubAPI); v == "1" || v == "true" {
+		return "", fetchDisabled
+	}
+	if ref == "" {
+		ref = "HEAD"
+	}
+	url := "https://raw.githubusercontent.com/" + owner + "/" + repo + "/" + ref + "/" + path
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", fetchError
+	}
+	// An authenticated request lifts the anonymous rate limit, which a
+	// repo with many third-party actions can otherwise hit (turning real
+	// findings into could-not-verify). Public content, so any read token
+	// works; private repos need it. Falls back to anonymous.
+	if tok := rawFetchToken(); tok != "" {
+		req.Header.Set("Authorization", "token "+tok)
+	}
+	resp, err := rawHTTPClient.Do(req)
+	if err != nil {
+		return "", fetchError
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		return "", fetchMissing
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fetchError // 403 rate-limit, 5xx, … → could not verify
+	}
+	// Cap the read: bundled dist/ files can be a few MB; refuse anything
+	// absurd to bound memory.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+	if err != nil {
+		return "", fetchError
+	}
+	return string(body), fetchOK
+}

--- a/github/action_source_test.go
+++ b/github/action_source_test.go
@@ -90,6 +90,53 @@ func TestScanActionSource(t *testing.T) {
 			files:    map[string]string{"action.yml": "runs:\n  using: composite\n  steps:\n    - run: |\n        curl -sSfL https://raw.githubusercontent.com/o/r/main/i.sh -o i.sh\n        echo \"abc123  i.sh\" | sha256sum -c\n        sh i.sh"},
 			wantTier: "data",
 		},
+		// --- #299 review: reObfEval must not fire on benign minified bundles (blocker 1) ---
+		{
+			name:     "minified new Function boilerplate next to a base64 decode is NOT obfuscated",
+			files:    map[string]string{"dist/index.js": `t=new Function("return this")();r=Buffer.from(e.data,"base64");`},
+			wantTier: "",
+		},
+		{
+			name:     "genuine new Function(atob(...)) is still obfuscated",
+			files:    map[string]string{"dist/index.js": `const run = new Function(atob(payload));run();`},
+			wantTier: "obfuscated",
+		},
+		// --- #299 review: pipe classified by URL/args mutability (blocker 2) ---
+		{
+			name:     "SHA-pinned URL piped to sh is data, not high (matches the ISSUE-714 remediation)",
+			files:    map[string]string{"action.yml": "runs:\n  using: composite\n  steps:\n    - run: curl -sSfL https://raw.githubusercontent.com/anchore/grype/8f2a3cd90ff2b3a24e2ba5cbde5a29f3d1b2c4e5/install.sh | sh -s -- -b /usr/local/bin"},
+			wantTier: "data",
+		},
+		{
+			name:     "release-asset URL piped to interpreter is data",
+			files:    map[string]string{"action.yml": "runs:\n  using: composite\n  steps:\n    - run: curl -L https://github.com/org/tool/releases/download/v1.2.3/bootstrap.py | python3 -"},
+			wantTier: "data",
+		},
+		{
+			name:     "remote data piped into a LOCAL committed script is not remote exec",
+			files:    map[string]string{"action.yml": "runs:\n  using: composite\n  steps:\n    - run: curl -s https://api.example.com/matrix.json | python3 scripts/gen_matrix.py >> \"$GITHUB_OUTPUT\""},
+			wantTier: "",
+		},
+		{
+			name:     "moving-ref URL piped to sh stays exec",
+			files:    map[string]string{"action.yml": "runs:\n  using: composite\n  steps:\n    - run: curl -sSfL https://raw.githubusercontent.com/o/r/main/i.sh | sh"},
+			wantTier: "exec",
+		},
+		// --- #299 review: reDownloadRun must anchor the run to a statement (NB-1) ---
+		// The download-then-`git push` case must not be reported as EXEC
+		// (high). The `.json` from a moving ref is still recorded by the
+		// separate data pass (low, not surfaced) — the FP that mattered was
+		// the exec/high verdict, which the statement anchor removes.
+		{
+			name:     "download of a data file followed by git push is NOT exec (recorded as low data)",
+			files:    map[string]string{"action.yml": "runs:\n  using: composite\n  steps:\n    - run: |\n        curl -sSfL https://raw.githubusercontent.com/org/repo/main/versions.json -o versions.json\n        git push origin HEAD"},
+			wantTier: "data",
+		},
+		{
+			name:     "download of a script then && ./run stays exec",
+			files:    map[string]string{"action.yml": "runs:\n  using: composite\n  steps:\n    - run: curl -sSfL https://raw.githubusercontent.com/org/repo/main/x.sh -o x.sh && ./x.sh"},
+			wantTier: "exec",
+		},
 	}
 
 	for _, tc := range cases {

--- a/github/action_source_test.go
+++ b/github/action_source_test.go
@@ -1,0 +1,194 @@
+package github
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanActionSource(t *testing.T) {
+	cases := []struct {
+		name     string
+		files    map[string]string
+		wantTier string // "" means expect nil
+		wantURL  string // substring the reported URL must contain
+	}{
+		{
+			name:     "grype install.sh from main is exec tier",
+			files:    map[string]string{"action.js": "const u = `https://raw.githubusercontent.com/anchore/grype/main/install.sh`;\ntools.downloadTool(u);"},
+			wantTier: "exec",
+			wantURL:  "anchore/grype/main/install.sh",
+		},
+		{
+			name:     "curl pipe sh is exec tier",
+			files:    map[string]string{"action.yml": "runs:\n  using: composite\n  steps:\n    - run: curl -sSfL https://example.com/i.sh | sudo bash"},
+			wantTier: "exec",
+			wantURL:  "curl",
+		},
+		{
+			name:     "docker release manifest from main is data tier",
+			files:    map[string]string{"dist/index.js": `releasesURL:"https://raw.githubusercontent.com/docker/actions-toolkit/main/.github/buildx-releases.json"`},
+			wantTier: "data",
+			wantURL:  "buildx-releases.json",
+		},
+		{
+			name:     "exec wins over data when both present",
+			files:    map[string]string{"a.js": `"raw.githubusercontent.com/o/r/main/m.json"`, "b.js": `"raw.githubusercontent.com/o/r/main/install.sh"`},
+			wantTier: "exec",
+			wantURL:  "install.sh",
+		},
+		{
+			name:     "pinned ref is not flagged",
+			files:    map[string]string{"action.js": `"https://raw.githubusercontent.com/anchore/grype/v0.114.0/install.sh"`},
+			wantTier: "",
+		},
+		{
+			name:     "release-download URL (not raw moving) is not flagged",
+			files:    map[string]string{"action.js": `"https://github.com/anchore/grype/releases/download/v0.114.0/grype.tar.gz"`},
+			wantTier: "",
+		},
+		{
+			name:     "clean action with no remote fetch",
+			files:    map[string]string{"action.yml": "runs:\n  using: node20\n  main: dist/index.js", "dist/index.js": "console.log('hi')"},
+			wantTier: "",
+		},
+		// --- obfuscation tier (critical) ---
+		{
+			name:     "base64 decode piped to sh is obfuscated",
+			files:    map[string]string{"action.yml": "runs:\n  using: composite\n  steps:\n    - run: echo $PAYLOAD | base64 -d | sh"},
+			wantTier: "obfuscated",
+		},
+		{
+			name:     "eval(atob(...)) is obfuscated",
+			files:    map[string]string{"dist/index.js": `const go = eval(atob(secret));`},
+			wantTier: "obfuscated",
+		},
+		{
+			name:     "obfuscation wins over a plain exec",
+			files:    map[string]string{"a.yml": "run: curl -sSfL https://raw.githubusercontent.com/o/r/main/i.sh | sh", "b.yml": `run: eval "$(printf %s "$X" | base64 -d)"`},
+			wantTier: "obfuscated",
+		},
+		// --- host-swap and download-then-run still caught as exec ---
+		{
+			name:     "github.com/<o>/<r>/raw host swap is exec",
+			files:    map[string]string{"action.js": `const u = "https://github.com/anchore/grype/raw/main/install.sh";`},
+			wantTier: "exec",
+			wantURL:  "grype/raw/main/install.sh",
+		},
+		{
+			name:     "download-then-run (no pipe) is exec",
+			files:    map[string]string{"action.yml": "runs:\n  using: composite\n  steps:\n    - run: |\n        curl -o /tmp/b.sh https://raw.githubusercontent.com/o/r/main/b.sh\n        sh /tmp/b.sh"},
+			wantTier: "exec",
+		},
+		{
+			name:     "branch named stable (outside the old list) is exec",
+			files:    map[string]string{"action.js": `"https://raw.githubusercontent.com/o/r/stable/install.sh"`},
+			wantTier: "exec",
+		},
+		// --- checksum downgrades exec to the low data tier ---
+		{
+			name:     "exec that verifies a checksum is downgraded (not high)",
+			files:    map[string]string{"action.yml": "runs:\n  using: composite\n  steps:\n    - run: |\n        curl -sSfL https://raw.githubusercontent.com/o/r/main/i.sh -o i.sh\n        echo \"abc123  i.sh\" | sha256sum -c\n        sh i.sh"},
+			wantTier: "data",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ScanActionSource(tc.files)
+			if tc.wantTier == "" {
+				if got != nil {
+					t.Fatalf("expected no finding, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %s-tier finding, got nil", tc.wantTier)
+			}
+			if got.Tier != tc.wantTier {
+				t.Fatalf("tier = %q, want %q", got.Tier, tc.wantTier)
+			}
+			if tc.wantURL != "" && !strings.Contains(got.URL, tc.wantURL) {
+				t.Fatalf("URL = %q, want to contain %q", got.URL, tc.wantURL)
+			}
+		})
+	}
+}
+
+func TestAnalyzeActionMutableExec_Subpath(t *testing.T) {
+	// A nested/composite action: action.yml lives under the subpath, and
+	// its entrypoint resolves relative to that dir. Only those paths
+	// exist in the fake fetcher; a root fetch must not be what triggers.
+	fetch := func(owner, repo, ref, p string) (string, fetchStatus) {
+		files := map[string]string{
+			"hassfest/action.yml":    "runs:\n  using: node20\n  main: dist/index.js",
+			"hassfest/dist/index.js": `tools.downloadTool("https://raw.githubusercontent.com/acme/tool/main/install.sh")`,
+		}
+		if owner == "acme" && repo == "actions" && ref == "v1" {
+			if v, ok := files[p]; ok {
+				return v, fetchOK
+			}
+		}
+		return "", fetchMissing
+	}
+	got := analyzeActionMutableExec(fetch, "acme", "actions", "v1", "hassfest")
+	if got == nil {
+		t.Fatal("expected a finding for the subpath action, got nil (subpath not resolved)")
+	}
+	if got.Tier != "exec" || got.File != "hassfest/dist/index.js" {
+		t.Fatalf("unexpected finding: %+v", got)
+	}
+}
+
+func TestAnalyzeActionMutableExec_Unverified(t *testing.T) {
+	// A network error fetching action.yml must surface as could-not-verify,
+	// never a silent nil (which would read as "clean").
+	fetchErr := func(owner, repo, ref, p string) (string, fetchStatus) {
+		return "", fetchError
+	}
+	got := analyzeActionMutableExec(fetchErr, "acme", "tool", "v1", "")
+	if got == nil || got.Tier != "unverified" {
+		t.Fatalf("network error must yield tier=unverified, got %+v", got)
+	}
+
+	// A 404 (not an action / subpath absent) is a legitimate silent nil.
+	fetchMiss := func(owner, repo, ref, p string) (string, fetchStatus) {
+		return "", fetchMissing
+	}
+	if got := analyzeActionMutableExec(fetchMiss, "acme", "tool", "v1", ""); got != nil {
+		t.Fatalf("a missing action.yml must yield nil, got %+v", got)
+	}
+}
+
+func TestSplitActionRefWithSubpath(t *testing.T) {
+	cases := []struct {
+		uses                      string
+		owner, repo, subpath, ref string
+		ok                        bool
+	}{
+		{"anchore/scan-action@v7", "anchore", "scan-action", "", "v7", true},
+		{"github/codeql-action/init@abc123", "github", "codeql-action", "init", "abc123", true},
+		{"home-assistant/actions/hassfest@master", "home-assistant", "actions", "hassfest", "master", true},
+		{"crowdsecurity/php-cs-bouncer/.github/workflows/test.yml@main", "", "", "", "", false}, // reusable workflow
+		{"./local/action@v1", "", "", "", "", false},
+		{"docker://alpine@sha256:x", "", "", "", "", false},
+		{"noref", "", "", "", "", false},
+	}
+	for _, tc := range cases {
+		o, r, s, ref, ok := splitActionRefWithSubpath(tc.uses)
+		if ok != tc.ok || o != tc.owner || r != tc.repo || s != tc.subpath || ref != tc.ref {
+			t.Errorf("%s → (%q,%q,%q,%q,%v), want (%q,%q,%q,%q,%v)",
+				tc.uses, o, r, s, ref, ok, tc.owner, tc.repo, tc.subpath, tc.ref, tc.ok)
+		}
+	}
+}
+
+func TestEntrypointPaths(t *testing.T) {
+	got := entrypointPaths("runs:\n  using: node20\n  main: dist/bundle.js\n")
+	if len(got) == 0 || got[0] != "dist/bundle.js" {
+		t.Fatalf("expected declared entrypoint first, got %v", got)
+	}
+	// the usual candidates are appended without duplicating the declared one
+	if !contains(got, "action.js") || !contains(got, "dist/index.js") {
+		t.Fatalf("expected candidate paths appended, got %v", got)
+	}
+}

--- a/github/action_source_test.go
+++ b/github/action_source_test.go
@@ -159,6 +159,57 @@ func TestAnalyzeActionMutableExec_Unverified(t *testing.T) {
 	}
 }
 
+func TestScanActionDefinition_Docker(t *testing.T) {
+	noFetch := func(string) (string, bool) { return "", false }
+
+	t.Run("docker:// mutable tag is exec", func(t *testing.T) {
+		yml := "runs:\n  using: docker\n  image: docker://ghcr.io/super-linter/super-linter:latest"
+		got := scanActionDefinition(yml, "action.yml", noFetch)
+		if got == nil || got.Tier != "exec" {
+			t.Fatalf("mutable docker:// tag must be exec, got %+v", got)
+		}
+	})
+
+	t.Run("docker:// version tag is low (data), not high", func(t *testing.T) {
+		yml := "runs:\n  using: docker\n  image: docker://ghcr.io/super-linter/super-linter:v8.7.0"
+		got := scanActionDefinition(yml, "action.yml", noFetch)
+		if got == nil || got.Tier != "data" {
+			t.Fatalf("version-tagged image must be data tier, got %+v", got)
+		}
+	})
+
+	t.Run("docker:// pinned by digest is clean", func(t *testing.T) {
+		yml := "runs:\n  using: docker\n  image: docker://ghcr.io/x/y@sha256:deadbeef"
+		if got := scanActionDefinition(yml, "action.yml", noFetch); got != nil {
+			t.Fatalf("digest-pinned image must be clean, got %+v", got)
+		}
+	})
+
+	t.Run("Dockerfile RUN curl|sh is exec", func(t *testing.T) {
+		yml := "runs:\n  using: docker\n  image: Dockerfile"
+		fetch := func(rel string) (string, bool) {
+			if rel == "Dockerfile" {
+				return "FROM alpine\nRUN curl -fsSL https://get.docker.com | sh\n", true
+			}
+			return "", false
+		}
+		got := scanActionDefinition(yml, "action.yml", fetch)
+		if got == nil || got.Tier != "exec" {
+			t.Fatalf("Dockerfile with curl|sh must be exec, got %+v", got)
+		}
+	})
+
+	t.Run("clean Dockerfile is not flagged", func(t *testing.T) {
+		yml := "runs:\n  using: docker\n  image: Dockerfile"
+		fetch := func(rel string) (string, bool) {
+			return "FROM alpine\nRUN apk add --no-cache bash\n", true
+		}
+		if got := scanActionDefinition(yml, "action.yml", fetch); got != nil {
+			t.Fatalf("clean Dockerfile must not be flagged, got %+v", got)
+		}
+	})
+}
+
 func TestSplitActionRefWithSubpath(t *testing.T) {
 	cases := []struct {
 		uses                      string

--- a/github/github_workflows.go
+++ b/github/github_workflows.go
@@ -132,7 +132,10 @@ func ScanGitHubWorkflows(projectPath, defaultBranch, rootDir, apiHost string, en
 	// kind, tag SHA). Best-effort: if gh is not authenticated, the
 	// client operates in degraded mode and leaves metadata empty.
 	if enrichActionMetadata {
-		enrichActionsWithAPIMetadata(pipeline, apiHost, nil)
+		// Plain variant is the test-only entry point; the mutable-exec
+		// source scan (network) is off here, exercised via its own unit
+		// tests and the progress/remote variants used in production.
+		enrichActionsWithAPIMetadata(pipeline, apiHost, false, nil)
 	}
 	return pipeline, partialErrors, nil
 }
@@ -149,7 +152,7 @@ func ScanGitHubWorkflows(projectPath, defaultBranch, rootDir, apiHost string, en
 // (RunGitHubAnalysis) using the same total so the bar keeps
 // climbing. progressFn may be nil; callers that don't care about
 // progress should call the plain ScanGitHubWorkflows variant.
-func ScanGitHubWorkflowsWithProgress(projectPath, defaultBranch, rootDir, apiHost string, enrichActionMetadata bool, progressFn ProgressFunc) (pipeline *ir.NormalizedPipeline, partialErrors []error, err error) {
+func ScanGitHubWorkflowsWithProgress(projectPath, defaultBranch, rootDir, apiHost string, enrichActionMetadata, scanMutableExec bool, progressFn ProgressFunc) (pipeline *ir.NormalizedPipeline, partialErrors []error, err error) {
 	pipeline = &ir.NormalizedPipeline{
 		Provider:      ir.ProviderGitHub,
 		ProjectPath:   projectPath,
@@ -157,8 +160,11 @@ func ScanGitHubWorkflowsWithProgress(projectPath, defaultBranch, rootDir, apiHos
 	}
 	// Producer-side check: if the scanned repo is itself an action whose
 	// own source fetches mutable remote code, flag it. Read from the
-	// local checkout; computed even when the repo has no workflows.
-	pipeline.SelfActionMutableExec = ScanLocalSelfAction(rootDir)
+	// local checkout; computed even when the repo has no workflows. Gated
+	// on the control being active so a disabled control does no scanning.
+	if scanMutableExec {
+		pipeline.SelfActionMutableExec = ScanLocalSelfAction(rootDir)
+	}
 	jobs, partialErrors, err := collectWorkflowJobs(rootDir)
 	if err != nil {
 		return nil, nil, err
@@ -180,7 +186,7 @@ func ScanGitHubWorkflowsWithProgress(projectPath, defaultBranch, rootDir, apiHos
 	total := n + 3
 	report(progressFn, 1, total, "Scanning workflow files")
 	if enrichActionMetadata {
-		enrichActionsWithAPIMetadata(pipeline, apiHost, wrapProgress(progressFn, total))
+		enrichActionsWithAPIMetadata(pipeline, apiHost, scanMutableExec, wrapProgress(progressFn, total))
 	}
 	return pipeline, partialErrors, nil
 }
@@ -279,7 +285,12 @@ func report(fn ProgressFunc, step, total int, message string) {
 // every unique reference so the caller's spinner can track the
 // long phase. Duplicate refs only emit once because the client
 // caches and the enrichment loop iterates actions left to right.
-func enrichActionsWithAPIMetadata(pipeline *ir.NormalizedPipeline, apiHost string, progressFn ProgressFunc) {
+// scanMutableExec gates the per-action source fetch that powers
+// actionsMustNotExecuteMutableRemoteCode (ISSUE-714). When false, the
+// collector skips resolveMutableExec entirely — up to ~7 sequential HTTP
+// requests per unique action — so disabling the control removes its
+// scan-time and rate-limit cost instead of merely hiding the findings.
+func enrichActionsWithAPIMetadata(pipeline *ir.NormalizedPipeline, apiHost string, scanMutableExec bool, progressFn ProgressFunc) {
 	client := NewGitHubMetadataClientForHost(apiHost)
 	if !client.Available() {
 		return
@@ -305,7 +316,10 @@ func enrichActionsWithAPIMetadata(pipeline *ir.NormalizedPipeline, apiHost strin
 				report(progressFn, done, total, fmt.Sprintf("Resolving action %s", action.Uses))
 			}
 			meta := client.Resolve(action.Uses)
-			mre := resolveMutableExec(action.Uses, mreCache)
+			var mre *ir.MutableRemoteExec
+			if scanMutableExec {
+				mre = resolveMutableExec(action.Uses, mreCache)
+			}
 			if isZeroMetadata(meta) && action.Comment == "" && mre == nil {
 				continue
 			}

--- a/github/github_workflows.go
+++ b/github/github_workflows.go
@@ -109,6 +109,10 @@ func ScanGitHubWorkflows(projectPath, defaultBranch, rootDir, apiHost string, en
 		ProjectPath:   projectPath,
 		DefaultBranch: defaultBranch,
 	}
+	// Producer-side check: if the scanned repo is itself an action whose
+	// own source fetches mutable remote code, flag it. Read from the
+	// local checkout; computed even when the repo has no workflows.
+	pipeline.SelfActionMutableExec = ScanLocalSelfAction(rootDir)
 
 	jobs, partialErrors, err := collectWorkflowJobs(rootDir)
 	if err != nil {
@@ -151,6 +155,10 @@ func ScanGitHubWorkflowsWithProgress(projectPath, defaultBranch, rootDir, apiHos
 		ProjectPath:   projectPath,
 		DefaultBranch: defaultBranch,
 	}
+	// Producer-side check: if the scanned repo is itself an action whose
+	// own source fetches mutable remote code, flag it. Read from the
+	// local checkout; computed even when the repo has no workflows.
+	pipeline.SelfActionMutableExec = ScanLocalSelfAction(rootDir)
 	jobs, partialErrors, err := collectWorkflowJobs(rootDir)
 	if err != nil {
 		return nil, nil, err
@@ -285,6 +293,7 @@ func enrichActionsWithAPIMetadata(pipeline *ir.NormalizedPipeline, apiHost strin
 	}
 	total := len(uniqueRefs)
 	seen := map[string]struct{}{}
+	mreCache := map[string]*ir.MutableRemoteExec{}
 	done := 0
 	for i := range pipeline.Jobs {
 		job := &pipeline.Jobs[i]
@@ -296,20 +305,22 @@ func enrichActionsWithAPIMetadata(pipeline *ir.NormalizedPipeline, apiHost strin
 				report(progressFn, done, total, fmt.Sprintf("Resolving action %s", action.Uses))
 			}
 			meta := client.Resolve(action.Uses)
-			if isZeroMetadata(meta) && action.Comment == "" {
+			mre := resolveMutableExec(action.Uses, mreCache)
+			if isZeroMetadata(meta) && action.Comment == "" && mre == nil {
 				continue
 			}
 			amd := &ir.ActionMetadata{
-				RepoArchived:     meta.RepoArchived,
-				RefExists:        meta.RefExists,
-				RefKnownAbsent:   meta.RefKnownAbsent,
-				RefKind:          meta.RefKind,
-				TagSha:           meta.TagSha,
-				LatestTag:        meta.LatestTag,
-				LatestReleaseSha: meta.LatestReleaseSha,
-				RefIsAmbiguous:   meta.RefIsAmbiguous,
-				Advisories:       meta.Advisories,
-				StargazersCount:  meta.StargazersCount,
+				RepoArchived:      meta.RepoArchived,
+				RefExists:         meta.RefExists,
+				RefKnownAbsent:    meta.RefKnownAbsent,
+				RefKind:           meta.RefKind,
+				TagSha:            meta.TagSha,
+				LatestTag:         meta.LatestTag,
+				LatestReleaseSha:  meta.LatestReleaseSha,
+				RefIsAmbiguous:    meta.RefIsAmbiguous,
+				Advisories:        meta.Advisories,
+				StargazersCount:   meta.StargazersCount,
+				MutableRemoteExec: mre,
 			}
 			if action.Comment != "" {
 				amd.CommentVersion = extractVersionFromComment(action.Comment)

--- a/github/github_workflows_remote.go
+++ b/github/github_workflows_remote.go
@@ -27,7 +27,7 @@ import (
 // remote mode — controls that depend on them simply see absent
 // inputs and produce no findings. Same degraded-mode contract as
 // missing API auth elsewhere.
-func ScanGitHubWorkflowsRemote(host, owner, repo, ref string, enrichActionMetadata bool, progressFn ProgressFunc) (*ir.NormalizedPipeline, []error, error) {
+func ScanGitHubWorkflowsRemote(host, owner, repo, ref string, enrichActionMetadata, scanMutableExec bool, progressFn ProgressFunc) (*ir.NormalizedPipeline, []error, error) {
 	if owner == "" || repo == "" {
 		return nil, nil, fmt.Errorf("owner and repo are required for remote scan")
 	}
@@ -40,7 +40,9 @@ func ScanGitHubWorkflowsRemote(host, owner, repo, ref string, enrichActionMetada
 
 	// Producer-side check: if the scanned repo is itself an action whose
 	// own source fetches mutable remote code, flag it (fetched over raw).
-	if host == "" {
+	// Gated on the control being active so a disabled control performs no
+	// network fetch of the repo's own action source.
+	if scanMutableExec && host == "" {
 		pipeline.SelfActionMutableExec = ScanRemoteSelfAction(owner, repo, ref)
 	}
 
@@ -111,7 +113,7 @@ func ScanGitHubWorkflowsRemote(host, owner, repo, ref string, enrichActionMetada
 		// and can switch to the grand total. wrapProgressRemote maps
 		// the enrichment's local 1..M counter into global slots
 		// (2+N)..(1+N+M).
-		enrichActionsWithAPIMetadata(pipeline, host, wrapProgressRemote(progressFn, pipeline))
+		enrichActionsWithAPIMetadata(pipeline, host, scanMutableExec, wrapProgressRemote(progressFn, pipeline))
 	}
 
 	return pipeline, partialErrors, nil

--- a/github/github_workflows_remote.go
+++ b/github/github_workflows_remote.go
@@ -38,6 +38,12 @@ func ScanGitHubWorkflowsRemote(host, owner, repo, ref string, enrichActionMetada
 		DefaultBranch: ref,
 	}
 
+	// Producer-side check: if the scanned repo is itself an action whose
+	// own source fetches mutable remote code, flag it (fetched over raw).
+	if host == "" {
+		pipeline.SelfActionMutableExec = ScanRemoteSelfAction(owner, repo, ref)
+	}
+
 	rest, err := newGitHubRESTClient(host)
 	if err != nil {
 		// ErrAuthRequired carries an actionable multi-line message;

--- a/github/github_workflows_remote_test.go
+++ b/github/github_workflows_remote_test.go
@@ -69,7 +69,7 @@ jobs:
 	defer server.Close()
 	swapRESTClient(t, server)
 
-	pipeline, partial, err := ScanGitHubWorkflowsRemote("", "owner", "repo", "main", false, nil)
+	pipeline, partial, err := ScanGitHubWorkflowsRemote("", "owner", "repo", "main", false, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestScanGitHubWorkflowsRemote_NoWorkflowsDir(t *testing.T) {
 	defer server.Close()
 	swapRESTClient(t, server)
 
-	pipeline, partial, err := ScanGitHubWorkflowsRemote("", "owner", "repo", "main", false, nil)
+	pipeline, partial, err := ScanGitHubWorkflowsRemote("", "owner", "repo", "main", false, false, nil)
 	if err != nil {
 		t.Fatalf("expected nil error on 404, got %v", err)
 	}
@@ -134,7 +134,7 @@ func TestScanGitHubWorkflowsRemote_NonexistentRepoErrors(t *testing.T) {
 	defer server.Close()
 	swapRESTClient(t, server)
 
-	_, _, err := ScanGitHubWorkflowsRemote("", "owner", "repo", "main", false, nil)
+	_, _, err := ScanGitHubWorkflowsRemote("", "owner", "repo", "main", false, false, nil)
 	if err == nil {
 		t.Fatal("expected a hard error for a non-existent repository, got nil (vacuous 100% bug #222)")
 	}
@@ -163,7 +163,7 @@ func TestScanGitHubWorkflowsRemote_NonexistentBranchErrors(t *testing.T) {
 	defer server.Close()
 	swapRESTClient(t, server)
 
-	_, _, err := ScanGitHubWorkflowsRemote("", "owner", "repo", "lolxkdaksjdad", false, nil)
+	_, _, err := ScanGitHubWorkflowsRemote("", "owner", "repo", "lolxkdaksjdad", false, false, nil)
 	if err == nil {
 		t.Fatal("expected a hard error for a non-existent branch, got nil (vacuous 100% bug #222)")
 	}
@@ -201,7 +201,7 @@ jobs:
 	defer server.Close()
 	swapRESTClient(t, server)
 
-	pipeline, partial, err := ScanGitHubWorkflowsRemote("", "owner", "repo", "main", false, nil)
+	pipeline, partial, err := ScanGitHubWorkflowsRemote("", "owner", "repo", "main", false, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected hard error: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestScanGitHubWorkflowsRemote_BadEncoding(t *testing.T) {
 	defer server.Close()
 	swapRESTClient(t, server)
 
-	_, partial, err := ScanGitHubWorkflowsRemote("", "owner", "repo", "", false, nil)
+	_, partial, err := ScanGitHubWorkflowsRemote("", "owner", "repo", "", false, false, nil)
 	if err != nil {
 		t.Fatalf("unexpected hard error: %v", err)
 	}
@@ -240,10 +240,10 @@ func TestScanGitHubWorkflowsRemote_BadEncoding(t *testing.T) {
 }
 
 func TestScanGitHubWorkflowsRemote_RejectsEmptyOwnerOrRepo(t *testing.T) {
-	if _, _, err := ScanGitHubWorkflowsRemote("", "", "repo", "main", false, nil); err == nil {
+	if _, _, err := ScanGitHubWorkflowsRemote("", "", "repo", "main", false, false, nil); err == nil {
 		t.Error("expected error for empty owner")
 	}
-	if _, _, err := ScanGitHubWorkflowsRemote("", "owner", "", "main", false, nil); err == nil {
+	if _, _, err := ScanGitHubWorkflowsRemote("", "owner", "", "main", false, false, nil); err == nil {
 		t.Error("expected error for empty repo")
 	}
 }

--- a/internal/ir/pipeline.go
+++ b/internal/ir/pipeline.go
@@ -23,6 +23,14 @@ type NormalizedPipeline struct {
 	Branches      []Branch          `json:"branches,omitempty"`
 	Dependabot    *DependabotConfig `json:"dependabot,omitempty"`
 
+	// SelfActionMutableExec is set when the scanned repository is itself
+	// a GitHub Action (has an action.yml) whose own source fetches and
+	// executes mutable remote code at runtime. This is the producer-side
+	// counterpart of the per-`uses:` action.metadata.mutableRemoteExec:
+	// scanning the action's own repo must flag that the action it
+	// publishes is the mutable-remote-exec vector. Nil otherwise.
+	SelfActionMutableExec *MutableRemoteExec `json:"selfActionMutableExec,omitempty"`
+
 	// WorkflowFileCount is the number of workflow files the GitHub
 	// collector fetched in remote (--github-url) mode. Used by
 	// TotalProgressStepsForPipeline to size the progress bar across
@@ -271,6 +279,28 @@ type ActionMetadata struct {
 	// threshold. Zero when enrichment did not run or the repo was
 	// unreachable — policies must abstain rather than flag on absence.
 	StargazersCount int `json:"stargazersCount,omitempty"`
+	// MutableRemoteExec, when set, records that the action's own source
+	// fetches code or a download-steering manifest from a MOVING ref
+	// (main/master/HEAD/…) at runtime — so pinning this action by SHA
+	// does not make its execution immutable. Nil when the source was not
+	// analysed (offline, non-github.com host, trusted owner) or nothing
+	// mutable was found. Consumed by the mutable-remote-exec control.
+	MutableRemoteExec *MutableRemoteExec `json:"mutableRemoteExec,omitempty"`
+}
+
+// MutableRemoteExec describes a mutable-remote-code signal found inside
+// a third-party action's own source. Tier separates the two risk levels
+// the control reports:
+//
+//   - "exec" — a script (.sh/.py/…) fetched from a moving ref and
+//     executed, or a `curl … | sh` pipe. Direct remote code execution.
+//   - "data" — a data manifest (.json/.yaml) pulled from a moving ref
+//     that steers a later binary download. Weaker: not executed itself.
+type MutableRemoteExec struct {
+	Tier string `json:"tier"`
+	URL  string `json:"url"`
+	Ref  string `json:"ref,omitempty"`
+	File string `json:"file"`
 }
 
 // Image references a container image (job image, service, step base).

--- a/policies/action_mutable_remote_exec.rego
+++ b/policies/action_mutable_remote_exec.rego
@@ -1,0 +1,95 @@
+# action-mutable-remote-exec — a third-party action's OWN source fetches
+# and runs code from a moving ref at runtime, so pinning the action by SHA
+# does not make its execution immutable (the anchore/scan-action → grype
+# case). Driven by the collector's per-action source analysis, exposed on
+# the IR as action.metadata.mutableRemoteExec (consumer side) and
+# pipeline.selfActionMutableExec (producer side: the scanned repo IS the
+# action).
+#
+# Graded by INTENT-TO-HIDE and VERIFIABILITY, not by a single flat
+# severity — a static text match on an unbounded evasion space cannot
+# prove absence, so:
+#
+#   ISSUE-715 critical — "obfuscated": decode-then-exec / eval(atob). No
+#                        legitimate action hides what it runs. Hiding IS
+#                        the finding; this is host/ref/encoding-agnostic.
+#   ISSUE-714 high     — "exec": a script fetched from a moving ref and
+#                        run, in the open, with NO checksum. A clean
+#                        result asserts "no known pattern seen", not
+#                        "safe". A checksum-verified fetch is content-
+#                        pinned and is NOT flagged.
+#   ISSUE-716 low      — "unverified": the source could not be fetched
+#                        (offline/GHES/private/rate-limit/Docker-image).
+#                        Surfaced as could-not-verify, never a silent pass.
+package action_mutable_remote_exec
+
+import rego.v1
+
+# _signals unifies every mutable-remote-exec signal: one per used action
+# that carries one (consumer side) plus the scanned repo's own action
+# (producer side).
+_signals contains sig if {
+	some i, j
+	job := input.pipeline.jobs[i]
+	action := job.uses[j]
+	mre := action.metadata.mutableRemoteExec
+	sig := {
+		"tier": mre.tier,
+		"url":  object.get(mre, "url", ""),
+		"who":  sprintf("action %q (used by job %q)", [action.uses, job.name]),
+		"job":  job.name,
+		"uses": action.uses,
+		"line": object.get(action, "line", 0),
+	}
+}
+
+_signals contains sig if {
+	mre := input.pipeline.selfActionMutableExec
+	sig := {
+		"tier": mre.tier,
+		"url":  object.get(mre, "url", ""),
+		"who":  "the action published by this repository",
+		"job":  "",
+		"uses": "",
+		"line": 0,
+	}
+}
+
+deny contains finding if {
+	some sig in _signals
+	sig.tier == "obfuscated"
+	finding := {
+		"code":     "ISSUE-715",
+		"severity": "critical",
+		"message":  sprintf("%s obfuscates a remote code fetch/exec (`%s`) — hiding what an action runs at runtime is treated as the strongest signal, whatever host/ref/encoding is used", [sig.who, sig.url]),
+		"job":      sig.job,
+		"uses":     sig.uses,
+		"line":     sig.line,
+	}
+}
+
+deny contains finding if {
+	some sig in _signals
+	sig.tier == "exec"
+	finding := {
+		"code":     "ISSUE-714",
+		"severity": "high",
+		"message":  sprintf("%s fetches and runs remote code from a mutable ref with no checksum (`%s`) — a SHA pin on the action does not reach this; a clean result means \"no known pattern seen\", not \"safe\"", [sig.who, sig.url]),
+		"job":      sig.job,
+		"uses":     sig.uses,
+		"line":     sig.line,
+	}
+}
+
+deny contains finding if {
+	some sig in _signals
+	sig.tier == "unverified"
+	finding := {
+		"code":     "ISSUE-716",
+		"severity": "low",
+		"message":  sprintf("%s: could not fetch the action source to verify it (offline, GHES, private, rate-limited, or a Docker-image action) — reported as could-not-verify, not a pass", [sig.who]),
+		"job":      sig.job,
+		"uses":     sig.uses,
+		"line":     sig.line,
+	}
+}

--- a/policies/rules_test.go
+++ b/policies/rules_test.go
@@ -3969,6 +3969,98 @@ func TestIssue114_KnownVulnerableAction(t *testing.T) {
 	})
 }
 
+// TestIssue714_MutableRemoteExec locks in the graduated mutable-remote-exec
+// rule: the tier keys the code — exec→ISSUE-714 (high), obfuscated→ISSUE-715
+// (critical), unverified→ISSUE-716 (low) — for both the consumer side
+// (a used action) and the producer side (the scanned repo IS the action).
+// The "data" tier and a missing signal stay silent.
+func TestIssue714_MutableRemoteExec(t *testing.T) {
+	engine := opaengine.New()
+	if err := engine.LoadFromFS(policies.FS); err != nil {
+		t.Fatalf("load embedded policies: %v", err)
+	}
+
+	codeHits := func(pipeline *ir.NormalizedPipeline, code string) (int, string) {
+		findings, err := engine.Evaluate(context.Background(), pipeline, nil)
+		if err != nil {
+			t.Fatalf("evaluate: %v", err)
+		}
+		hits, msg := 0, ""
+		for _, f := range findings {
+			if f.Code == code {
+				hits++
+				msg = f.Message
+			}
+		}
+		return hits, msg
+	}
+
+	consumer := func(tier, url string) *ir.NormalizedPipeline {
+		return &ir.NormalizedPipeline{
+			Provider: ir.ProviderGitHub,
+			Jobs: []ir.Job{{
+				Name: "build",
+				Uses: []ir.Action{{
+					Uses:     "vendor/action@v1",
+					Metadata: &ir.ActionMetadata{MutableRemoteExec: &ir.MutableRemoteExec{Tier: tier, URL: url}},
+				}},
+			}},
+		}
+	}
+	producer := func(tier, url string) *ir.NormalizedPipeline {
+		return &ir.NormalizedPipeline{
+			Provider:              ir.ProviderGitHub,
+			SelfActionMutableExec: &ir.MutableRemoteExec{Tier: tier, URL: url},
+		}
+	}
+
+	t.Run("exec → ISSUE-714 high (consumer & producer)", func(t *testing.T) {
+		u := "raw.githubusercontent.com/anchore/grype/main/install.sh"
+		if h, msg := codeHits(consumer("exec", u), "ISSUE-714"); h != 1 || !strings.Contains(msg, u) {
+			t.Fatalf("consumer exec: hits=%d msg=%q", h, msg)
+		}
+		if h, _ := codeHits(producer("exec", u), "ISSUE-714"); h != 1 {
+			t.Fatalf("producer exec: want 1 ISSUE-714, got %d", h)
+		}
+	})
+
+	t.Run("obfuscated → ISSUE-715 critical (consumer & producer)", func(t *testing.T) {
+		if h, _ := codeHits(consumer("obfuscated", "base64 -d | sh"), "ISSUE-715"); h != 1 {
+			t.Fatalf("consumer obfuscated: want 1 ISSUE-715, got %d", h)
+		}
+		// obfuscated must NOT also fire the high exec code
+		if h, _ := codeHits(consumer("obfuscated", "x"), "ISSUE-714"); h != 0 {
+			t.Fatalf("obfuscated must not fire ISSUE-714, got %d", h)
+		}
+		if h, _ := codeHits(producer("obfuscated", "eval(atob(x))"), "ISSUE-715"); h != 1 {
+			t.Fatalf("producer obfuscated: want 1 ISSUE-715, got %d", h)
+		}
+	})
+
+	t.Run("unverified → ISSUE-716 low, never a pass", func(t *testing.T) {
+		if h, _ := codeHits(consumer("unverified", ""), "ISSUE-716"); h != 1 {
+			t.Fatalf("consumer unverified: want 1 ISSUE-716, got %d", h)
+		}
+	})
+
+	t.Run("data tier and absent signal stay silent", func(t *testing.T) {
+		for _, code := range []string{"ISSUE-714", "ISSUE-715", "ISSUE-716"} {
+			if h, _ := codeHits(consumer("data", "x"), code); h != 0 {
+				t.Fatalf("data tier fired %s (%d)", code, h)
+			}
+		}
+		absent := &ir.NormalizedPipeline{
+			Provider: ir.ProviderGitHub,
+			Jobs:     []ir.Job{{Name: "b", Uses: []ir.Action{{Uses: "actions/checkout@v4", Metadata: &ir.ActionMetadata{RefKind: "tag"}}}}},
+		}
+		for _, code := range []string{"ISSUE-714", "ISSUE-715", "ISSUE-716"} {
+			if h, _ := codeHits(absent, code); h != 0 {
+				t.Fatalf("absent signal fired %s (%d)", code, h)
+			}
+		}
+	})
+}
+
 // TestIssue108_ActionArchivedRepo locks in the three branches of the
 // archived-repo rule: archived=true positive, archived=false negative,
 // and missing-metadata silent abstain (no false positive when the


### PR DESCRIPTION
Implements #295.

## Problem

`actionsMustBePinnedByCommitSha` (ISSUE-701) checks that a `uses:` ref is an
immutable SHA — but pinning the ref does not pin the *execution*. An action can
be SHA-pinned and still fetch and run a script from a **moving ref** at runtime,
so the code actually executed changes with nothing committed where the pin can
see it. The canonical case is `anchore/scan-action`, which runs
`raw.githubusercontent.com/anchore/grype/main/install.sh`.

## What this adds

New control `actionsMustNotExecuteMutableRemoteCode`, with two findings keyed to
blast radius:

- **ISSUE-714 (high)** — a workflow *uses* such an action (consumer side).
- **ISSUE-715 (critical)** — the scanned repo *is* such an action (producer
  side). A flaw in a published action reaches every consumer that pins it, so it
  is scored via the Critical malus (an action that fetches mutable remote code no
  longer earns an A).

The collector fetches each third-party action's own source (`action.yml` +
entrypoint, at the pinned ref, over raw content to clear the 1 MB contents-API
cap), memoised per `uses:`, and scans it in two tiers:

- **exec** (RED, surfaced): a script (`.sh`/`.py`/…) fetched from a moving ref
  and executed, or a `curl … | sh` pipe.
- **data** (recorded, not yet surfaced): a mutable manifest steering a download
  (e.g. docker/actions-toolkit release manifest) — weaker, kept separate to
  avoid noise.

Also covered: subpath actions (`owner/repo/subpath@ref`); reusable-workflow calls
are skipped (not actions); first-party owners (`actions/`, `github/`) skipped;
`PLUMBER_DISABLE_GITHUB_API` honoured so the source fetch stays offline.

## Verification

- `plumber analyze --project anchore/scan-action` → **ISSUE-715 critical, letter E** (was A).
- A workflow using `CodSpeedHQ/action` (`curl | bash`) → ISSUE-714; `docker/*`
  and `actions/checkout` stay silent.
- Census of 116 unique third-party actions across 55 real repos: 1 exec-tier, 3
  data-tier, no false positive on the rest.
- Pure-function scan tests (grype exec, curl|sh, docker data, subpath, pinned/
  clean negatives) + rego tests (consumer high, producer critical, absent
  abstains). `make build && make test && make lint` green.

## Follow-ups (out of scope)

Docker-image actions (`RUN curl|sh` in the Dockerfile), GitHub Enterprise /
private hosts, and surfacing the data tier.

> **Note:** If you submit a PR for this feature, please keep "Allow edits from maintainers" enabled so we can collaborate more easily.