### PR TITLE
fix(ci): Fix typo in ci to always rebuild runtime allowing update to layers. Necessary for security updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,7 +255,7 @@ jobs:
           # current OS security fixes; the cached `builder` stage keeps Go builds
           # fast. Without this the runtime layer is restored from gha cache release
           # after release and ships stale openssl/curl/git.
-          no-cache-filter: runtime
+          no-cache-filters: runtime
 
       - name: Attest Docker image
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1


### PR DESCRIPTION
<img width="1440" height="785" alt="image" src="https://github.com/user-attachments/assets/6ddb3a01-9dd5-4081-bea5-e358b8f66494" />


Failing here: https://github.com/getplumber/plumber/actions/runs/28788875179/job/85362310154