### PR TITLE
chore: input-handling hardening

### DIFF
--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -1302,7 +1302,7 @@ func printNoControlsWarning(result *control.AnalysisResult) {
 		fmt.Printf(fmtIndentLine, styleError.Render("CI configuration errors:"))
 		bullet := styleError.Render("•")
 		for _, e := range result.CiErrors {
-			fmt.Printf("    %s %s\n", bullet, e)
+			fmt.Printf("    %s %s\n", bullet, sanitizeTerminal(e))
 		}
 		fmt.Println()
 		return

--- a/cmd/render_details.go
+++ b/cmd/render_details.go
@@ -70,7 +70,7 @@ func renderWarnings(warnings []string) {
 	fmt.Println()
 	fmt.Printf("  %s⚠ Could not verify %d item(s):%s\n", colorYellow, len(warnings), colorReset)
 	for _, w := range warnings {
-		fmt.Printf("    %s•%s %s\n", colorYellow, colorReset, w)
+		fmt.Printf("    %s•%s %s\n", colorYellow, colorReset, sanitizeTerminal(w))
 	}
 	// When a version stays unresolved (the authenticated read was blocked and
 	// the anonymous fallback did not succeed), a user-supplied token resolves

--- a/cmd/render_details.go
+++ b/cmd/render_details.go
@@ -88,7 +88,7 @@ func renderDegradedCaveat(reasons []string) {
 	}
 	fmt.Printf("  %s⚠ Data collection was incomplete — results may be partial:%s\n", colorYellow, colorReset)
 	for _, r := range reasons {
-		fmt.Printf("    %s•%s %s\n", colorYellow, colorReset, r)
+		fmt.Printf("    %s•%s %s\n", colorYellow, colorReset, sanitizeTerminal(r))
 	}
 	fmt.Printf("    %s↳ controls with un-collected data are marked \"not evaluated\"; the letter score is withheld until the run completes cleanly.%s\n\n", colorDim, colorReset)
 }

--- a/configuration/plumberconfig.go
+++ b/configuration/plumberconfig.go
@@ -5,9 +5,14 @@ import (
 	"os"
 	"sort"
 
+	"github.com/getplumber/plumber/utils"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
+
+// maxConfigFileBytes bounds a .plumber.yaml read. The config is read from the
+// analyzed repository, so its size is not trusted.
+const maxConfigFileBytes = 2 << 20 // 2 MiB
 
 // validControlSchema maps each known control name to its valid sub-keys.
 // When adding a new control, add its entry here to enable validation.
@@ -773,7 +778,7 @@ func LoadPlumberConfig(configPath string) (*PlumberConfig, string, []string, err
 	l = l.WithField("configPath", configPath)
 	l.Info("Loading configuration from file")
 
-	data, err := os.ReadFile(configPath)
+	data, err := utils.ReadFileLimit(configPath, maxConfigFileBytes)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, configPath, nil, fmt.Errorf("config file not found: %s", configPath)

--- a/control/mrcomment.go
+++ b/control/mrcomment.go
@@ -240,7 +240,7 @@ func generateMRComment(result *AnalysisResult, pc *configuration.PlumberConfig, 
 // tabs become spaces) and Markdown-active characters are backslash-escaped so
 // the text renders literally.
 func sanitizeMarkdownInline(s string) string {
-	const escaped = "\\`*_[]()<>|~"
+	const escaped = "\\`*_[]()<>|~@#!%$"
 	var b strings.Builder
 	b.Grow(len(s))
 	for _, r := range s {

--- a/control/mrcomment_sanitize_test.go
+++ b/control/mrcomment_sanitize_test.go
@@ -42,6 +42,15 @@ func TestSanitizeMarkdownInline(t *testing.T) {
 		}
 	})
 
+	t.Run("mention and reference chars are escaped", func(t *testing.T) {
+		got := sanitizeMarkdownInline("ping @all see #123 and !45 for 50% $x")
+		for _, sub := range []string{`\@`, `\#`, `\!`, `\%`, `\$`} {
+			if !strings.Contains(got, sub) {
+				t.Fatalf("expected %q escaped in %q", sub, got)
+			}
+		}
+	})
+
 	t.Run("plain text is preserved verbatim", func(t *testing.T) {
 		in := "Job build uses a mutable tag"
 		if got := sanitizeMarkdownInline(in); got != in {

--- a/control/task.go
+++ b/control/task.go
@@ -451,11 +451,18 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 			clearProgressLine(conf)
 			fmt.Fprintf(os.Stderr, "Using local CI configuration (specify --branch to force upstream CI config fetch): %s\n", localCIPath)
 			l.WithField("localCIPath", localCIPath).Info("Using local CI configuration file")
+		} else if os.IsNotExist(err) {
+			l.WithField("localCIPath", localCIPath).Debug("Local CI config file not found, will use remote")
 		} else {
+			// The file is present but could not be read (e.g. it exceeds the
+			// size limit). Surface it instead of silently scoring against the
+			// remote CI as though no local file existed.
+			clearProgressLine(conf)
+			fmt.Fprintf(os.Stderr, "Local CI configuration at %s could not be read (%v); using remote CI configuration instead\n", localCIPath, err)
 			l.WithFields(logrus.Fields{
 				"localCIPath": localCIPath,
 				"error":       err,
-			}).Debug("Local CI config file not found, will use remote")
+			}).Warn("Local CI config file present but unreadable; using remote")
 		}
 	} else if conf.Branch != "" {
 		clearProgressLine(conf)

--- a/control/task.go
+++ b/control/task.go
@@ -11,8 +11,13 @@ import (
 	opaengine "github.com/getplumber/plumber/internal/engine/opa"
 	"github.com/getplumber/plumber/internal/ir"
 	"github.com/getplumber/plumber/policies"
+	"github.com/getplumber/plumber/utils"
 	"github.com/sirupsen/logrus"
 )
+
+// maxLocalCIConfigBytes bounds a local .gitlab-ci.yml read from the analyzed
+// repository, whose size is not trusted.
+const maxLocalCIConfigBytes = 2 << 20 // 2 MiB
 
 // opaEvaluateTimeout bounds a single Rego/OPA evaluation. Policy evaluation
 // over a normal pipeline is sub-second; this ceiling only exists so a
@@ -440,7 +445,7 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 				"ciConfPath": project.CiConfPath,
 				"error":      cErr,
 			}).Warn("Local CI config path escapes the repository; using remote")
-		} else if content, err := os.ReadFile(localCIPath); err == nil {
+		} else if content, err := utils.ReadFileLimit(localCIPath, maxLocalCIConfigBytes); err == nil {
 			conf.LocalCIConfigContent = content
 			conf.UsingLocalCIConfig = true
 			clearProgressLine(conf)

--- a/github/github_workflows.go
+++ b/github/github_workflows.go
@@ -45,6 +45,54 @@ const (
 	fmtFileErr = "%s: %w"
 )
 
+// collectWorkflowJobs reads every .yml/.yaml file under
+// <rootDir>/.github/workflows/ and returns the parsed jobs, sorted by
+// name. A missing workflows directory — or one that resolves outside
+// the repository (e.g. a committed symlink) — is not an error: the
+// scan simply carries no jobs, and the caller still collects the
+// repository-level artifacts (dependabot, Renovate, security policy,
+// Dockerfiles) that do not depend on that directory. Individual
+// unreadable or unparseable files land in partialErrors so the caller
+// can surface them without aborting the whole scan.
+func collectWorkflowJobs(rootDir string) (jobs []ir.Job, partialErrors []error, err error) {
+	dir, ok := resolveWithinRoot(rootDir, githubWorkflowsSubdir)
+	if !ok {
+		return nil, nil, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf(fmtReadErr, dir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".yml") && !strings.HasSuffix(name, ".yaml") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		data, readErr := utils.ReadFileLimit(path, maxWorkflowFileBytes)
+		if readErr != nil {
+			partialErrors = append(partialErrors, fmt.Errorf(fmtFileErr, name, readErr))
+			continue
+		}
+		fileJobs, parseErr := parseGitHubWorkflowJobs(data, workflowBaseName(name), path)
+		if parseErr != nil {
+			partialErrors = append(partialErrors, fmt.Errorf(fmtFileErr, name, parseErr))
+			continue
+		}
+		jobs = append(jobs, fileJobs...)
+	}
+	sort.Slice(jobs, func(i, j int) bool {
+		return jobs[i].Name < jobs[j].Name
+	})
+	return jobs, partialErrors, nil
+}
+
 // ScanGitHubWorkflows reads every .yml/.yaml file under
 // <rootDir>/.github/workflows/ and aggregates them into a single
 // NormalizedPipeline. Job names are namespaced by the workflow file base
@@ -62,43 +110,12 @@ func ScanGitHubWorkflows(projectPath, defaultBranch, rootDir, apiHost string, en
 		DefaultBranch: defaultBranch,
 	}
 
-	dir, ok := resolveWithinRoot(rootDir, githubWorkflowsSubdir)
-	if !ok {
-		return pipeline, nil, nil
-	}
-	entries, err := os.ReadDir(dir)
+	jobs, partialErrors, err := collectWorkflowJobs(rootDir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return pipeline, nil, nil
-		}
-		return nil, nil, fmt.Errorf(fmtReadErr, dir, err)
+		return nil, nil, err
 	}
+	pipeline.Jobs = jobs
 
-	for _, entry := range entries {
-		if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
-			continue
-		}
-		name := entry.Name()
-		if !strings.HasSuffix(name, ".yml") && !strings.HasSuffix(name, ".yaml") {
-			continue
-		}
-		path := filepath.Join(dir, name)
-		data, readErr := utils.ReadFileLimit(path, maxWorkflowFileBytes)
-		if readErr != nil {
-			partialErrors = append(partialErrors, fmt.Errorf(fmtFileErr, name, readErr))
-			continue
-		}
-		jobs, parseErr := parseGitHubWorkflowJobs(data, workflowBaseName(name), path)
-		if parseErr != nil {
-			partialErrors = append(partialErrors, fmt.Errorf(fmtFileErr, name, parseErr))
-			continue
-		}
-		pipeline.Jobs = append(pipeline.Jobs, jobs...)
-	}
-
-	sort.Slice(pipeline.Jobs, func(i, j int) bool {
-		return pipeline.Jobs[i].Name < pipeline.Jobs[j].Name
-	})
 	if dcfg, derr := scanDependabotConfig(rootDir); derr != nil {
 		partialErrors = append(partialErrors, derr)
 	} else if dcfg != nil {
@@ -134,41 +151,11 @@ func ScanGitHubWorkflowsWithProgress(projectPath, defaultBranch, rootDir, apiHos
 		ProjectPath:   projectPath,
 		DefaultBranch: defaultBranch,
 	}
-	dir, ok := resolveWithinRoot(rootDir, githubWorkflowsSubdir)
-	if !ok {
-		return pipeline, nil, nil
-	}
-	entries, err := os.ReadDir(dir)
+	jobs, partialErrors, err := collectWorkflowJobs(rootDir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return pipeline, nil, nil
-		}
-		return nil, nil, fmt.Errorf(fmtReadErr, dir, err)
+		return nil, nil, err
 	}
-	for _, entry := range entries {
-		if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
-			continue
-		}
-		name := entry.Name()
-		if !strings.HasSuffix(name, ".yml") && !strings.HasSuffix(name, ".yaml") {
-			continue
-		}
-		path := filepath.Join(dir, name)
-		data, readErr := utils.ReadFileLimit(path, maxWorkflowFileBytes)
-		if readErr != nil {
-			partialErrors = append(partialErrors, fmt.Errorf(fmtFileErr, name, readErr))
-			continue
-		}
-		jobs, parseErr := parseGitHubWorkflowJobs(data, workflowBaseName(name), path)
-		if parseErr != nil {
-			partialErrors = append(partialErrors, fmt.Errorf(fmtFileErr, name, parseErr))
-			continue
-		}
-		pipeline.Jobs = append(pipeline.Jobs, jobs...)
-	}
-	sort.Slice(pipeline.Jobs, func(i, j int) bool {
-		return pipeline.Jobs[i].Name < pipeline.Jobs[j].Name
-	})
+	pipeline.Jobs = jobs
 	if dcfg, derr := scanDependabotConfig(rootDir); derr != nil {
 		partialErrors = append(partialErrors, derr)
 	} else if dcfg != nil {

--- a/github/github_workflows.go
+++ b/github/github_workflows.go
@@ -16,6 +16,30 @@ import (
 
 const githubWorkflowsSubdir = ".github/workflows"
 
+// maxWorkflowFileBytes bounds a single workflow / dependabot file read.
+const maxWorkflowFileBytes = 1 << 20 // 1 MiB
+
+// resolveWithinRoot joins relParts onto rootDir and returns the path only when
+// it resolves inside rootDir, with symlinks resolved on both sides. ok is false
+// when the path escapes the repository (e.g. a committed symlink), so the
+// caller ignores it rather than reading outside the checkout.
+func resolveWithinRoot(rootDir string, relParts ...string) (string, bool) {
+	rootReal := rootDir
+	if r, err := filepath.EvalSymlinks(rootDir); err == nil {
+		rootReal = r
+	}
+	joined := filepath.Join(append([]string{rootReal}, relParts...)...)
+	targetReal := joined
+	if r, err := filepath.EvalSymlinks(joined); err == nil {
+		targetReal = r
+	}
+	rel, err := filepath.Rel(rootReal, targetReal)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return joined, false
+	}
+	return joined, true
+}
+
 const (
 	fmtReadErr = "read %s: %w"
 	fmtFileErr = "%s: %w"
@@ -38,7 +62,10 @@ func ScanGitHubWorkflows(projectPath, defaultBranch, rootDir, apiHost string, en
 		DefaultBranch: defaultBranch,
 	}
 
-	dir := filepath.Join(rootDir, githubWorkflowsSubdir)
+	dir, ok := resolveWithinRoot(rootDir, githubWorkflowsSubdir)
+	if !ok {
+		return pipeline, nil, nil
+	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -48,7 +75,7 @@ func ScanGitHubWorkflows(projectPath, defaultBranch, rootDir, apiHost string, en
 	}
 
 	for _, entry := range entries {
-		if entry.IsDir() {
+		if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
 			continue
 		}
 		name := entry.Name()
@@ -56,7 +83,7 @@ func ScanGitHubWorkflows(projectPath, defaultBranch, rootDir, apiHost string, en
 			continue
 		}
 		path := filepath.Join(dir, name)
-		data, readErr := os.ReadFile(path)
+		data, readErr := utils.ReadFileLimit(path, maxWorkflowFileBytes)
 		if readErr != nil {
 			partialErrors = append(partialErrors, fmt.Errorf(fmtFileErr, name, readErr))
 			continue
@@ -107,7 +134,10 @@ func ScanGitHubWorkflowsWithProgress(projectPath, defaultBranch, rootDir, apiHos
 		ProjectPath:   projectPath,
 		DefaultBranch: defaultBranch,
 	}
-	dir := filepath.Join(rootDir, githubWorkflowsSubdir)
+	dir, ok := resolveWithinRoot(rootDir, githubWorkflowsSubdir)
+	if !ok {
+		return pipeline, nil, nil
+	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -116,7 +146,7 @@ func ScanGitHubWorkflowsWithProgress(projectPath, defaultBranch, rootDir, apiHos
 		return nil, nil, fmt.Errorf(fmtReadErr, dir, err)
 	}
 	for _, entry := range entries {
-		if entry.IsDir() {
+		if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
 			continue
 		}
 		name := entry.Name()
@@ -124,7 +154,7 @@ func ScanGitHubWorkflowsWithProgress(projectPath, defaultBranch, rootDir, apiHos
 			continue
 		}
 		path := filepath.Join(dir, name)
-		data, readErr := os.ReadFile(path)
+		data, readErr := utils.ReadFileLimit(path, maxWorkflowFileBytes)
 		if readErr != nil {
 			partialErrors = append(partialErrors, fmt.Errorf(fmtFileErr, name, readErr))
 			continue
@@ -356,8 +386,11 @@ type ghDependabotConfig struct {
 // is (nil, nil) and the pipeline simply carries no dependabot data.
 func scanDependabotConfig(rootDir string) (*ir.DependabotConfig, error) {
 	for _, name := range []string{"dependabot.yml", "dependabot.yaml"} {
-		path := filepath.Join(rootDir, ".github", name)
-		data, err := os.ReadFile(path)
+		path, ok := resolveWithinRoot(rootDir, ".github", name)
+		if !ok {
+			continue
+		}
+		data, err := utils.ReadFileLimit(path, maxWorkflowFileBytes)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue

--- a/github/github_workflows_symlink_test.go
+++ b/github/github_workflows_symlink_test.go
@@ -46,6 +46,47 @@ func TestScanGitHubWorkflowsSkipsSymlink(t *testing.T) {
 	}
 }
 
+// TestScanGitHubWorkflowsSymlinkedDirStillScansArtifacts verifies that a
+// workflows directory symlinked outside the repository is ignored without
+// aborting the rest of the scan: repository-level artifacts (dependabot
+// config, security policy, ...) are still collected.
+func TestScanGitHubWorkflowsSymlinkedDirStillScansArtifacts(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	ghDir := filepath.Join(root, ".github")
+	if err := os.MkdirAll(ghDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	outsideWfDir := filepath.Join(outside, "workflows")
+	if err := os.MkdirAll(outsideWfDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWriteFile(t, filepath.Join(outsideWfDir, "evil.yml"),
+		"name: leaked\non: push\njobs:\n  SHOULDNOTAPPEAR:\n    runs-on: x\n    steps:\n      - run: echo x\n")
+	if err := os.Symlink(outsideWfDir, filepath.Join(ghDir, "workflows")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	mustWriteFile(t, filepath.Join(ghDir, "dependabot.yml"),
+		"updates:\n  - package-ecosystem: npm\n    insecure-external-code-execution: allow\n")
+	mustWriteFile(t, filepath.Join(root, "SECURITY.md"), "# security\n")
+
+	pipeline, _, err := ScanGitHubWorkflows("o/r", "main", root, "github.com", false)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(pipeline.Jobs) != 0 {
+		t.Fatalf("symlinked workflows dir should yield no jobs, got %+v", pipeline.Jobs)
+	}
+	if pipeline.Dependabot == nil {
+		t.Fatal("dependabot config should still be scanned when the workflows dir is rejected")
+	}
+	if pipeline.SecurityPolicyPath == "" {
+		t.Fatal("security policy should still be scanned when the workflows dir is rejected")
+	}
+}
+
 // TestScanGitHubWorkflowsCapsSize verifies an oversized workflow file is not
 // read into the pipeline (bounded read).
 func TestScanGitHubWorkflowsCapsSize(t *testing.T) {

--- a/github/github_workflows_symlink_test.go
+++ b/github/github_workflows_symlink_test.go
@@ -1,0 +1,71 @@
+package github
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestScanGitHubWorkflowsSkipsSymlink verifies that a committed symlinked
+// workflow file is not followed out of the repository, while a real in-repo
+// workflow is still scanned.
+func TestScanGitHubWorkflowsSkipsSymlink(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	wfDir := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(wfDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	mustWriteFile(t, filepath.Join(wfDir, "ci.yml"),
+		"name: ci\non: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n")
+
+	secret := filepath.Join(outside, "secret.yml")
+	mustWriteFile(t, secret,
+		"name: leaked\non: push\njobs:\n  SHOULDNOTAPPEAR:\n    runs-on: x\n    steps:\n      - run: echo x\n")
+	if err := os.Symlink(secret, filepath.Join(wfDir, "evil.yml")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	pipeline, _, err := ScanGitHubWorkflows("o/r", "main", root, "github.com", false)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	foundLegit := false
+	for _, j := range pipeline.Jobs {
+		if strings.Contains(j.Name, "SHOULDNOTAPPEAR") || strings.Contains(j.Name, "evil") {
+			t.Fatalf("symlinked workflow was scanned: %q", j.Name)
+		}
+		if strings.Contains(j.Name, "build") {
+			foundLegit = true
+		}
+	}
+	if !foundLegit {
+		t.Fatalf("legit in-repo workflow not scanned; jobs=%+v", pipeline.Jobs)
+	}
+}
+
+// TestScanGitHubWorkflowsCapsSize verifies an oversized workflow file is not
+// read into the pipeline (bounded read).
+func TestScanGitHubWorkflowsCapsSize(t *testing.T) {
+	root := t.TempDir()
+	wfDir := filepath.Join(root, ".github", "workflows")
+	if err := os.MkdirAll(wfDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	big := make([]byte, maxWorkflowFileBytes+1)
+	if err := os.WriteFile(filepath.Join(wfDir, "big.yml"), big, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pipeline, partial, err := ScanGitHubWorkflows("o/r", "main", root, "github.com", false)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(pipeline.Jobs) != 0 {
+		t.Fatalf("oversized workflow should yield no jobs, got %d", len(pipeline.Jobs))
+	}
+	if len(partial) == 0 {
+		t.Fatal("expected a partial error for the oversized workflow")
+	}
+}

--- a/utils/fileio.go
+++ b/utils/fileio.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// ReadFileLimit reads a file but returns an error if it exceeds max bytes,
+// bounding memory when reading files whose size is not trusted. The open error
+// is returned unwrapped so callers can still use os.IsNotExist.
+func ReadFileLimit(path string, max int64) ([]byte, error) {
+	f, err := os.Open(path) //nolint:gosec // callers pass validated or known paths
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	data, err := io.ReadAll(io.LimitReader(f, max+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > max {
+		return nil, fmt.Errorf("%s exceeds the %d-byte limit", path, max)
+	}
+	return data, nil
+}


### PR DESCRIPTION
## Summary
A set of small, independent hardening changes to how repository-supplied inputs are read and rendered. No behavior change for well-formed inputs; each change ships with regression tests.

## Changes (one per commit)
- Constrain workflow and dependabot file collection to the repository, skip symlinked entries, and bound read size.
- Neutralize control characters in repo-derived verification-warning output.
- Neutralize control characters in repo-derived degraded-reason and CI-error output.
- Bound `.plumber.yaml` and local CI-config reads by size.
- Escape additional characters in repo-derived merge-request comment text.