### PR TITLE
feat(gate)!: gate runs on the Plumber Score, drop the compliance percentage

### DIFF
--- a/.github/workflows/plumber-action.yml
+++ b/.github/workflows/plumber-action.yml
@@ -1,6 +1,6 @@
 # Runs Plumber on this repository the same way a user would: it analyzes the
 # repo's own workflows, uploads findings to Code Scanning (Security tab), and
-# fails the job when compliance is below threshold. Findings are uploaded even
+# fails the job when the Plumber Score is below the gate. Findings are uploaded even
 # when the scan fails, so the Security tab always reflects the latest state.
 #
 # Plumber is built from source so the gate tracks the code in this repo (the
@@ -56,7 +56,6 @@ jobs:
             --output plumber-report.json \
             --score-point \
             --score-push \
-            --threshold 100 \
             --fail-warnings
 
       - name: Upload SARIF to Code Scanning
@@ -79,8 +78,8 @@ jobs:
             plumber-report.json
           if-no-files-found: warn
 
-      - name: Enforce compliance threshold
+      - name: Enforce score gate
         if: ${{ always() && steps.analyze.outcome == 'failure' }}
         run: |
-          echo "::error::Plumber failed: compliance below threshold, or a check could not be verified with --fail-warnings (exit 3). See the analyze step log and the Security tab."
+          echo "::error::Plumber failed: the Plumber Score is below the gate, or a check could not be verified with --fail-warnings (exit 3). See the analyze step log and the Security tab."
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,7 +309,7 @@ jobs:
           # frozen_string_literal: true
 
           class Plumber < Formula
-            desc "CI/CD compliance scanner for GitLab pipelines"
+            desc "CI/CD security scanner for GitLab and GitHub pipelines"
             homepage "https://getplumber.io"
             version "VERSION_PLACEHOLDER"
             license "MPL-2.0"
@@ -379,7 +379,7 @@ jobs:
           # frozen_string_literal: true
 
           class PlumberAT${VERSION_UNDERSCORE} < Formula
-            desc "CI/CD compliance scanner for GitLab pipelines"
+            desc "CI/CD security scanner for GitLab and GitHub pipelines"
             homepage "https://getplumber.io"
             version "${VERSION}"
             license "MPL-2.0"

--- a/README.md
+++ b/README.md
@@ -317,8 +317,8 @@ More details:
 
 | Code | Meaning |
 |---|---|
-| `0` | The security score is greater than or equal to `--threshold` |
-| `1` | The security score is below `--threshold` |
+| `0` | The Plumber Score meets the gate (`--min-points` / `--min-score`) |
+| `1` | The Plumber Score is below the gate (or the deprecated `--threshold` is not met) |
 | `2` | Invalid usage, configuration, or a runtime / provider / auth / network failure |
 | `3` | A check could not be verified and `--fail-warnings` is set (e.g. an action version that could not be resolved) |
 

--- a/action.yml
+++ b/action.yml
@@ -25,9 +25,15 @@ inputs:
   github-url:
     description: "GitHub Enterprise Server host, e.g. ghes.example.com. Default: github.com."
     default: ""
+  min-points:
+    description: "Minimum Plumber Score points to pass (0-100). Default: 100 — any finding fails, same as the previous default on repos with workflows. Note: a repo with no workflows now fails the gate (nothing scoreable) where the old compliance gate passed it."
+    default: ""
+  min-score:
+    description: "Minimum Plumber Score letter to pass (A-E), e.g. B fails on C, D, E. When set without min-points, the letter alone gates."
+    default: ""
   threshold:
-    description: "Minimum compliance percentage to pass (0-100)."
-    default: "100"
+    description: "Deprecated: minimum percentage of passing controls (0-100). Use min-points / min-score to gate on the Plumber Score instead. The value 100 is treated as unset (same as the GitLab component): the default score gate also fails on any finding, and additionally fails a repo with no workflows."
+    default: ""
   config-file:
     description: "Path to a .plumber.yaml config. Default: the repo's .plumber.yaml (required — the run fails if absent; generate one with 'plumber config generate')."
     default: ""
@@ -60,7 +66,7 @@ inputs:
     default: "true"
   artifact-name:
     description: "Name of the uploaded artifact bundle."
-    default: "plumber-compliance"
+    default: "plumber-report"
   output:
     description: "JSON report output path. Empty to skip."
     default: "plumber-report.json"
@@ -75,11 +81,8 @@ inputs:
     default: "plumber.sarif"
 
 outputs:
-  compliance:
-    description: "Overall compliance percentage from the run."
-    value: ${{ steps.run.outputs.compliance }}
   passed:
-    description: "'true' when compliance is at or above the threshold."
+    description: "'true' when the run met its gate (min-points / min-score, or the deprecated threshold)."
     value: ${{ steps.run.outputs.passed }}
   report:
     description: "Path to the JSON report."
@@ -161,6 +164,8 @@ runs:
         PLUMBER_METADATA_TOKEN: ${{ inputs.metadata-token }}
         IN_PROJECT: ${{ inputs.project }}
         IN_GITHUB_URL: ${{ inputs.github-url }}
+        IN_MIN_POINTS: ${{ inputs.min-points }}
+        IN_MIN_SCORE: ${{ inputs.min-score }}
         IN_THRESHOLD: ${{ inputs.threshold }}
         IN_CONFIG: ${{ inputs.config-file }}
         IN_CONTROLS: ${{ inputs.controls }}
@@ -175,7 +180,18 @@ runs:
         IN_SARIF: ${{ inputs.sarif }}
       run: |
         set -uo pipefail
-        args=(analyze --threshold "$IN_THRESHOLD")
+        args=(analyze)
+        # The default gate is the Plumber Score (min-points 100: any finding
+        # fails). threshold is deprecated and only forwarded when set to a
+        # custom value: an explicit 100 is treated as unset and gates on the
+        # score instead (mirrors the GitLab component). The score gate also
+        # fails a repo with no workflows — nothing scoreable — which the old
+        # GitHub compliance gate passed.
+        [ -n "$IN_MIN_POINTS" ] && args+=(--min-points "$IN_MIN_POINTS")
+        [ -n "$IN_MIN_SCORE" ]  && args+=(--min-score "$IN_MIN_SCORE")
+        if [ -n "$IN_THRESHOLD" ] && [ "$IN_THRESHOLD" != "100" ]; then
+          args+=(--threshold "$IN_THRESHOLD")
+        fi
         if [ -n "$IN_PROJECT" ]; then
           # Remote-fetch: scan an upstream repo via the API (no checkout).
           gh_url="${IN_GITHUB_URL:-github.com}"
@@ -198,15 +214,16 @@ runs:
         [ -n "$IN_PBOM_CDX" ]       && args+=(--pbom-cyclonedx "$IN_PBOM_CDX")
         [ -n "$IN_SARIF" ]          && args+=(--sarif "$IN_SARIF")
 
-        plumber "${args[@]}"
-        code=$?
+        # Composite steps run under `bash -e`; capture the exit code inside an
+        # || list so a gate failure doesn't kill the step before exit_code and
+        # passed are written (the enforce step owns pass/fail).
+        code=0
+        plumber "${args[@]}" || code=$?
         echo "exit_code=${code}" >> "$GITHUB_OUTPUT"
 
-        # Surface compliance / passed as step outputs from the JSON report.
+        # Surface the gate verdict as a step output from the JSON report.
         if [ -n "$IN_OUTPUT" ] && [ -f "$IN_OUTPUT" ]; then
-          comp="$(python3 -c "import json,sys;print(json.load(open(sys.argv[1])).get('compliance',''))" "$IN_OUTPUT" 2>/dev/null || true)"
           passed="$(python3 -c "import json,sys;print(str(json.load(open(sys.argv[1])).get('passed','')).lower())" "$IN_OUTPUT" 2>/dev/null || true)"
-          echo "compliance=${comp}" >> "$GITHUB_OUTPUT"
           echo "passed=${passed}" >> "$GITHUB_OUTPUT"
         fi
         exit 0
@@ -216,22 +233,20 @@ runs:
       shell: bash
       env:
         IN_OUTPUT: ${{ inputs.output }}
-        IN_THRESHOLD: ${{ inputs.threshold }}
-        COMPLIANCE: ${{ steps.run.outputs.compliance }}
         PASSED: ${{ steps.run.outputs.passed }}
         EXIT_CODE: ${{ steps.run.outputs.exit_code }}
       run: |
         set -uo pipefail
         {
-          echo "## Plumber compliance"
+          echo "## Plumber"
           echo ""
-          if [ -n "${COMPLIANCE:-}" ]; then
+          if [ -n "${PASSED:-}" ]; then
             status="❌ failed"; [ "${PASSED:-}" = "true" ] && status="✅ passed"
             # A degraded run (exit 3: --fail-warnings + a check that could not be
-            # verified) can still be at/above threshold, so PASSED is "true".
+            # verified) can still meet its gate, so PASSED is "true".
             # Surface it here instead of printing a bare green.
             [ "${EXIT_CODE:-0}" = "3" ] && status="⚠️ could not fully verify (exit 3)"
-            echo "**Compliance:** ${COMPLIANCE}% (threshold ${IN_THRESHOLD}%): ${status}"
+            echo "**Plumber check:** ${status}"
           else
             echo "_Plumber ran; see the job log for the full report._"
           fi
@@ -242,7 +257,13 @@ runs:
         d=json.load(open(sys.argv[1]))
         s=d.get("plumberScore") or {}
         if s:
-            print(f"**Plumber Score:** {s.get('score','?')} ({s.get('finalPoints','?')}/100)")
+            gate=""
+            if d.get("minScore") or d.get("minPoints") is not None:
+                parts=[]
+                if d.get("minPoints") is not None: parts.append(f"≥ {d['minPoints']:g} pts")
+                if d.get("minScore"): parts.append(f"≥ {d['minScore']}")
+                gate=f" — required {' and '.join(parts)}"
+            print(f"**Plumber Score:** {s.get('score','?')} ({s.get('finalPoints','?')}/100){gate}")
             c=s.get('counts',{})
             print("")
             print(f"Critical {c.get('critical',0)} · High {c.get('high',0)} · Medium {c.get('medium',0)} · Low {c.get('low',0)}")
@@ -269,12 +290,13 @@ runs:
         if-no-files-found: ignore
         retention-days: 30
 
-    - name: Enforce threshold
+    - name: Enforce gate
       if: ${{ always() }}
       shell: bash
       env:
         EXIT_CODE: ${{ steps.run.outputs.exit_code }}
         SOFT_FAIL: ${{ inputs.soft-fail }}
+        IN_THRESHOLD: ${{ inputs.threshold }}
       run: |
         set -uo pipefail
         code="${EXIT_CODE:-2}"
@@ -289,17 +311,23 @@ runs:
           3)
             # --fail-warnings is on and at least one check could not be
             # verified (e.g. an action version that could not be resolved).
-            # Distinct from a compliance failure; soft-fail does not mask it.
+            # Distinct from a gate failure; soft-fail does not mask it.
             echo "::error::Plumber could not verify one or more checks and fail-warnings is enabled (exit 3). See the 'Could not verify' warnings in the analyze step log."
             exit 1
             ;;
           1)
-            # Compliance below threshold.
+            # Gate failure: the Plumber Score gate (min-points / min-score),
+            # or the deprecated threshold gate when that input is set to a
+            # custom value (100 is treated as unset, see the analyze step).
+            gate="The Plumber Score is below the configured gate (min-points / min-score)."
+            if [ -n "${IN_THRESHOLD:-}" ] && [ "${IN_THRESHOLD}" != "100" ]; then
+              gate="The percentage of passing controls is below the deprecated threshold input (migrate to min-points / min-score)."
+            fi
             if [ "$SOFT_FAIL" = "true" ]; then
-              echo "::warning::Compliance is below the threshold, but soft-fail is enabled."
+              echo "::warning::${gate} soft-fail is enabled, not failing the job."
               exit 0
             fi
-            echo "::error::Compliance is below the configured threshold."
+            echo "::error::${gate}"
             exit 1
             ;;
           *)

--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -37,7 +37,16 @@ var (
 	printOutput       bool
 	configFile        string
 	threshold         float64
-	pbomFile          string
+	// thresholdSet is true when the deprecated --threshold was supplied
+	// explicitly (flag or PLUMBER_ANALYZE_THRESHOLD); it switches the gate
+	// back to the legacy passing-controls percentage.
+	thresholdSet bool
+	minScore     string
+	minPoints    float64
+	// minPointsSet distinguishes an explicit --min-points from its default:
+	// when only --min-score is given, the points gate is off.
+	minPointsSet bool
+	pbomFile     string
 	pbomCycloneDXFile string
 	sarifFile         string
 	glsastFile        string
@@ -64,7 +73,7 @@ var analyzeCmd = &cobra.Command{
 	Use:          "analyze",
 	Short:        "Analyze CI/CD configuration (GitLab via API, or local GitHub Actions when origin is GitHub)",
 	SilenceUsage: true, // Don't print usage on errors (e.g., threshold failures)
-	Long: `Analyze CI/CD configuration for compliance issues.
+	Long: `Analyze CI/CD configuration for security issues.
 
 GitLab path (when the git remote is GitLab, or when you pass --gitlab-url and --project):
   Connects to GitLab, retrieves CI/CD configuration and project settings, and runs
@@ -81,14 +90,16 @@ Flags (auto-detected from git remote if not specified):
 
 Optional flags:
   --config           Path to .plumber.yaml config file (default: .plumber.yaml)
-  --threshold        Minimum compliance percentage to pass, 0-100 (default: 100)
+  --min-points       Minimum Plumber Score points to pass, 0-100 (default: 100 — any finding fails)
+  --min-score        Minimum Plumber Score letter to pass, A-E (e.g. B fails on C, D, E)
+  --threshold        Deprecated: minimum percentage of passing controls, 0-100; use --min-points / --min-score
   --branch           Branch to analyze (defaults to project's default branch)
   --print            Print text output to stdout (default: true)
   --output           Write JSON results to file (optional)
   --pbom             Write PBOM (Pipeline Bill of Materials) to file (optional)
   --pbom-cyclonedx   Write PBOM in CycloneDX format for integration with security tools
-  --mr-comment       Post/update a compliance comment on the merge request (requires api scope, merge request pipeline only)
-  --badge            Create/update a Plumber compliance badge on the project (requires api scope; only runs on default branch)
+  --mr-comment       Post/update a Plumber comment on the merge request (requires api scope, merge request pipeline only)
+  --badge            Create/update a Plumber letter-score badge on the project (requires api scope; only runs on default branch)
   --score            Letter score, points, bar, and counts in stdout (banner only); points + score in JSON/PBOM/CycloneDX; badge/MR use letter when set (optional)
   --score-point      Same as --score plus full points breakdown in stdout and MR comment (optional; wins if both set)
   --score-push       Publish this repo's Plumber Score to the hosted badge service (CI only; a local run is a no-op) (optional)
@@ -99,8 +110,8 @@ Optional flags:
   --ci-config-path   Override the CI configuration file path (default: auto-detected from GitLab project settings, usually .gitlab-ci.yml)
 
 Exit codes:
-  0  Analysis passed (compliance >= threshold)
-  1  Compliance failure (compliance < threshold)
+  0  Analysis passed (score gate met)
+  1  Gate failure (Plumber Score below --min-points / --min-score, or deprecated --threshold not met)
   2  Runtime error (configuration error, network failure, missing token, etc.)
 
 Examples:
@@ -113,8 +124,8 @@ Examples:
   # Analyze a specific project
   plumber analyze --gitlab-url https://gitlab.com --project mygroup/myproject
 
-  # Analyze with custom config and threshold
-  plumber analyze --gitlab-url https://gitlab.com --project mygroup/myproject --config custom.yaml --threshold 80
+  # Analyze with custom config and a relaxed score gate
+  plumber analyze --gitlab-url https://gitlab.com --project mygroup/myproject --config custom.yaml --min-points 80
 
   # Analyze and save JSON to file (no stdout)
   plumber analyze --gitlab-url https://gitlab.com --project mygroup/myproject --print=false --output results.json
@@ -147,7 +158,9 @@ func init() {
 
 	// Optional flags with defaults
 	analyzeCmd.Flags().StringVar(&configFile, "config", ".plumber.yaml", "Path to .plumber.yaml config file")
-	analyzeCmd.Flags().Float64Var(&threshold, "threshold", 100, "Minimum compliance percentage to pass, 0-100")
+	analyzeCmd.Flags().Float64Var(&threshold, "threshold", 100, "Deprecated: minimum percentage of passing controls, 0-100; use --min-points / --min-score instead")
+	analyzeCmd.Flags().StringVar(&minScore, "min-score", "", "Minimum Plumber Score letter to pass, A-E (e.g. B fails on C, D, E)")
+	analyzeCmd.Flags().Float64Var(&minPoints, "min-points", 100, "Minimum Plumber Score points to pass, 0-100 (default 100: any finding fails)")
 	analyzeCmd.Flags().StringVar(&defaultBranch, "branch", "", "Branch to analyze (defaults to project's default branch)")
 	analyzeCmd.Flags().BoolVar(&printOutput, "print", true, "Print text output to stdout")
 	analyzeCmd.Flags().StringVarP(&outputFile, "output", "o", "", "Write JSON results to file")
@@ -503,6 +516,8 @@ var envKeys = map[string]string{
 	"branch":         "PLUMBER_ANALYZE_BRANCH",
 	"config":         "PLUMBER_ANALYZE_CONFIG",
 	"threshold":      "PLUMBER_ANALYZE_THRESHOLD",
+	"min-score":      "PLUMBER_ANALYZE_MIN_SCORE",
+	"min-points":     "PLUMBER_ANALYZE_MIN_POINTS",
 	"print":          "PLUMBER_ANALYZE_PRINT",
 	"output":         "PLUMBER_ANALYZE_OUTPUT",
 	"pbom":           "PLUMBER_ANALYZE_PBOM",
@@ -552,6 +567,41 @@ func envBoolFallback(cmd *cobra.Command, flag, envKey string, dest *bool) error 
 	return nil
 }
 
+// resolveGateFlags validates the pass/fail gate flags after the env fallbacks
+// ran and records which gate is active. The default gate is the Plumber Score
+// (--min-points 100: any finding fails, exactly the behavior the old default
+// --threshold 100 had). Supplying the deprecated --threshold switches back to
+// the legacy passing-controls percentage and warns; combining it with the
+// score gate flags is an error.
+func resolveGateFlags(cmd *cobra.Command) error {
+	thresholdSet = cmd.Flags().Changed("threshold") || os.Getenv(envKeys["threshold"]) != ""
+	minPointsSet = cmd.Flags().Changed("min-points") || os.Getenv(envKeys["min-points"]) != ""
+
+	if thresholdSet && (minPointsSet || minScore != "") {
+		return fmt.Errorf("the deprecated --threshold cannot be combined with --min-points / --min-score; drop --threshold")
+	}
+	if thresholdSet {
+		fmt.Fprintf(os.Stderr, "Warning: --threshold is deprecated and will be removed in a future release; gate on the Plumber Score with --min-points (0-100) or --min-score (A-E) instead. See https://getplumber.io/docs/plumber-score\n")
+		// Inverted comparison so NaN fails closed: ParseFloat accepts "nan",
+		// which every ordered comparison answers false — `< 0 || > 100` would
+		// let it through and the gate could then never fail.
+		if !(threshold >= 0 && threshold <= 100) {
+			return fmt.Errorf("threshold must be between 0 and 100")
+		}
+		return nil
+	}
+	if !(minPoints >= 0 && minPoints <= 100) {
+		return fmt.Errorf("min-points must be between 0 and 100")
+	}
+	if minScore != "" {
+		minScore = strings.ToUpper(strings.TrimSpace(minScore))
+		if control.ScoreLetterRank(minScore) == 0 {
+			return fmt.Errorf("min-score must be one of A, B, C, D, E")
+		}
+	}
+	return nil
+}
+
 func envFloat64Fallback(cmd *cobra.Command, flag, envKey string, dest *float64) error {
 	if !cmd.Flags().Changed(flag) {
 		if v := os.Getenv(envKey); v != "" {
@@ -595,6 +645,8 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 		func() error { return envStringFallback(cmd, "skip-controls", envKeys["skip-controls"], &skipControls) },
 		func() error { return envStringFallback(cmd, "ci-config-path", envKeys["ci-config-path"], &ciConfigPath) },
 		func() error { return envFloat64Fallback(cmd, "threshold", envKeys["threshold"], &threshold) },
+		func() error { return envStringFallback(cmd, "min-score", envKeys["min-score"], &minScore) },
+		func() error { return envFloat64Fallback(cmd, "min-points", envKeys["min-points"], &minPoints) },
 		func() error { return envBoolFallback(cmd, "print", envKeys["print"], &printOutput) },
 		func() error { return envBoolFallback(cmd, "mr-comment", envKeys["mr-comment"], &mrComment) },
 		func() error { return envBoolFallback(cmd, "badge", envKeys["badge"], &badge) },
@@ -611,6 +663,10 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	flags := readAnalyzeFlags(cmd)
 
 	if err := validateProviderFlags(flags); err != nil {
+		return err
+	}
+
+	if err := resolveGateFlags(cmd); err != nil {
 		return err
 	}
 
@@ -635,10 +691,6 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	remote, err := resolveGitLabTarget(flags, remoteInfo)
 	if err != nil {
 		return err
-	}
-
-	if threshold < 0 || threshold > 100 {
-		return fmt.Errorf("threshold must be between 0 and 100")
 	}
 
 	gitlabToken, err := resolveGitLabToken(flags)
@@ -738,14 +790,14 @@ func parseControlsFilter(raw string) ([]string, error) {
 // same bytes are written to --output and pushed to the score service, so the
 // stored badge record and the file on disk can never diverge.
 func buildAnalysisJSONReport(result *control.AnalysisResult, pc *configuration.PlumberConfig, s complianceSummary, p jsonOutputParams) ([]byte, error) {
-	threshold, compliance, score, scoreMode, provider, includeOnly, skip :=
-		s.threshold, s.compliance, s.score, s.scoreMode, p.provider, p.includeOnly, p.skip
+	score, scoreMode, provider, includeOnly, skip :=
+		s.score, s.scoreMode, p.provider, p.includeOnly, p.skip
 	// Marshal AnalysisResult into a generic map so the per-control
 	// `*Result` legacy blocks can sit alongside its existing fields
 	// without forcing every consumer to follow the dev's flat-findings
 	// shape. The legacy keys (imageForbiddenTagsResult, …) carry the
-	// same issues + metrics + compliance triplet v0.2.x emitted, so
-	// downstream tooling parses the dev output unchanged.
+	// same issues + metrics pair v0.2.x emitted, so downstream tooling
+	// parses the dev output unchanged.
 	raw, err := json.Marshal(result)
 	if err != nil {
 		return nil, fmt.Errorf("marshal result: %w", err)
@@ -754,9 +806,21 @@ func buildAnalysisJSONReport(result *control.AnalysisResult, pc *configuration.P
 	if err := json.Unmarshal(raw, &output); err != nil {
 		return nil, fmt.Errorf("unmarshal result: %w", err)
 	}
-	output["threshold"] = threshold
-	output["compliance"] = compliance
-	output["passed"] = compliance >= threshold
+	// The gate that produced `passed` is spelled out next to it: the score
+	// gate emits minPoints / minScore; the deprecated --threshold gate emits
+	// threshold for the pipelines still supplying it. The compliance
+	// percentage itself is gone (#320) — plumberScore is the grade.
+	if s.thresholdSet {
+		output["threshold"] = s.threshold
+	} else {
+		if s.pointsGateActive() {
+			output["minPoints"] = s.minPoints
+		}
+		if s.minScore != "" {
+			output["minScore"] = s.minScore
+		}
+	}
+	output["passed"] = s.passed()
 	if scoreMode && score != nil {
 		output["plumberScore"] = score
 	}
@@ -902,7 +966,7 @@ func writeJSONToFile(result *control.AnalysisResult, pc *configuration.PlumberCo
 // partialControlEntries lists controls whose evaluation was partial —
 // some inputs reachable, others not. CI gates parse this to decide
 // whether to fail loud ("we never actually checked your protection
-// rules") even when compliance is 100%.
+// rules") even when the run passed its gate.
 func partialControlEntries(result *control.AnalysisResult) []map[string]any {
 	if result == nil || result.GitHubStats == nil {
 		return nil
@@ -927,7 +991,7 @@ var analysisJSONLegacyKeyHead = []string{
 	"projectPath", "projectId", "defaultBranch",
 	"ciConfigSource", "ciValid", "ciMissing", "ciErrors",
 	"pipelineOriginMetrics", "pipelineImageMetrics",
-	"compliance", "threshold", "passed", "plumberScore",
+	"minPoints", "minScore", "threshold", "passed", "plumberScore",
 }
 
 // analysisJSONLegacyKeyTail lists keys pinned to the END of the object, after
@@ -1170,20 +1234,104 @@ type jsonOutputParams struct {
 	skip        []string
 }
 
-// complianceSummary bundles the computed compliance values passed to outputText.
+// complianceSummary bundles the computed gate values passed to outputText.
 type complianceSummary struct {
+	// compliance is the legacy passing-controls percentage, computed only to
+	// serve the deprecated --threshold gate. It is never emitted anymore.
 	compliance   float64
 	controlCount int
 	threshold    float64
+	thresholdSet bool
+	minPoints    float64
+	minPointsSet bool
+	minScore     string
 	score        *control.PlumberScoreResult
 	scoreMode    bool
 	scorePoint   bool
+	// ciMissing / ciInvalid: nothing was scoreable. Zero findings on an
+	// absent or unparseable CI configuration must not pass the score gate.
+	ciMissing bool
+	ciInvalid bool
+}
+
+// pointsGateActive reports whether the points gate applies: either it was set
+// explicitly, or nothing was set at all (the default gate is min-points 100).
+// When only --min-score is given, the letter alone gates.
+func (s complianceSummary) pointsGateActive() bool {
+	return s.minPointsSet || s.minScore == ""
+}
+
+// gateErr returns nil when the active gate passes, or the exit-code-1 error
+// describing the failure. The deprecated --threshold gate wins when supplied;
+// otherwise the Plumber Score gates the run.
+func (s complianceSummary) gateErr() error {
+	if s.thresholdSet {
+		if s.compliance < s.threshold {
+			return &ComplianceError{Compliance: s.compliance, Threshold: s.threshold}
+		}
+		return nil
+	}
+	if s.ciMissing {
+		return &ScoreGateError{CiMissing: true}
+	}
+	if s.ciInvalid {
+		return &ScoreGateError{CiInvalid: true}
+	}
+	// Zero controls evaluated (provider-mismatched or empty .plumber.yaml,
+	// skip-all filter): zero findings score 100 pts, but nothing was checked,
+	// so fail closed exactly like the missing/invalid-CI cases above.
+	if s.controlCount == 0 {
+		return &ScoreGateError{NoControls: true}
+	}
+	if s.score == nil {
+		return nil
+	}
+	if s.minScore != "" && control.ScoreLetterRank(s.score.Score) < control.ScoreLetterRank(s.minScore) {
+		return &ScoreGateError{Letter: s.score.Score, MinLetter: s.minScore, Points: s.score.FinalPoints}
+	}
+	if s.pointsGateActive() && s.score.FinalPoints < s.minPoints {
+		return &ScoreGateError{Points: s.score.FinalPoints, MinPoints: s.minPoints, PointsGate: true, Letter: s.score.Score}
+	}
+	return nil
+}
+
+// passed reports whether the active gate is met. It is the value written to
+// the JSON `passed` field and shown by the MR comment and job summaries.
+func (s complianceSummary) passed() bool {
+	return s.gateErr() == nil
+}
+
+// gateLine renders the active gate and its outcome as one human-readable
+// sentence fragment, e.g. "score A — 100.0/100 pts, required ≥ 100 pts".
+func (s complianceSummary) gateLine() string {
+	if s.thresholdSet {
+		return fmt.Sprintf("%.1f%% of controls passing, deprecated threshold %.0f%%", s.compliance, s.threshold)
+	}
+	if s.ciMissing {
+		return "no CI configuration found, nothing to score"
+	}
+	if s.ciInvalid {
+		return "invalid CI configuration, nothing to score"
+	}
+	if s.controlCount == 0 {
+		return "no controls evaluated, nothing to score"
+	}
+	if s.score == nil {
+		return ""
+	}
+	requirements := []string{}
+	if s.pointsGateActive() {
+		requirements = append(requirements, fmt.Sprintf("≥ %.0f pts", s.minPoints))
+	}
+	if s.minScore != "" {
+		requirements = append(requirements, fmt.Sprintf("≥ %s", s.minScore))
+	}
+	return fmt.Sprintf("score %s — %.1f/100 pts, required %s", s.score.Score, s.score.FinalPoints, strings.Join(requirements, " and "))
 }
 
 // controlSummary holds summary data for a control
 type controlSummary struct {
 	name       string
-	compliance float64
 	issues     int
 	skipped    bool
 	codes      []string
@@ -1233,28 +1381,6 @@ func compareSeverityWorstFirst(a, b control.SeverityCounts) int {
 		return 1
 	}
 	return 0
-}
-
-func sortControlSummariesForComplianceTable(s []controlSummary) {
-	sort.SliceStable(s, func(i, j int) bool {
-		a, b := s[i], s[j]
-		if a.skipped != b.skipped {
-			return !a.skipped && b.skipped
-		}
-		if a.skipped {
-			return a.name < b.name
-		}
-		if a.compliance != b.compliance {
-			return a.compliance < b.compliance
-		}
-		if cmp := compareSeverityWorstFirst(a.bySeverity, b.bySeverity); cmp != 0 {
-			return cmp < 0
-		}
-		if a.issues != b.issues {
-			return a.issues > b.issues
-		}
-		return a.name < b.name
-	})
 }
 
 func sortControlSummariesForIssuesTable(s []controlSummary) {
@@ -1489,20 +1615,18 @@ func printScoreBreakdown(score *control.PlumberScoreResult) {
 	fmt.Println()
 }
 
-func printControlHeader(name string, compliance float64, skipped bool) {
+func printControlHeader(name string, issues int, skipped bool) {
 	line := strings.Repeat("─", 50)
 	fmt.Printf(fmtColored, colorDim, line, colorReset)
-	if skipped {
+	switch {
+	case skipped:
 		fmt.Printf("%s%s%s %s(skipped)%s\n", colorBold, name, colorReset, colorDim, colorReset)
-	} else {
-		compColor := colorGreen
-		if compliance < 100 {
-			compColor = colorYellow
-		}
-		if compliance == 0 {
-			compColor = colorRed
-		}
-		fmt.Printf("%s%s%s %s(%.1f%% compliant)%s\n", colorBold, name, colorReset, compColor, compliance, colorReset)
+	case issues == 0:
+		fmt.Printf("%s%s%s %s(passed)%s\n", colorBold, name, colorReset, colorGreen, colorReset)
+	case issues == 1:
+		fmt.Printf("%s%s%s %s(1 issue)%s\n", colorBold, name, colorReset, colorRed, colorReset)
+	default:
+		fmt.Printf("%s%s%s %s(%d issues)%s\n", colorBold, name, colorReset, colorRed, issues, colorReset)
 	}
 	fmt.Printf(fmtColored, colorDim, line, colorReset)
 }
@@ -1678,91 +1802,3 @@ func indentBlock(s, prefix string) string {
 	return strings.Join(lines, "\n")
 }
 
-// complianceTableRow is a single row in the compliance summary table.
-type complianceTableRow struct {
-	isTotal bool
-	name    string
-	compStr string
-	status  string
-	compOK  bool
-}
-
-func complianceStatusEmoji(ok bool) string {
-	if ok {
-		return "🟢"
-	}
-	return "🔴"
-}
-
-func buildComplianceRows(controls []controlSummary, overallCompliance, threshold float64) []complianceTableRow {
-	sorted := append([]controlSummary(nil), controls...)
-	sortControlSummariesForComplianceTable(sorted)
-
-	rows := make([]complianceTableRow, 0, len(sorted)+1)
-	for _, ctrl := range sorted {
-		r := complianceTableRow{name: ctrl.name, compStr: "-", status: "-"}
-		if !ctrl.skipped {
-			r.compOK = ctrl.compliance >= 100
-			r.compStr = fmt.Sprintf("%.1f%%", ctrl.compliance)
-			r.status = complianceStatusEmoji(r.compOK)
-		}
-		rows = append(rows, r)
-	}
-	totalOK := overallCompliance >= threshold
-	rows = append(rows, complianceTableRow{
-		isTotal: true,
-		name:    fmt.Sprintf("Total (required: %.0f%%)", threshold),
-		compStr: fmt.Sprintf("%.1f%%", overallCompliance),
-		compOK:  totalOK,
-		status:  complianceStatusEmoji(totalOK),
-	})
-	return rows
-}
-
-func complianceValueStyle(base lipgloss.Style, r complianceTableRow) lipgloss.Style {
-	if r.compStr == "-" {
-		return base.Faint(true)
-	}
-	if r.compOK {
-		return base.Inherit(styleSuccess)
-	}
-	return base.Inherit(styleError)
-}
-
-func complianceTableStyleFunc(rows []complianceTableRow) func(int, int) lipgloss.Style {
-	return func(row, col int) lipgloss.Style {
-		if row == table.HeaderRow {
-			return styleHeader
-		}
-		if row < 0 || row >= len(rows) {
-			return styleCell
-		}
-		r := rows[row]
-		style := styleCell
-		if r.isTotal {
-			style = style.Bold(true)
-		}
-		if col == 1 || col == 2 {
-			return complianceValueStyle(style, r)
-		}
-		return style
-	}
-}
-
-func printComplianceTable(controls []controlSummary, overallCompliance, threshold float64) {
-	fmt.Printf(fmtIndentLine, styleTitle.Render("Compliance"))
-
-	rows := buildComplianceRows(controls, overallCompliance, threshold)
-
-	tbl := table.New().
-		Border(lipgloss.RoundedBorder()).
-		BorderStyle(styleAccent).
-		Headers("Control", "Compliance", "Status").
-		StyleFunc(complianceTableStyleFunc(rows))
-
-	for _, r := range rows {
-		tbl.Row(r.name, r.compStr, r.status)
-	}
-
-	fmt.Println(indentBlock(tbl.String(), "  "))
-}

--- a/cmd/analyze_gitlab_test.go
+++ b/cmd/analyze_gitlab_test.go
@@ -194,61 +194,6 @@ func TestComputeGitLabCompliance_WithFinding(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// buildComplianceRows
-// ---------------------------------------------------------------------------
-
-func TestBuildComplianceRows_SkippedShowsDash(t *testing.T) {
-	controls := []controlSummary{
-		{name: "ctrl", compliance: 100, skipped: true},
-	}
-	rows := buildComplianceRows(controls, 100.0, 100.0)
-	// rows[0] = the control; rows[1] = total
-	if rows[0].compStr != "-" || rows[0].status != "-" {
-		t.Fatalf("skipped row: want compStr='-' status='-', got %q %q", rows[0].compStr, rows[0].status)
-	}
-}
-
-func TestBuildComplianceRows_PassingControl(t *testing.T) {
-	controls := []controlSummary{
-		{name: "ctrl", compliance: 100, skipped: false},
-	}
-	rows := buildComplianceRows(controls, 100.0, 100.0)
-	if rows[0].compStr != "100.0%" {
-		t.Fatalf("passing row: want '100.0%%', got %q", rows[0].compStr)
-	}
-	if !rows[0].compOK {
-		t.Fatal("passing row: compOK should be true")
-	}
-	if rows[0].status != "🟢" {
-		t.Fatalf("passing row: status want 🟢, got %q", rows[0].status)
-	}
-}
-
-func TestBuildComplianceRows_FailingControl(t *testing.T) {
-	controls := []controlSummary{
-		{name: "ctrl", compliance: 0, skipped: false},
-	}
-	rows := buildComplianceRows(controls, 0.0, 100.0)
-	if rows[0].status != "🔴" {
-		t.Fatalf("failing row: status want 🔴, got %q", rows[0].status)
-	}
-}
-
-func TestBuildComplianceRows_TotalRow(t *testing.T) {
-	rows := buildComplianceRows(nil, 75.0, 80.0)
-	total := rows[len(rows)-1]
-	if !total.isTotal {
-		t.Fatal("last row should be the total row")
-	}
-	if total.compStr != "75.0%" {
-		t.Fatalf("total compStr: got %q", total.compStr)
-	}
-	if total.status != "🔴" {
-		t.Fatalf("total below threshold: want 🔴, got %q", total.status)
-	}
-}
-
-// ---------------------------------------------------------------------------
 // issueTableCells
 // ---------------------------------------------------------------------------
 

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -34,18 +34,7 @@ func runWithProvider(p provider.Provider, cmd *cobra.Command, conf *configuratio
 
 	newLocationLinker(conf, result, p.Name()).Annotate(result.Findings)
 
-	compliance, controlCount := p.ComputeCompliance(result, conf)
-	scoreMode := true // the score banner is shown by default (#218); --score is a no-op
-	scoreResult := computeScoreResult(result, scoreMode)
-
-	summary := complianceSummary{
-		compliance:   compliance,
-		controlCount: controlCount,
-		threshold:    threshold,
-		score:        scoreResult,
-		scoreMode:    scoreMode,
-		scorePoint:   showScorePoint,
-	}
+	summary := buildComplianceSummary(p, result, conf)
 
 	if printOutput {
 		if err := outputTextWithProvider(p, result, conf, summary, controlsFilterList, skipControlsList); err != nil {
@@ -60,17 +49,39 @@ func runWithProvider(p provider.Provider, cmd *cobra.Command, conf *configuratio
 	handleScorePublishing(p, conf, result, summary)
 
 	pas := provider.PostActionSummary{
-		Compliance: compliance,
-		Threshold:  threshold,
-		Score:      scoreResult,
-		ScoreMode:  scoreMode,
-		ScorePoint: showScorePoint,
+		Passed:     summary.passed(),
+		GateLine:   summary.gateLine(),
+		Score:      summary.score,
+		ScoreMode:  summary.scoreMode,
+		ScorePoint: summary.scorePoint,
 	}
 	if err := p.PostAnalysisActions(cmd, result, conf, pas); err != nil {
 		return err
 	}
 
-	return finalizeRun(result, compliance)
+	return finalizeRun(result, summary)
+}
+
+// buildComplianceSummary assembles the gate inputs for a run: the Plumber
+// Score (the default gate), the score-gate flags, and — only to serve the
+// deprecated --threshold gate — the legacy passing-controls percentage.
+func buildComplianceSummary(p provider.Provider, result *control.AnalysisResult, conf *configuration.Configuration) complianceSummary {
+	compliance, controlCount := p.ComputeCompliance(result, conf)
+	scoreMode := true // the score banner is shown by default (#218); --score is a no-op
+	return complianceSummary{
+		compliance:   compliance,
+		controlCount: controlCount,
+		threshold:    threshold,
+		thresholdSet: thresholdSet,
+		minPoints:    minPoints,
+		minPointsSet: minPointsSet,
+		minScore:     minScore,
+		score:        computeScoreResult(result, scoreMode),
+		scoreMode:    scoreMode,
+		scorePoint:   showScorePoint,
+		ciMissing:    result.CiMissing,
+		ciInvalid:    !result.CiValid && !result.CiMissing,
+	}
 }
 
 // outputTextWithProvider renders terminal output using the provider's catalog
@@ -106,21 +117,17 @@ func outputTextWithProvider(p provider.Provider, result *control.AnalysisResult,
 	switch {
 	case result.DataCollectionDegraded:
 		fmt.Printf("  Status: %s%sINCOMPLETE — data collection failed%s\n\n", colorBold, colorYellow, colorReset)
-	case s.compliance >= s.threshold:
-		fmt.Printf("  Status: %s%sPASSED ✓%s\n\n", colorBold, colorGreen, colorReset)
+	case s.passed():
+		fmt.Printf("  Status: %s%sPASSED ✓%s %s(%s)%s\n\n", colorBold, colorGreen, colorReset, colorDim, s.gateLine(), colorReset)
 	default:
-		fmt.Printf("  Status: %s%sFAILED ✗%s\n\n", colorBold, colorRed, colorReset)
+		fmt.Printf("  Status: %s%sFAILED ✗%s %s(%s)%s\n\n", colorBold, colorRed, colorReset, colorDim, s.gateLine(), colorReset)
 	}
 
 	// On a degraded run suppress the issues table when empty (it would imply a
-	// clean pipeline we never evaluated) and always suppress the compliance
-	// table and score, which would present partial data as a verdict (#220).
+	// clean pipeline we never evaluated) and the score, which would present
+	// partial data as a verdict (#220).
 	if !result.DataCollectionDegraded || len(result.Findings) > 0 {
 		printIssuesTable(controls)
-		fmt.Println()
-	}
-	if !result.DataCollectionDegraded {
-		printComplianceTable(controls, s.compliance, s.threshold)
 		fmt.Println()
 	}
 
@@ -149,14 +156,9 @@ func buildProviderControlSummariesAndGroups(p provider.Provider, result *control
 		}
 		codes, items := findingsToItems(findings)
 		skipped := e.Skipped || dataCollectionFailed
-		entryCompliance := 100.0
-		if !skipped && len(items) > 0 {
-			entryCompliance = 0.0
-		}
 		stats := provider.BuildControlStats(p.Name(), e.ControlName, result, conf.PlumberConfig, findings)
 		controls = append(controls, controlSummary{
 			name:       e.DisplayName,
-			compliance: entryCompliance,
 			issues:     len(items),
 			skipped:    skipped,
 			codes:      uniqueSortedIssueCodeStrings(codes),
@@ -164,7 +166,6 @@ func buildProviderControlSummariesAndGroups(p provider.Provider, result *control
 		})
 		groups = append(groups, findingGroup{
 			Title:      e.DisplayName,
-			Compliance: entryCompliance,
 			Skipped:    skipped,
 			SkipReason: e.SkipReason,
 			Stats:      stats,
@@ -224,17 +225,7 @@ func writeOutputsWithProvider(p provider.Provider, result *control.AnalysisResul
 // pipeline.
 func presentResultWithProvider(p provider.Provider, cmd *cobra.Command, result *control.AnalysisResult, conf *configuration.Configuration) error {
 	newLocationLinker(conf, result, p.Name()).Annotate(result.Findings)
-	compliance, controlCount := p.ComputeCompliance(result, conf)
-	scoreMode := true // the score banner is shown by default (#218); --score is a no-op
-	scoreResult := computeScoreResult(result, scoreMode)
-	summary := complianceSummary{
-		compliance:   compliance,
-		controlCount: controlCount,
-		threshold:    threshold,
-		score:        scoreResult,
-		scoreMode:    scoreMode,
-		scorePoint:   showScorePoint,
-	}
+	summary := buildComplianceSummary(p, result, conf)
 	if printOutput {
 		if err := outputTextWithProvider(p, result, conf, summary, conf.ControlsFilter, conf.SkipControlsFilter); err != nil {
 			return err
@@ -245,18 +236,18 @@ func presentResultWithProvider(p provider.Provider, cmd *cobra.Command, result *
 	}
 	handleScorePublishing(p, conf, result, summary)
 	pas := provider.PostActionSummary{
-		Compliance: compliance,
-		Threshold:  threshold,
-		Score:      scoreResult,
-		ScoreMode:  scoreMode,
-		ScorePoint: showScorePoint,
+		Passed:     summary.passed(),
+		GateLine:   summary.gateLine(),
+		Score:      summary.score,
+		ScoreMode:  summary.scoreMode,
+		ScorePoint: summary.scorePoint,
 	}
 	if cmd != nil {
 		if err := p.PostAnalysisActions(cmd, result, conf, pas); err != nil {
 			return err
 		}
 	}
-	return finalizeRun(result, compliance)
+	return finalizeRun(result, summary)
 }
 
 func joinStrings(ss []string) string {
@@ -295,24 +286,15 @@ func computeScoreResult(result *control.AnalysisResult, scoreMode bool) *control
 }
 
 // finalizeRun applies the exit-code gates in priority order: a degraded run
-// (incomplete data) fails at exit 3 regardless of compliance (#220); then
+// (incomplete data) fails at exit 3 regardless of the gate (#220); then
 // --fail-warnings fails at exit 3 when "could not verify" warnings exist;
-// otherwise the compliance threshold governs.
-func finalizeRun(result *control.AnalysisResult, compliance float64) error {
+// otherwise the score gate (or the deprecated --threshold gate) governs.
+func finalizeRun(result *control.AnalysisResult, s complianceSummary) error {
 	if result.DataCollectionDegraded {
 		return &IncompleteDataError{Reasons: result.DegradedReasons}
 	}
 	if failWarnings && len(result.Warnings) > 0 {
 		return &DegradedError{Count: len(result.Warnings)}
 	}
-	return checkComplianceThreshold(compliance)
-}
-
-// checkComplianceThreshold returns a ComplianceError when compliance is below
-// the configured threshold, nil otherwise.
-func checkComplianceThreshold(compliance float64) error {
-	if compliance < threshold {
-		return &ComplianceError{Compliance: compliance, Threshold: threshold}
-	}
-	return nil
+	return s.gateErr()
 }

--- a/cmd/analyze_sort_test.go
+++ b/cmd/analyze_sort_test.go
@@ -6,36 +6,6 @@ import (
 	"github.com/getplumber/plumber/control"
 )
 
-func TestSortControlSummariesForComplianceTable(t *testing.T) {
-	s := []controlSummary{
-		{name: "b", compliance: 100, issues: 0, skipped: false, bySeverity: control.SeverityCounts{}},
-		{name: "a", compliance: 0, issues: 2, skipped: false, bySeverity: control.SeverityCounts{Critical: 1}},
-		{name: "c", compliance: 0, issues: 1, skipped: false, bySeverity: control.SeverityCounts{High: 2}},
-		{name: "z-skipped", compliance: 0, issues: 0, skipped: true},
-	}
-	sortControlSummariesForComplianceTable(s)
-	if s[0].name != "a" || s[1].name != "c" {
-		t.Fatalf("expected 0%% rows first (a then c), got %q then %q", s[0].name, s[1].name)
-	}
-	if s[2].name != "b" {
-		t.Fatalf("expected 100%% third, got %q", s[2].name)
-	}
-	if s[3].name != "z-skipped" {
-		t.Fatalf("expected skipped last, got %q", s[3].name)
-	}
-}
-
-func TestSortControlSummariesForComplianceTable_tieSeverityThenIssues(t *testing.T) {
-	s := []controlSummary{
-		{name: "low-issues", compliance: 50, issues: 1, skipped: false, bySeverity: control.SeverityCounts{Medium: 1}},
-		{name: "high-issues", compliance: 50, issues: 5, skipped: false, bySeverity: control.SeverityCounts{Medium: 1}},
-	}
-	sortControlSummariesForComplianceTable(s)
-	if s[0].name != "high-issues" {
-		t.Fatalf("same compliance+severity: more issues first, got %q", s[0].name)
-	}
-}
-
 func TestSortControlSummariesForIssuesTable(t *testing.T) {
 	s := []controlSummary{
 		{name: "z-low", issues: 10, bySeverity: control.SeverityCounts{Low: 3}},

--- a/cmd/degraded_render_test.go
+++ b/cmd/degraded_render_test.go
@@ -4,10 +4,10 @@ import "testing"
 
 func TestFilterGroupsForDegraded(t *testing.T) {
 	groups := []findingGroup{
-		{Title: "green-stats-only", Compliance: 100, Findings: nil},
-		{Title: "has-findings", Compliance: 0, Findings: []detailedFinding{{Code: "ISSUE-103"}}},
+		{Title: "green-stats-only", Findings: nil},
+		{Title: "has-findings", Findings: []detailedFinding{{Code: "ISSUE-103"}}},
 		{Title: "skipped-disabled", Skipped: true, Findings: nil},
-		{Title: "another-green", Compliance: 100, Findings: nil},
+		{Title: "another-green", Findings: nil},
 	}
 
 	t.Run("not degraded returns input unchanged", func(t *testing.T) {
@@ -29,7 +29,7 @@ func TestFilterGroupsForDegraded(t *testing.T) {
 
 	t.Run("degraded with no findings yields empty", func(t *testing.T) {
 		clean := []findingGroup{
-			{Title: "a", Compliance: 100},
+			{Title: "a"},
 			{Title: "b", Skipped: true},
 		}
 		got := filterGroupsForDegraded(clean, true)

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -2,22 +2,67 @@ package cmd
 
 import "fmt"
 
-// ComplianceError is returned when analysis completes successfully but the
-// measured compliance score falls below the required threshold.
+// ScoreGateError is returned when analysis completes successfully but the
+// Plumber Score falls below the configured gate (--min-points and/or
+// --min-score).
 //
 // It is distinct from a generic runtime error so that callers (e.g. Execute)
 // can map it to a dedicated exit code:
 //
-//	0 – analysis passed (compliance ≥ threshold)
-//	1 – compliance failure (compliance < threshold)
+//	0 – analysis passed (score gate met)
+//	1 – gate failure (score below --min-points / --min-score)
 //	2 – runtime / configuration error
+type ScoreGateError struct {
+	Points    float64
+	MinPoints float64
+	// PointsGate reports whether the points gate was the one that failed;
+	// otherwise the letter gate did.
+	PointsGate bool
+	Letter     string
+	MinLetter  string
+	// CiMissing / CiInvalid mark a run with nothing scoreable: no findings
+	// means a perfect score, but an absent or unparseable CI configuration
+	// must not read as a clean pass. The old GitLab default gate failed this
+	// too (compliance zeroed on missing/invalid CI); on GitHub, whose
+	// compliance ignored CiMissing, this is an intentional tightening — a
+	// repo with no workflows used to pass and now fails.
+	CiMissing bool
+	CiInvalid bool
+	// NoControls marks the config-side variant of nothing-scoreable: the CI
+	// was read but zero controls were evaluated (a .plumber.yaml that only
+	// configures the other provider, all controls disabled, or a skip-all
+	// filter). Zero findings then means "nothing was checked", not "clean" —
+	// the old GitLab default failed this too (compliance 0 when no control
+	// is considered); on GitHub it is the same intentional tightening as
+	// CiMissing.
+	NoControls bool
+}
+
+func (e *ScoreGateError) Error() string {
+	switch {
+	case e.CiMissing:
+		return "no CI configuration was found to score; the gate fails rather than passing an empty pipeline"
+	case e.CiInvalid:
+		return "the CI configuration is invalid and could not be scored; the gate fails rather than passing an unevaluated pipeline"
+	case e.NoControls:
+		return "no controls were evaluated (none enabled for this provider in .plumber.yaml, or all skipped); the gate fails rather than passing an unchecked pipeline"
+	case e.PointsGate:
+		return fmt.Sprintf("Plumber Score %.1f pts (%s) is below the required %.1f pts", e.Points, e.Letter, e.MinPoints)
+	default:
+		return fmt.Sprintf("Plumber Score %s is below the required minimum score %s", e.Letter, e.MinLetter)
+	}
+}
+
+// ComplianceError is returned when the deprecated --threshold gate is active
+// and the measured percentage of passing controls falls below it. It maps to
+// the same exit code 1 as ScoreGateError and disappears with --threshold.
 type ComplianceError struct {
 	Compliance float64
 	Threshold  float64
 }
 
 func (e *ComplianceError) Error() string {
-	return fmt.Sprintf("compliance %.1f%% is below threshold %.1f%%", e.Compliance, e.Threshold)
+	return fmt.Sprintf("passing controls %.1f%% is below the deprecated --threshold %.1f%%; migrate to --min-points / --min-score", e.Compliance, e.Threshold)
 }
 
 // DegradedError is returned when --fail-warnings is set and the run produced
@@ -25,7 +70,7 @@ func (e *ComplianceError) Error() string {
 // because an action's pinned commit could not be resolved to a version (tag
 // list blocked by an org IP allow list, rate limit, or network). The run
 // itself completed; some data could not be checked. It maps to exit code 3
-// (runtime / data condition), distinct from a compliance failure (1) and a
+// (runtime / data condition), distinct from a gate failure (1) and a
 // configuration error (2), so strict CI can tell "we could not fully verify"
 // apart from "a real control failed".
 type DegradedError struct {
@@ -39,11 +84,11 @@ func (e *DegradedError) Error() string {
 // IncompleteDataError is returned when a run is data-collection-degraded:
 // a GitLab merged-CI fetch failed, or some GitHub workflow files / the
 // branch-protection fetch could not be retrieved. The analysis ran on
-// partial data, so Plumber withholds the verdict — score and compliance
-// tables in the terminal, badge/MR updates — and fails the run rather than
-// pass an incomplete scan. Artifacts are still written but stamped degraded
+// partial data, so Plumber withholds the verdict — the score banner in the
+// terminal, badge/MR updates — and fails the run rather than pass an
+// incomplete scan. Artifacts are still written but stamped degraded
 // (#220). Maps to exit code 3, the same "could not fully verify" lane as
-// DegradedError, distinct from a real compliance failure (1) and a
+// DegradedError, distinct from a real gate failure (1) and a
 // configuration error (2).
 type IncompleteDataError struct {
 	Reasons []string

--- a/cmd/gate_test.go
+++ b/cmd/gate_test.go
@@ -1,0 +1,469 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/control"
+	"github.com/getplumber/plumber/provider"
+	"github.com/spf13/cobra"
+)
+
+func scoreWithPoints(points float64) *control.PlumberScoreResult {
+	// Mirrors the documented letter boundaries (docs/scoring.md).
+	letter := "E"
+	switch {
+	case points >= 90:
+		letter = "A"
+	case points >= 71:
+		letter = "B"
+	case points >= 51:
+		letter = "C"
+	case points >= 31:
+		letter = "D"
+	}
+	return &control.PlumberScoreResult{FinalPoints: points, Score: letter}
+}
+
+// ---------------------------------------------------------------------------
+// gateErr / passed — score gate (the default)
+// ---------------------------------------------------------------------------
+
+func TestGate_DefaultPassesOnPerfectScore(t *testing.T) {
+	s := complianceSummary{minPoints: 100, score: scoreWithPoints(100), controlCount: 1}
+	if err := s.gateErr(); err != nil {
+		t.Fatalf("100 pts with default gate must pass, got %v", err)
+	}
+	if !s.passed() {
+		t.Fatal("passed() must be true")
+	}
+}
+
+func TestGate_DefaultFailsOnAnyFinding(t *testing.T) {
+	// Any finding costs points, so <100 pts must fail the default gate —
+	// exact parity with the old default --threshold 100 behavior.
+	s := complianceSummary{minPoints: 100, score: scoreWithPoints(97), controlCount: 1}
+	err := s.gateErr()
+	var gateErr *ScoreGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("97 pts with default gate must fail with ScoreGateError, got %v", err)
+	}
+	if !gateErr.PointsGate {
+		t.Fatal("failure must be attributed to the points gate")
+	}
+}
+
+func TestGate_MinPointsRelaxed(t *testing.T) {
+	s := complianceSummary{minPoints: 80, minPointsSet: true, score: scoreWithPoints(85), controlCount: 1}
+	if err := s.gateErr(); err != nil {
+		t.Fatalf("85 pts >= 80 must pass, got %v", err)
+	}
+}
+
+func TestGate_MinScoreOnlyDisablesPointsGate(t *testing.T) {
+	// --min-score C without --min-points: 85 pts (B) passes even though the
+	// default minPoints value (100) is still in the struct.
+	s := complianceSummary{minPoints: 100, minScore: "C", score: scoreWithPoints(85), controlCount: 1}
+	if err := s.gateErr(); err != nil {
+		t.Fatalf("letter B >= C with points gate off must pass, got %v", err)
+	}
+}
+
+func TestGate_MinScoreFails(t *testing.T) {
+	s := complianceSummary{minPoints: 100, minScore: "B", score: scoreWithPoints(45), controlCount: 1} // D
+	err := s.gateErr()
+	var gateErr *ScoreGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("letter D < B must fail with ScoreGateError, got %v", err)
+	}
+	if gateErr.PointsGate {
+		t.Fatal("failure must be attributed to the letter gate")
+	}
+	if gateErr.Letter != "D" || gateErr.MinLetter != "B" {
+		t.Fatalf("letters = %q < %q, want D < B", gateErr.Letter, gateErr.MinLetter)
+	}
+}
+
+func TestGate_MinScoreEqualLetterPasses(t *testing.T) {
+	// --min-score B on a repo scoring exactly B: equality must pass ("require
+	// at least a B" is the common configuration; the comparison is strict <).
+	s := complianceSummary{minPoints: 100, minScore: "B", score: scoreWithPoints(85), controlCount: 1} // B
+	if err := s.gateErr(); err != nil {
+		t.Fatalf("letter B == min-score B must pass, got %v", err)
+	}
+}
+
+func TestGate_BothGatesMustPass(t *testing.T) {
+	// --min-score C --min-points 90: letter passes (B) but points fail.
+	s := complianceSummary{minPoints: 90, minPointsSet: true, minScore: "C", score: scoreWithPoints(85), controlCount: 1}
+	var gateErr *ScoreGateError
+	if !errors.As(s.gateErr(), &gateErr) {
+		t.Fatal("85 pts < 90 must fail even when the letter gate passes")
+	}
+	if !gateErr.PointsGate {
+		t.Fatal("failure must be attributed to the points gate")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// gateErr — nothing scoreable (missing / invalid CI)
+// ---------------------------------------------------------------------------
+
+func TestGate_MissingCIFailsDespitePerfectScore(t *testing.T) {
+	// No CI configuration → zero findings → 100 pts, but the gate must fail.
+	// The old GitLab default (--threshold 100 on compliance 0) failed this
+	// case too; on GitHub, whose compliance ignored CiMissing, this is an
+	// intentional tightening (a CI-less repo used to pass).
+	s := complianceSummary{minPoints: 100, score: scoreWithPoints(100), ciMissing: true}
+	var gateErr *ScoreGateError
+	if !errors.As(s.gateErr(), &gateErr) || !gateErr.CiMissing {
+		t.Fatalf("missing CI must fail the score gate, got %v", s.gateErr())
+	}
+	if !strings.Contains(s.gateLine(), "no CI configuration") {
+		t.Fatalf("gateLine %q must explain the missing CI", s.gateLine())
+	}
+}
+
+func TestGate_InvalidCIFailsDespitePerfectScore(t *testing.T) {
+	s := complianceSummary{minPoints: 100, score: scoreWithPoints(100), ciInvalid: true}
+	var gateErr *ScoreGateError
+	if !errors.As(s.gateErr(), &gateErr) || !gateErr.CiInvalid {
+		t.Fatalf("invalid CI must fail the score gate, got %v", s.gateErr())
+	}
+}
+
+func TestGate_NoControlsFailsDespitePerfectScore(t *testing.T) {
+	// Valid CI but zero controls evaluated (a .plumber.yaml that only
+	// configures the other provider, all controls disabled, or a skip-all
+	// filter): zero findings score 100 pts, but nothing was checked, so the
+	// gate must fail. The old GitLab default failed this too (compliance 0
+	// when no control is considered).
+	s := complianceSummary{minPoints: 100, score: scoreWithPoints(100), controlCount: 0}
+	var gateErr *ScoreGateError
+	if !errors.As(s.gateErr(), &gateErr) || !gateErr.NoControls {
+		t.Fatalf("zero evaluated controls must fail the score gate, got %v", s.gateErr())
+	}
+	if !strings.Contains(s.gateLine(), "no controls evaluated") {
+		t.Fatalf("gateLine %q must explain that no controls ran", s.gateLine())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// gateErr — deprecated --threshold gate
+// ---------------------------------------------------------------------------
+
+func TestGate_DeprecatedThresholdWins(t *testing.T) {
+	// threshold set: the legacy passing-controls percentage gates, the score
+	// is ignored (even a failing score passes when compliance meets it).
+	s := complianceSummary{
+		thresholdSet: true, threshold: 80, compliance: 90,
+		minPoints: 100, score: scoreWithPoints(20), // letter E
+	}
+	if err := s.gateErr(); err != nil {
+		t.Fatalf("compliance 90 >= threshold 80 must pass, got %v", err)
+	}
+
+	s.compliance = 75
+	var complianceErr *ComplianceError
+	if !errors.As(s.gateErr(), &complianceErr) {
+		t.Fatal("compliance 75 < threshold 80 must fail with ComplianceError")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// gateLine
+// ---------------------------------------------------------------------------
+
+func TestGateLine_ScoreGate(t *testing.T) {
+	s := complianceSummary{minPoints: 100, score: scoreWithPoints(85), controlCount: 1}
+	line := s.gateLine()
+	for _, want := range []string{"score B", "85.0/100 pts", "≥ 100 pts"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("gateLine %q must contain %q", line, want)
+		}
+	}
+}
+
+func TestGateLine_MinScoreOnly(t *testing.T) {
+	s := complianceSummary{minPoints: 100, minScore: "C", score: scoreWithPoints(85), controlCount: 1}
+	line := s.gateLine()
+	if strings.Contains(line, "pts, required ≥ 100 pts") {
+		t.Fatalf("points requirement must not appear when only --min-score gates: %q", line)
+	}
+	if !strings.Contains(line, "≥ C") {
+		t.Fatalf("gateLine %q must contain the letter requirement", line)
+	}
+}
+
+func TestGateLine_DeprecatedThreshold(t *testing.T) {
+	s := complianceSummary{thresholdSet: true, threshold: 80, compliance: 75}
+	line := s.gateLine()
+	if !strings.Contains(line, "75.0%") || !strings.Contains(line, "80%") {
+		t.Fatalf("gateLine %q must carry compliance and threshold", line)
+	}
+	if !strings.Contains(line, "deprecated") {
+		t.Fatalf("gateLine %q must flag the threshold gate as deprecated", line)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resolveGateFlags — gate selection and validation
+// ---------------------------------------------------------------------------
+
+// newGateFlagsCmd resets the gate globals (re-registering the flags rebinds
+// them to their defaults), clears the set-markers and the component env vars,
+// restores everything on cleanup, and returns a command resolveGateFlags can
+// inspect — the same shape runAnalyze hands it.
+func newGateFlagsCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	origThreshold, origThresholdSet := threshold, thresholdSet
+	origMinPoints, origMinPointsSet := minPoints, minPointsSet
+	origMinScore := minScore
+	t.Cleanup(func() {
+		threshold, thresholdSet = origThreshold, origThresholdSet
+		minPoints, minPointsSet = origMinPoints, origMinPointsSet
+		minScore = origMinScore
+	})
+	thresholdSet, minPointsSet = false, false
+	t.Setenv(envKeys["threshold"], "")
+	t.Setenv(envKeys["min-points"], "")
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Float64Var(&threshold, "threshold", 100, "")
+	cmd.Flags().StringVar(&minScore, "min-score", "", "")
+	cmd.Flags().Float64Var(&minPoints, "min-points", 100, "")
+	return cmd
+}
+
+func TestResolveGateFlags_NothingSetIsDefaultScoreGate(t *testing.T) {
+	cmd := newGateFlagsCmd(t)
+	if err := resolveGateFlags(cmd); err != nil {
+		t.Fatalf("no gate flags must resolve cleanly, got %v", err)
+	}
+	if thresholdSet || minPointsSet {
+		t.Fatalf("nothing set: want both markers false, got thresholdSet=%v minPointsSet=%v", thresholdSet, minPointsSet)
+	}
+}
+
+func TestResolveGateFlags_ThresholdExcludesScoreGate(t *testing.T) {
+	t.Run("with min-points", func(t *testing.T) {
+		cmd := newGateFlagsCmd(t)
+		mustSetFlag(t, cmd, "threshold", "80")
+		mustSetFlag(t, cmd, "min-points", "90")
+		if err := resolveGateFlags(cmd); err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+			t.Fatalf("threshold + min-points must error, got %v", err)
+		}
+	})
+	t.Run("with min-score", func(t *testing.T) {
+		cmd := newGateFlagsCmd(t)
+		mustSetFlag(t, cmd, "threshold", "80")
+		mustSetFlag(t, cmd, "min-score", "B")
+		if err := resolveGateFlags(cmd); err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+			t.Fatalf("threshold + min-score must error, got %v", err)
+		}
+	})
+}
+
+func TestResolveGateFlags_EnvThresholdActivatesLegacyGate(t *testing.T) {
+	// The GitLab component path: PLUMBER_ANALYZE_THRESHOLD, never a CLI flag.
+	cmd := newGateFlagsCmd(t)
+	t.Setenv(envKeys["threshold"], "50")
+	threshold = 50 // the env fallback copies the value in before resolveGateFlags runs
+	if err := resolveGateFlags(cmd); err != nil {
+		t.Fatalf("env threshold 50 must resolve cleanly, got %v", err)
+	}
+	if !thresholdSet {
+		t.Fatal("PLUMBER_ANALYZE_THRESHOLD must switch the run to the deprecated gate")
+	}
+}
+
+func TestResolveGateFlags_EnvMinPointsActivatesPointsGate(t *testing.T) {
+	// The GitLab component delivers min_points only via env
+	// (PLUMBER_ANALYZE_MIN_POINTS), never as a CLI flag. minPointsSet must
+	// pick it up: with min-score also set, pointsGateActive() is
+	// minPointsSet || minScore == "", so losing the env clause silently
+	// disables the points gate for exactly that configuration.
+	cmd := newGateFlagsCmd(t)
+	t.Setenv(envKeys["min-points"], "80")
+	minPoints = 80 // the env fallback copies the value in before resolveGateFlags runs
+	minScore = "C"
+	if err := resolveGateFlags(cmd); err != nil {
+		t.Fatalf("env min-points 80 + min-score C must resolve cleanly, got %v", err)
+	}
+	if !minPointsSet {
+		t.Fatal("PLUMBER_ANALYZE_MIN_POINTS must mark the points gate as set")
+	}
+
+	// Both gates active: 60 pts (letter C) meets ≥ C but not ≥ 80 pts.
+	s := complianceSummary{minPoints: 80, minPointsSet: minPointsSet, minScore: minScore, score: scoreWithPoints(60), controlCount: 1}
+	var gateErr *ScoreGateError
+	if !errors.As(s.gateErr(), &gateErr) || !gateErr.PointsGate {
+		t.Fatalf("60 pts < env min-points 80 must fail on the points gate, got %v", s.gateErr())
+	}
+}
+
+func TestResolveGateFlags_MinScoreNormalized(t *testing.T) {
+	cmd := newGateFlagsCmd(t)
+	minScore = " b "
+	if err := resolveGateFlags(cmd); err != nil {
+		t.Fatalf("min-score ' b ' must normalize, got %v", err)
+	}
+	if minScore != "B" {
+		t.Fatalf("min-score = %q, want normalized %q", minScore, "B")
+	}
+}
+
+func TestResolveGateFlags_MinScoreInvalidErrors(t *testing.T) {
+	// An unknown letter must error out (exit 2), never silently disable the
+	// gate: a non-empty minScore turns off the default points gate, so letting
+	// "F" through would pass every run unconditionally.
+	for _, bad := range []string{"F", "AA", "1"} {
+		cmd := newGateFlagsCmd(t)
+		minScore = bad
+		if err := resolveGateFlags(cmd); err == nil || !strings.Contains(err.Error(), "must be one of A, B, C, D, E") {
+			t.Fatalf("min-score %q must error, got %v", bad, err)
+		}
+	}
+}
+
+func TestResolveGateFlags_RangeValidation(t *testing.T) {
+	t.Run("min-points out of range", func(t *testing.T) {
+		cmd := newGateFlagsCmd(t)
+		mustSetFlag(t, cmd, "min-points", "150")
+		if err := resolveGateFlags(cmd); err == nil || !strings.Contains(err.Error(), "between 0 and 100") {
+			t.Fatalf("min-points 150 must error, got %v", err)
+		}
+	})
+	t.Run("threshold out of range", func(t *testing.T) {
+		cmd := newGateFlagsCmd(t)
+		mustSetFlag(t, cmd, "threshold", "150")
+		if err := resolveGateFlags(cmd); err == nil || !strings.Contains(err.Error(), "between 0 and 100") {
+			t.Fatalf("threshold 150 must error, got %v", err)
+		}
+	})
+	t.Run("NaN fails closed", func(t *testing.T) {
+		// ParseFloat accepts "nan", and NaN answers false to every ordered
+		// comparison — both in the range check and in gateErr's
+		// `FinalPoints < minPoints` — so an accepted NaN would disable the
+		// gate entirely. It must be rejected at validation instead.
+		cmd := newGateFlagsCmd(t)
+		mustSetFlag(t, cmd, "min-points", "nan")
+		if err := resolveGateFlags(cmd); err == nil || !strings.Contains(err.Error(), "between 0 and 100") {
+			t.Fatalf("min-points NaN must error, got %v", err)
+		}
+
+		cmd = newGateFlagsCmd(t)
+		mustSetFlag(t, cmd, "threshold", "nan")
+		if err := resolveGateFlags(cmd); err == nil || !strings.Contains(err.Error(), "between 0 and 100") {
+			t.Fatalf("threshold NaN must error, got %v", err)
+		}
+	})
+}
+
+func mustSetFlag(t *testing.T, cmd *cobra.Command, name, value string) {
+	t.Helper()
+	if err := cmd.Flags().Set(name, value); err != nil {
+		t.Fatalf("set --%s=%s: %v", name, value, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildComplianceSummary — ciMissing / ciInvalid wiring from AnalysisResult
+// ---------------------------------------------------------------------------
+
+func TestBuildComplianceSummary_CiWiring(t *testing.T) {
+	newGateFlagsCmd(t) // reset gate globals: default points gate (min-points 100)
+	p := &provider.GitLabProvider{}
+	conf := confWithDebugTrace()
+
+	t.Run("missing CI fails the gate", func(t *testing.T) {
+		s := buildComplianceSummary(p, &control.AnalysisResult{CiMissing: true, CiValid: true}, conf)
+		var gateErr *ScoreGateError
+		if !errors.As(s.gateErr(), &gateErr) || !gateErr.CiMissing {
+			t.Fatalf("CiMissing result must fail with ScoreGateError{CiMissing}, got %v", s.gateErr())
+		}
+	})
+
+	t.Run("invalid CI fails the gate", func(t *testing.T) {
+		s := buildComplianceSummary(p, &control.AnalysisResult{CiValid: false, CiMissing: false}, conf)
+		var gateErr *ScoreGateError
+		if !errors.As(s.gateErr(), &gateErr) || !gateErr.CiInvalid {
+			t.Fatalf("invalid-CI result must fail with ScoreGateError{CiInvalid}, got %v", s.gateErr())
+		}
+	})
+
+	t.Run("valid CI with no findings passes", func(t *testing.T) {
+		s := buildComplianceSummary(p, &control.AnalysisResult{CiValid: true}, conf)
+		if !s.passed() {
+			t.Fatalf("clean run on valid CI must pass, got %v", s.gateErr())
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// buildAnalysisJSONReport — the machine contract action.yml and the job
+// summary parse: conditional minPoints/minScore/threshold keys + passed
+// ---------------------------------------------------------------------------
+
+func TestBuildAnalysisJSONReport_GateContract(t *testing.T) {
+	result := &control.AnalysisResult{CiValid: true}
+	pc := confWithDebugTrace().PlumberConfig
+	params := jsonOutputParams{provider: "gitlab"}
+
+	decode := func(t *testing.T, s complianceSummary) map[string]any {
+		t.Helper()
+		payload, err := buildAnalysisJSONReport(result, pc, s, params)
+		if err != nil {
+			t.Fatalf("buildAnalysisJSONReport: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(payload, &m); err != nil {
+			t.Fatalf("report is not valid JSON: %v", err)
+		}
+		return m
+	}
+	assertAbsent := func(t *testing.T, m map[string]any, keys ...string) {
+		t.Helper()
+		for _, k := range keys {
+			if v, ok := m[k]; ok {
+				t.Errorf("key %q must be absent, got %v", k, v)
+			}
+		}
+	}
+
+	t.Run("default points gate", func(t *testing.T) {
+		m := decode(t, complianceSummary{minPoints: 100, score: scoreWithPoints(100), scoreMode: true, controlCount: 1})
+		if m["minPoints"] != 100.0 {
+			t.Fatalf("minPoints = %v, want 100", m["minPoints"])
+		}
+		if m["passed"] != true {
+			t.Fatalf("passed = %v, want true", m["passed"])
+		}
+		assertAbsent(t, m, "minScore", "threshold", "compliance")
+	})
+
+	t.Run("letter-only gate omits minPoints", func(t *testing.T) {
+		m := decode(t, complianceSummary{minPoints: 100, minScore: "C", score: scoreWithPoints(85), scoreMode: true, controlCount: 1})
+		if m["minScore"] != "C" {
+			t.Fatalf("minScore = %v, want C", m["minScore"])
+		}
+		if m["passed"] != true {
+			t.Fatalf("passed = %v, want true (85 pts, letter B >= C)", m["passed"])
+		}
+		// minPoints must NOT appear: only --min-score gates this run, and the
+		// job summary renders exactly the keys present.
+		assertAbsent(t, m, "minPoints", "threshold", "compliance")
+	})
+
+	t.Run("deprecated threshold gate", func(t *testing.T) {
+		m := decode(t, complianceSummary{thresholdSet: true, threshold: 80, compliance: 75})
+		if m["threshold"] != 80.0 {
+			t.Fatalf("threshold = %v, want 80", m["threshold"])
+		}
+		if m["passed"] != false {
+			t.Fatalf("passed = %v, want false (compliance 75 < 80)", m["passed"])
+		}
+		assertAbsent(t, m, "minPoints", "minScore", "compliance")
+	})
+}

--- a/cmd/legacy_json.go
+++ b/cmd/legacy_json.go
@@ -28,9 +28,8 @@ func _minAccessLevelGitlab(levels []gitlab.BranchProtectionAccessLevel) int {
 // legacyResultsByName builds the per-control `*Result` JSON blocks
 // that the v0.2.x analyzer emitted alongside the bare findings list.
 // External consumers (CI gates, dashboards, MR comment generators)
-// learned to parse those blocks: each control's issues list, its
-// `metrics` object, and the binary `compliance` flag travel together
-// under a stable JSON key. The Rego port had collapsed them into a
+// learned to parse those blocks: each control's issues list and its
+// `metrics` object travel together under a stable JSON key. The Rego port had collapsed them into a
 // single `findings` array, so we reconstruct them here from the IR
 // data still attached to AnalysisResult plus the bucketed Rego
 // findings.
@@ -80,15 +79,10 @@ func legacyResultsByName(result *control.AnalysisResult, pc *configuration.Plumb
 // buildLegacyResult routes a control entry to its legacy JSON
 // builder and returns the (jsonKey, block) pair.
 func buildLegacyResult(e control.ControlEntry, result *control.AnalysisResult, pc *configuration.PlumberConfig, findings []opaengine.Finding) (string, any) {
-	compliance := 100.0
-	if !e.Skipped && len(findings) > 0 {
-		compliance = 0
-	}
 	common := legacyCommon{
-		Compliance: compliance,
-		CiValid:    result.CiValid,
-		CiMissing:  result.CiMissing,
-		Skipped:    e.Skipped,
+		CiValid:   result.CiValid,
+		CiMissing: result.CiMissing,
+		Skipped:   e.Skipped,
 	}
 
 	switch e.ControlName {
@@ -131,12 +125,11 @@ func buildLegacyResult(e control.ControlEntry, result *control.AnalysisResult, p
 }
 
 // legacyCommon carries the bookkeeping fields shared by every
-// `*Result` block: compliance, ciValid, ciMissing, skipped.
+// `*Result` block: ciValid, ciMissing, skipped.
 type legacyCommon struct {
-	Compliance float64
-	CiValid    bool
-	CiMissing  bool
-	Skipped    bool
+	CiValid   bool
+	CiMissing bool
+	Skipped   bool
 }
 
 // projectFinding strips the verbose Rego-side fields (severity,
@@ -414,7 +407,6 @@ func buildImageForbiddenTagsBlock(c legacyCommon, result *control.AnalysisResult
 			"ciInvalid":          0,
 			"ciMissing":          0,
 		},
-		"compliance":           c.Compliance,
 		"version":              "0.4.0",
 		"ciValid":              c.CiValid,
 		"ciMissing":            c.CiMissing,
@@ -442,11 +434,10 @@ func buildImageAuthorizedSourcesBlock(c legacyCommon, result *control.AnalysisRe
 			"ciInvalid":    0,
 			"ciMissing":    0,
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -557,10 +548,9 @@ func buildBranchProtectionBlock(c legacyCommon, result *control.AnalysisResult, 
 	// than emitting `"issues": []`; reproduce that quirk so byte-for-
 	// byte JSON consumers (snapshot tests, etc.) stay aligned.
 	block := map[string]any{
-		"enabled":    !c.Skipped,
-		"compliance": c.Compliance,
-		"version":    "0.2.0",
-		"data":       data,
+		"enabled": !c.Skipped,
+		"version": "0.2.0",
+		"data":    data,
 		"metrics": map[string]any{
 			"branches":                   total,
 			"branchesToProtect":          toProtect,
@@ -593,11 +583,10 @@ func buildHardcodedJobsBlock(c legacyCommon, result *control.AnalysisResult, fin
 			"ciInvalid":     0,
 			"ciMissing":     0,
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -649,11 +638,10 @@ func buildOutdatedIncludesBlock(c legacyCommon, result *control.AnalysisResult, 
 			"ciInvalid":      0,
 			"ciMissing":      0,
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -698,11 +686,10 @@ func buildIncludeRefConfusionBlock(c legacyCommon, result *control.AnalysisResul
 			"ciInvalid":     0,
 			"ciMissing":     0,
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -722,11 +709,10 @@ func buildForbiddenVersionsBlock(c legacyCommon, result *control.AnalysisResult,
 			"usingForbiddenVersion":  usingForbidden,
 			"usingAuthorizedVersion": usingAuthorized,
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -747,11 +733,10 @@ func buildRequirementGroupsBlock(c legacyCommon, cfg *configuration.RequiredComp
 			"ciInvalid":         0,
 			"ciMissing":         0,
 		},
-		"compliance": c.Compliance,
-		"version":    "0.2.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.2.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -772,11 +757,10 @@ func buildRequirementGroupsTemplateBlock(c legacyCommon, cfg *configuration.Requ
 			"ciInvalid":         0,
 			"ciMissing":         0,
 		},
-		"compliance": c.Compliance,
-		"version":    "0.2.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.2.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -852,11 +836,10 @@ func buildDebugTraceBlock(c legacyCommon, result *control.AnalysisResult, findin
 			"totalVariablesChecked": _countAllVariableBindings(result),
 			"forbiddenFound":        len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -872,11 +855,10 @@ func buildVariableInjectionBlock(c legacyCommon, result *control.AnalysisResult,
 			"totalScriptLinesChecked": _countScriptLines(result),
 			"unsafeExpansionsFound":   len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -887,11 +869,10 @@ func buildSecurityJobsBlock(c legacyCommon, result *control.AnalysisResult, pc *
 			"securityJobsFound": _countSecurityJobs(result, pc),
 			"weakenedJobs":      len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -907,11 +888,10 @@ func buildUnverifiedScriptsBlock(c legacyCommon, result *control.AnalysisResult,
 			"totalScriptLinesChecked": _countScriptLines(result),
 			"unverifiedScriptsFound":  len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -931,11 +911,10 @@ func buildJobVariablesOverrideBlock(c legacyCommon, result *control.AnalysisResu
 			"totalVariablesChecked": totalChecked,
 			"overriddenFound":       len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -957,10 +936,9 @@ func buildDockerInDockerBlock(c legacyCommon, result *control.AnalysisResult, fi
 			"dindServicesFound":   _countDinDServices(result),
 			"insecureDaemonFound": insecure,
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }

--- a/cmd/legacy_json_github.go
+++ b/cmd/legacy_json_github.go
@@ -18,15 +18,10 @@ import (
 // caller skips it so we don't pollute the JSON with empty placeholder
 // blocks (the bug the GitLab-only legacyResultsByName had).
 func buildLegacyResultGitHub(e control.ControlEntry, result *control.AnalysisResult, pc *configuration.PlumberConfig, findings []opaengine.Finding) (string, any) {
-	compliance := 100.0
-	if !e.Skipped && len(findings) > 0 {
-		compliance = 0
-	}
 	common := legacyCommon{
-		Compliance: compliance,
-		CiValid:    result.CiValid,
-		CiMissing:  result.CiMissing,
-		Skipped:    e.Skipped,
+		CiValid:   result.CiValid,
+		CiMissing: result.CiMissing,
+		Skipped:   e.Skipped,
 	}
 
 	switch e.ControlName {
@@ -100,11 +95,10 @@ func buildActionPinningBlock(c legacyCommon, result *control.AnalysisResult, fin
 			"actionRefsUnpinned": s.ActionRefsUnpinned,
 			"actionRefsExempt":   s.ActionRefsExempt,
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -137,7 +131,6 @@ func buildImageForbiddenTagsBlockGitHub(c legacyCommon, result *control.Analysis
 			"ciInvalid":          0,
 			"ciMissing":          0,
 		},
-		"compliance":           c.Compliance,
 		"version":              "0.4.0",
 		"ciValid":              c.CiValid,
 		"ciMissing":            c.CiMissing,
@@ -239,10 +232,9 @@ func buildBranchProtectionBlockGitHub(c legacyCommon, result *control.AnalysisRe
 	}
 
 	block := map[string]any{
-		"enabled":    !c.Skipped,
-		"compliance": c.Compliance,
-		"version":    "0.2.0",
-		"data":       data,
+		"enabled": !c.Skipped,
+		"version": "0.2.0",
+		"data":    data,
 		"metrics": map[string]any{
 			"branches":                   len(branches),
 			"branchesToProtect":          totalToProtect,
@@ -295,11 +287,10 @@ func buildDockerInDockerBlockGitHub(c legacyCommon, result *control.AnalysisResu
 			"dindServicesFound":   s.JobsWithDinD,
 			"insecureDaemonFound": insecure,
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -315,11 +306,10 @@ func buildSecurityJobsBlockGitHub(c legacyCommon, result *control.AnalysisResult
 			"securityJobsFound": s.SecurityJobsTotal,
 			"weakenedJobs":      len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -333,11 +323,10 @@ func buildReusableSecretsBlock(c legacyCommon, result *control.AnalysisResult, f
 			"reusableCalls":               s.ReusableCalls,
 			"reusableCallsSecretsInherit": s.ReusableCallsSecretsInherit,
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -352,11 +341,10 @@ func buildTemplateInjectionBlock(c legacyCommon, result *control.AnalysisResult,
 			"scriptLinesChecked":      s.ScriptLinesTotal,
 			"templateInjectionsFound": len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -369,11 +357,10 @@ func buildGitHubEnvInjectionBlock(c legacyCommon, result *control.AnalysisResult
 			"scriptLinesChecked":       s.ScriptLinesTotal,
 			"githubEnvInjectionsFound": len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -388,11 +375,10 @@ func buildOverprovisionedSecretsBlock(c legacyCommon, result *control.AnalysisRe
 			"workflowsScanned":           s.WorkflowsTotal,
 			"secretsContextExportsFound": len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -406,11 +392,10 @@ func buildCachePoisoningBlock(c legacyCommon, result *control.AnalysisResult, fi
 			"workflowsScanned":          s.WorkflowsTotal,
 			"unscopedCacheRestoreFound": len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -425,11 +410,10 @@ func buildDangerousTriggersBlock(c legacyCommon, result *control.AnalysisResult,
 			"workflowsScanned":              s.WorkflowsTotal,
 			"workflowsWithDangerousTrigger": s.WorkflowsWithDangerousTrigger,
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -448,11 +432,10 @@ func buildPullRequestTargetHeadCheckoutBlock(c legacyCommon, result *control.Ana
 			"workflowsScanned":           s.WorkflowsTotal,
 			"headCheckoutsUnderPrTarget": len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -466,11 +449,10 @@ func buildPermissionsBlock(c legacyCommon, result *control.AnalysisResult, findi
 			"workflowsTotal":              s.WorkflowsTotal,
 			"workflowsMissingPermissions": s.WorkflowsMissingPermissions,
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -498,11 +480,10 @@ func buildRequiredActionsBlock(c legacyCommon, cfg *configuration.RequiredAction
 			"satisfiedGroups":   satisfied,
 			"anySatisfiedGroup": len(requirementGroups) > 0 && satisfied > 0,
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -584,11 +565,10 @@ func buildExcessivePermissionsBlock(c legacyCommon, result *control.AnalysisResu
 			"jobsTotal":        s.JobsTotal,
 			"jobsWithWriteAll": len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -610,11 +590,10 @@ func buildAuthorizedActionSourcesBlock(c legacyCommon, result *control.AnalysisR
 			"actionRefsTotal":        s.ActionRefsTotal + s.ActionRefsExempt,
 			"actionRefsUnauthorized": len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -631,11 +610,10 @@ func buildRefConfusionBlock(c legacyCommon, result *control.AnalysisResult, find
 			"actionRefsTotal":     s.ActionRefsTotal,
 			"actionRefsAmbiguous": len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -652,11 +630,10 @@ func buildArchivedActionsBlock(c legacyCommon, result *control.AnalysisResult, f
 			"actionRefsTotal":    s.ActionRefsTotal,
 			"actionRefsArchived": len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -681,11 +658,10 @@ func buildDebugTraceBlockGitHub(c legacyCommon, result *control.AnalysisResult, 
 			"totalVariablesChecked": total,
 			"forbiddenFound":        len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -703,11 +679,10 @@ func buildKnownVulnerableActionsBlock(c legacyCommon, result *control.AnalysisRe
 			"actionRefsTotal":      s.ActionRefsTotal,
 			"actionRefsVulnerable": len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -720,11 +695,10 @@ func buildUnverifiedScriptsBlockGitHub(c legacyCommon, result *control.AnalysisR
 			"totalScriptLinesChecked": s.ScriptLinesTotal,
 			"unverifiedScriptsFound":  len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }
 
@@ -739,10 +713,9 @@ func buildLeakedSecretsBlock(c legacyCommon, _ *control.AnalysisResult, findings
 		"metrics": map[string]any{
 			"hitsFound": len(findings),
 		},
-		"compliance": c.Compliance,
-		"version":    "0.1.0",
-		"ciValid":    c.CiValid,
-		"ciMissing":  c.CiMissing,
-		"skipped":    c.Skipped,
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
 	}
 }

--- a/cmd/legacy_json_github_test.go
+++ b/cmd/legacy_json_github_test.go
@@ -50,17 +50,17 @@ func TestPullRequestTargetHeadCheckoutJSONBlock(t *testing.T) {
 	if issues[0]["url"] == nil {
 		t.Errorf("issue must carry a url (file:line link), got %v", issues[0])
 	}
-	if m["compliance"] != 0.0 {
-		t.Errorf("compliance with a finding = %v, want 0", m["compliance"])
+	if _, present := m["compliance"]; present {
+		t.Errorf("per-control compliance was removed (#320); block still carries %v", m["compliance"])
 	}
 
-	// Clean run: no findings → 100% compliant, empty issues.
+	// Clean run: no findings → empty issues, still no compliance key.
 	cleanName, cleanBlock := buildLegacyResultGitHub(entry, result, nil, nil)
 	if cleanName != "pullRequestTargetHeadCheckoutResult" {
 		t.Fatalf("clean block name = %q", cleanName)
 	}
-	if cm := cleanBlock.(map[string]any); cm["compliance"] != 100.0 {
-		t.Errorf("clean compliance = %v, want 100", cm["compliance"])
+	if cm := cleanBlock.(map[string]any); cm["compliance"] != nil {
+		t.Errorf("clean block must not carry compliance (#320), got %v", cm["compliance"])
 	}
 }
 
@@ -117,16 +117,16 @@ func TestAuthorizedActionSourcesJSONBlock(t *testing.T) {
 	if metrics["actionRefsTotal"] != 6 {
 		t.Errorf("actionRefsTotal = %v, want 6 (ActionRefsTotal 4 + ActionRefsExempt 2)", metrics["actionRefsTotal"])
 	}
-	if m["compliance"] != 0.0 {
-		t.Errorf("compliance with a finding = %v, want 0", m["compliance"])
+	if _, present := m["compliance"]; present {
+		t.Errorf("per-control compliance was removed (#320); block still carries %v", m["compliance"])
 	}
 
-	// Clean run: no findings → 100% compliant.
+	// Clean run: no findings → still no compliance key.
 	cleanName, cleanBlock := buildLegacyResultGitHub(entry, result, nil, nil)
 	if cleanName != "authorizedActionSourcesResult" {
 		t.Fatalf("clean block name = %q", cleanName)
 	}
-	if cm := cleanBlock.(map[string]any); cm["compliance"] != 100.0 {
-		t.Errorf("clean compliance = %v, want 100", cm["compliance"])
+	if cm := cleanBlock.(map[string]any); cm["compliance"] != nil {
+		t.Errorf("clean block must not carry compliance (#320), got %v", cm["compliance"])
 	}
 }

--- a/cmd/render_details.go
+++ b/cmd/render_details.go
@@ -44,12 +44,10 @@ type detailedFinding struct {
 }
 
 // findingGroup collects everything needed to render one per-rule
-// section: its title, compliance, optional stats block, and the list
-// of findings.
+// section: its title, optional stats block, and the list of findings.
 type findingGroup struct {
-	Title      string
-	Compliance float64
-	Skipped    bool
+	Title   string
+	Skipped bool
 	// SkipReason overrides the default "disabled in configuration"
 	// string printed under a skipped header. Empty → renderer uses
 	// the default; non-empty → the renderer prints "(<reason>)".
@@ -115,16 +113,16 @@ func filterGroupsForDegraded(groups []findingGroup, degraded bool) []findingGrou
 
 // renderFindingGroups prints each group in the canonical Plumber
 // format used across providers: horizontal separator header with the
-// rule title and compliance (or "skipped"), the stat lines, and an
-// "Issues Found" listing with severity tag, code, message and doc URL.
-// Groups with no stats, no findings and not marked skipped are not
-// rendered (they would just be empty noise).
+// rule title and pass/issue-count status (or "skipped"), the stat
+// lines, and an "Issues Found" listing with severity tag, code,
+// message and doc URL. Groups with no stats, no findings and not
+// marked skipped are not rendered (they would just be empty noise).
 func renderFindingGroups(groups []findingGroup) {
 	for _, g := range groups {
 		if !g.Skipped && len(g.Stats) == 0 && len(g.Findings) == 0 {
 			continue
 		}
-		printControlHeader(g.Title, g.Compliance, g.Skipped)
+		printControlHeader(g.Title, len(g.Findings), g.Skipped)
 		if g.Skipped {
 			reason := g.SkipReason
 			if reason == "" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,10 +49,13 @@ func Execute() {
 	}
 
 	if err != nil {
+		var gateErr *ScoreGateError
 		var complianceErr *ComplianceError
 		var degradedErr *DegradedError
 		var incompleteErr *IncompleteDataError
 		switch {
+		case errors.As(err, &gateErr):
+			os.Exit(1)
 		case errors.As(err, &complianceErr):
 			os.Exit(1)
 		case errors.As(err, &degradedErr):

--- a/cmd/styles.go
+++ b/cmd/styles.go
@@ -29,16 +29,15 @@ var (
 // Semantic styles — prefer these over raw colors to keep call sites
 // readable.
 var (
-	styleTitle   = lipgloss.NewStyle().Foreground(colBody).Bold(true)
-	styleAccent  = lipgloss.NewStyle().Foreground(colAccent)
-	styleMuted   = lipgloss.NewStyle().Foreground(colMuted)
-	styleDim     = lipgloss.NewStyle().Faint(true)
-	styleError   = lipgloss.NewStyle().Foreground(colCritical)
-	styleSuccess = lipgloss.NewStyle().Foreground(colPass)
-	styleCell    = lipgloss.NewStyle().Padding(0, 1)
-	styleHeader  = lipgloss.NewStyle().Foreground(colBody).Bold(true).Padding(0, 1)
-	styleRule    = lipgloss.NewStyle().Foreground(colMuted)
-	styleFail    = lipgloss.NewStyle().Foreground(colCritical).Bold(true)
+	styleTitle  = lipgloss.NewStyle().Foreground(colBody).Bold(true)
+	styleAccent = lipgloss.NewStyle().Foreground(colAccent)
+	styleMuted  = lipgloss.NewStyle().Foreground(colMuted)
+	styleDim    = lipgloss.NewStyle().Faint(true)
+	styleError  = lipgloss.NewStyle().Foreground(colCritical)
+	styleCell   = lipgloss.NewStyle().Padding(0, 1)
+	styleHeader = lipgloss.NewStyle().Foreground(colBody).Bold(true).Padding(0, 1)
+	styleRule   = lipgloss.NewStyle().Foreground(colMuted)
+	styleFail   = lipgloss.NewStyle().Foreground(colCritical).Bold(true)
 )
 
 // hrWidth controls the width of the horizontal separator used by

--- a/control/badge.go
+++ b/control/badge.go
@@ -8,31 +8,26 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// ManageProjectBadge creates or updates the Plumber compliance badge on the project.
-// The badge shows the compliance percentage with green (passed) or red (failed) color.
-// When useLetterScore is true and ps is non-nil, the badge shows letter score (A–E) instead (see ScoreBadgeURL).
+// ManageProjectBadge creates or updates the Plumber badge on the project.
+// The badge shows the Plumber letter score (A–E, see ScoreBadgeURL) and links
+// to the score documentation. No-op when no score is available.
 func ManageProjectBadge(
 	projectID int,
-	compliance float64,
-	threshold float64,
 	conf *configuration.Configuration,
 	ps *PlumberScoreResult,
-	useLetterScore bool,
 ) error {
+	if ps == nil {
+		return nil
+	}
 	l := logrus.WithFields(logrus.Fields{
-		"action":     "ManageProjectBadge",
-		"projectID":  projectID,
-		"compliance": compliance,
-		"threshold":  threshold,
+		"action":    "ManageProjectBadge",
+		"projectID": projectID,
+		"score":     ps.Score,
 	})
 
 	// Generate badge image URL
-	badgeImageURL := ComplianceBadgeURL(compliance, threshold)
-	badgeLinkURL := conf.GitlabURL + "/" + conf.ProjectPath
-	if useLetterScore && ps != nil {
-		badgeImageURL = ScoreBadgeURL(ps.Score)
-		badgeLinkURL = PlumberScoreDocURL
-	}
+	badgeImageURL := ScoreBadgeURL(ps.Score)
+	badgeLinkURL := PlumberScoreDocURL
 
 	// List existing badges to find Plumber badge
 	badges, err := gitlab.ListProjectBadges(projectID, conf.GitlabToken, conf.GitlabURL, conf)

--- a/control/mrcomment.go
+++ b/control/mrcomment.go
@@ -12,20 +12,23 @@ import (
 
 const (
 	// MRCommentIdentifier is an invisible HTML comment used to find the Plumber
-	// comment in the merge request notes so it can be updated on subsequent runs.
+	// comment in the merge request notes so it can be updated on subsequent
+	// runs. The historical wording is kept on purpose: changing it would stop
+	// matching comments posted by older versions and create duplicates.
 	MRCommentIdentifier = "<!-- Plumber Compliance Comment -->"
 )
 
-// ManageMergeRequestComment creates or updates the Plumber compliance comment
-// on the given merge request. projectID and gitlabURL come from the already-
-// resolved configuration/result; only mrIID is CI-specific.
+// ManageMergeRequestComment creates or updates the Plumber comment on the
+// given merge request. projectID and gitlabURL come from the already-resolved
+// configuration/result; only mrIID is CI-specific. passed is the run's gate
+// verdict and gateLine its human-readable rendering.
 func ManageMergeRequestComment(
 	projectID int,
 	mrIID int,
 	result *AnalysisResult,
 	pc *configuration.PlumberConfig,
-	compliance float64,
-	threshold float64,
+	passed bool,
+	gateLine string,
 	conf *configuration.Configuration,
 	score *PlumberScoreResult,
 	scoreMode bool,
@@ -38,7 +41,7 @@ func ManageMergeRequestComment(
 	})
 
 	// Generate comment body
-	commentBody := generateMRComment(result, pc, compliance, threshold, score, scoreMode, scorePointMode, conf.ControlsFilter, conf.SkipControlsFilter)
+	commentBody := generateMRComment(result, pc, passed, gateLine, score, scoreMode, scorePointMode, conf.ControlsFilter, conf.SkipControlsFilter)
 
 	// List existing notes to find our comment
 	notes, err := gitlab.ListMergeRequestNotes(
@@ -98,19 +101,6 @@ func ManageMergeRequestComment(
 	return nil
 }
 
-// ComplianceBadgeURL builds a Shields.io badge URL for the given compliance %.
-// Color is green if compliance meets threshold, red otherwise.
-// Exported so it can be used by the project badge feature.
-func ComplianceBadgeURL(compliance, threshold float64) string {
-	pct := fmt.Sprintf("%.1f%%", compliance)
-	color := "red"
-	if compliance >= threshold {
-		color = "brightgreen"
-	}
-	message := strings.ReplaceAll(pct, "%", "%25")
-	return fmt.Sprintf("https://img.shields.io/badge/Plumber-%s-%s", message, color)
-}
-
 // ScoreBadgeURL builds a Shields.io badge URL showing the Plumber letter score (A–E).
 func ScoreBadgeURL(letter string) string {
 	color := "red"
@@ -131,23 +121,18 @@ func ScoreBadgeURL(letter string) string {
 
 // generateMRComment builds the Markdown body for the merge request comment
 // based on the analysis result.
-func generateMRComment(result *AnalysisResult, pc *configuration.PlumberConfig, compliance, threshold float64, score *PlumberScoreResult, scoreMode, scorePointMode bool, controlsFilterList, skipControlsList []string) string {
+func generateMRComment(result *AnalysisResult, pc *configuration.PlumberConfig, passed bool, gateLine string, score *PlumberScoreResult, scoreMode, scorePointMode bool, controlsFilterList, skipControlsList []string) string {
 	var b strings.Builder
 
 	// Hidden identifier so we can find this comment later
 	b.WriteString(MRCommentIdentifier + "\n")
 
-	// Compliance badge (green if passed, red if failed)
-	passed := compliance >= threshold
-	badgeURL := ComplianceBadgeURL(compliance, threshold)
+	// Letter-score badge linking to the score documentation
 	if scoreMode && score != nil {
-		badgeURL = ScoreBadgeURL(score.Score)
-		fmt.Fprintf(&b, "[![Plumber](%s)](%s)\n\n", badgeURL, PlumberScoreDocURL)
-	} else {
-		fmt.Fprintf(&b, "![Plumber](%s)\n\n", badgeURL)
+		fmt.Fprintf(&b, "[![Plumber](%s)](%s)\n\n", ScoreBadgeURL(score.Score), PlumberScoreDocURL)
 	}
 
-	b.WriteString("*If this merge request is merged, the expected pipeline compliance will be as shown above.*\n\n")
+	b.WriteString("*If this merge request is merged, the expected Plumber Score will be as shown above.*\n\n")
 
 	if scorePointMode && score != nil {
 		b.WriteString("### Plumber Score\n\n")
@@ -167,14 +152,12 @@ func generateMRComment(result *AnalysisResult, pc *configuration.PlumberConfig, 
 	}
 
 	// Gather controls from the config-driven catalog joined with the
-	// Rego Findings list. Compliance is binary per control (100% when
-	// no finding matches, 0% otherwise); skipped status comes from
-	// .plumber.yaml.
+	// Rego Findings list. A control passes when no finding matches;
+	// skipped status comes from .plumber.yaml.
 	type controlEntry struct {
-		name       string
-		compliance float64
-		issues     int
-		skipped    bool
+		name    string
+		issues  int
+		skipped bool
 	}
 
 	findingsByControl := FindingsByControl(result.Findings)
@@ -185,11 +168,7 @@ func generateMRComment(result *AnalysisResult, pc *configuration.PlumberConfig, 
 	MarkSkippedByFilter(mrEntries, controlsFilterList, skipControlsList)
 	for _, e := range mrEntries {
 		count := len(findingsByControl[e.ControlName])
-		ctrlCompliance := 100.0
-		if !e.Skipped && count > 0 {
-			ctrlCompliance = 0.0
-		}
-		controls = append(controls, controlEntry{e.DisplayName, ctrlCompliance, count, e.Skipped})
+		controls = append(controls, controlEntry{e.DisplayName, count, e.Skipped})
 		if !e.Skipped {
 			totalIssues += count
 		}
@@ -197,26 +176,24 @@ func generateMRComment(result *AnalysisResult, pc *configuration.PlumberConfig, 
 
 	// Controls summary table
 	b.WriteString("### Controls\n\n")
-	b.WriteString("| Control | Compliance | Issues |\n")
-	b.WriteString("|---------|-----------|--------|\n")
+	b.WriteString("| Control | Status | Issues |\n")
+	b.WriteString("|---------|--------|--------|\n")
 	for _, c := range controls {
 		if c.skipped {
 			fmt.Fprintf(&b, "| %s | _skipped_ | — |\n", c.name)
+		} else if c.issues > 0 {
+			fmt.Fprintf(&b, "| :x: %s | failed | %d |\n", c.name, c.issues)
 		} else {
-			icon := ":white_check_mark:"
-			if c.compliance < 100 {
-				icon = ":x:"
-			}
-			fmt.Fprintf(&b, "| %s %s | %.1f%% | %d |\n", icon, c.name, c.compliance, c.issues)
+			fmt.Fprintf(&b, "| :white_check_mark: %s | passed | 0 |\n", c.name)
 		}
 	}
 	b.WriteString("\n")
 
 	// Status line after the table
 	if passed {
-		fmt.Fprintf(&b, ":white_check_mark: **Compliance: %.1f%%** meets threshold (%.0f%%)\n\n", compliance, threshold)
+		fmt.Fprintf(&b, ":white_check_mark: **Plumber check passed** (%s)\n\n", gateLine)
 	} else {
-		fmt.Fprintf(&b, ":warning: **Compliance: %.1f%%** is below threshold (%.0f%%)\n\n", compliance, threshold)
+		fmt.Fprintf(&b, ":warning: **Plumber check failed** — %s\n\n", gateLine)
 	}
 
 	// Issue details as a normal section

--- a/control/mrcomment_test.go
+++ b/control/mrcomment_test.go
@@ -1,0 +1,121 @@
+package control
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
+)
+
+// generateMRComment is the user-facing MR verdict: these tests lock the gate
+// verdict line (passed/gateLine are threaded in from complianceSummary, no
+// longer computed here), the passed/failed/issues Controls table, the hidden
+// update-in-place identifier, and the badge-only-with-a-score rule.
+
+// mrCommentPC enables branch protection and Docker-in-Docker; every other
+// control is absent from the config and must render as skipped.
+func mrCommentPC() *configuration.PlumberConfig {
+	enabled := true
+	return &configuration.PlumberConfig{
+		GitLab: &configuration.ProviderConfig{
+			Controls: configuration.ControlsConfig{
+				BranchMustBeProtected: &configuration.BranchProtectionControlConfig{
+					Enabled: &enabled,
+				},
+				PipelineMustNotUseDockerInDocker: &configuration.DockerInDockerControlConfig{
+					Enabled: &enabled,
+				},
+			},
+		},
+	}
+}
+
+func TestGenerateMRComment_FailedGate(t *testing.T) {
+	result := &AnalysisResult{
+		CiValid: true,
+		Findings: []opaengine.Finding{
+			{Code: string(CodeBranchUnprotected), Message: "branch main is not protected", Severity: "critical"},
+		},
+	}
+	gateLine := "score D — 45.0/100 pts, required ≥ 100 pts"
+	body := generateMRComment(result, mrCommentPC(), false, gateLine, &PlumberScoreResult{Score: "D", FinalPoints: 45}, true, false, nil, nil)
+
+	if !strings.Contains(body, ":warning: **Plumber check failed**") {
+		t.Fatalf("failed gate must render the failure line, got:\n%s", body)
+	}
+	if !strings.Contains(body, gateLine) {
+		t.Fatalf("body must carry the gate line %q, got:\n%s", gateLine, body)
+	}
+	if strings.Contains(body, "Plumber check passed") {
+		t.Fatalf("failed gate must not render a pass, got:\n%s", body)
+	}
+	// The finding must appear in the Issues section with its code.
+	if !strings.Contains(body, "### Issues") || !strings.Contains(body, string(CodeBranchUnprotected)) {
+		t.Fatalf("body must list the finding under Issues, got:\n%s", body)
+	}
+}
+
+func TestGenerateMRComment_PassedGate(t *testing.T) {
+	result := &AnalysisResult{CiValid: true}
+	gateLine := "score A — 100.0/100 pts, required ≥ 100 pts"
+	body := generateMRComment(result, mrCommentPC(), true, gateLine, &PlumberScoreResult{Score: "A", FinalPoints: 100}, true, false, nil, nil)
+
+	if !strings.Contains(body, ":white_check_mark: **Plumber check passed** ("+gateLine+")") {
+		t.Fatalf("passed gate must render the pass line with the gate line, got:\n%s", body)
+	}
+	if strings.Contains(body, "Plumber check failed") {
+		t.Fatalf("passed gate must not render a failure, got:\n%s", body)
+	}
+	if strings.Contains(body, "### Issues") {
+		t.Fatalf("clean run must not render an Issues section, got:\n%s", body)
+	}
+}
+
+func TestGenerateMRComment_IdentifierStability(t *testing.T) {
+	// Update-in-place matches comments posted by older versions against this
+	// exact historical wording; the body must start with it, verbatim.
+	body := generateMRComment(&AnalysisResult{CiValid: true}, mrCommentPC(), true, "gate", nil, false, false, nil, nil)
+	if !strings.HasPrefix(body, MRCommentIdentifier+"\n") {
+		t.Fatalf("body must start with the MR comment identifier, got:\n%s", body[:min(len(body), 120)])
+	}
+	if MRCommentIdentifier != "<!-- Plumber Compliance Comment -->" {
+		t.Fatalf("MRCommentIdentifier changed to %q; older comments would stop matching and duplicate", MRCommentIdentifier)
+	}
+}
+
+func TestGenerateMRComment_ControlsTable(t *testing.T) {
+	result := &AnalysisResult{
+		CiValid: true,
+		Findings: []opaengine.Finding{
+			{Code: string(CodeBranchUnprotected), Message: "branch main is not protected", Severity: "critical"},
+		},
+	}
+	body := generateMRComment(result, mrCommentPC(), false, "gate", nil, false, false, nil, nil)
+
+	if !strings.Contains(body, "| :x: Branch must be protected | failed | 1 |") {
+		t.Fatalf("control with findings must render a failed row, got:\n%s", body)
+	}
+	if !strings.Contains(body, "| :white_check_mark: Pipeline must not use Docker-in-Docker | passed | 0 |") {
+		t.Fatalf("clean enabled control must render a passed row, got:\n%s", body)
+	}
+	if !strings.Contains(body, "| _skipped_ | — |") {
+		t.Fatalf("controls absent from the config must render as skipped, got:\n%s", body)
+	}
+}
+
+func TestGenerateMRComment_BadgeOnlyWithScore(t *testing.T) {
+	result := &AnalysisResult{CiValid: true}
+
+	withScore := generateMRComment(result, mrCommentPC(), true, "gate", &PlumberScoreResult{Score: "B", FinalPoints: 85}, true, false, nil, nil)
+	if !strings.Contains(withScore, ScoreBadgeURL("B")) {
+		t.Fatalf("score mode with a score must render the letter badge, got:\n%s", withScore)
+	}
+
+	// No score (e.g. score withheld): no badge at all — the old always-badge
+	// else branch was removed on purpose.
+	withoutScore := generateMRComment(result, mrCommentPC(), true, "gate", nil, true, false, nil, nil)
+	if strings.Contains(withoutScore, "img.shields.io") {
+		t.Fatalf("no score must render no badge, got:\n%s", withoutScore)
+	}
+}

--- a/control/scoring.go
+++ b/control/scoring.go
@@ -291,6 +291,25 @@ func ComputePlumberScore(codeCounts map[ErrorCode]int) PlumberScoreResult {
 	return out
 }
 
+// ScoreLetterRank orders letter scores for gate comparisons: A=5 … E=1,
+// 0 for anything unknown, so "at least a B" is Rank(got) >= Rank("B").
+func ScoreLetterRank(letter string) int {
+	switch letter {
+	case "A":
+		return 5
+	case "B":
+		return 4
+	case "C":
+		return 3
+	case "D":
+		return 2
+	case "E":
+		return 1
+	default:
+		return 0
+	}
+}
+
 func scoreLetterFromPoints(finalPoints float64) string {
 	switch {
 	case finalPoints >= 90:

--- a/docs/GITHUB_ISSUES.md
+++ b/docs/GITHUB_ISSUES.md
@@ -1860,8 +1860,8 @@ the policy from the repo landing page and the "Security" tab.
 
 | Code | Meaning |
 | :--- | :--- |
-| `0` | No finding above the threshold |
-| `1` | At least one finding / compliance below threshold |
+| `0` | The Plumber Score meets the gate (`--min-points` / `--min-score`) |
+| `1` | The Plumber Score is below the gate |
 | `2` | Runtime error (bad config, missing auth, collector failure) |
 
 ### `.plumber.yaml` control names

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -133,6 +133,22 @@ The legacy `--score` flag is deprecated and has no effect now that the score is 
 
 ---
 
+## Gating CI on the score
+
+The score is also the pass/fail gate for `plumber analyze` (exit code 1 on failure):
+
+- `--min-points <0-100>`: fail when `finalPoints` is below the value. **Default: 100** — any finding fails the run.
+- `--min-score <A-E>`: fail when the letter is below the given one (e.g. `--min-score B` fails on C, D, E). When set without `--min-points`, the letter alone gates.
+- Both set: both must pass.
+
+A run with **nothing scoreable** fails the score gate rather than passing as an empty 100-point pipeline. This covers three cases: no CI configuration found, a CI configuration that could not be parsed, and **zero controls evaluated** (a `.plumber.yaml` that enables no controls for the scanned provider — e.g. a `github:`-only config on a GitLab project — or a filter that skips them all). On GitLab this matches the old default (compliance was 0 in all three cases); **on GitHub it is a behavior change**: the old compliance gate passed a repository with no workflows or no enabled controls, the score gate fails it. Skip Plumber (or use `soft-fail`) on repositories that intentionally have no CI.
+
+The legacy `--threshold` flag (percentage of passing controls) is **deprecated**: it still works, with a warning, and cannot be combined with the score gate flags. Its old default (100) matches the default score gate on any repository with CI to score, since any finding drops both below 100.
+
+The JSON report spells out the active gate next to the verdict: `minPoints` / `minScore` (or `threshold` when the deprecated flag is used) and `passed`.
+
+---
+
 ## Where this appears
 
 | Surface | When |

--- a/output-example.json
+++ b/output-example.json
@@ -26,7 +26,6 @@
       "ciInvalid": 0,
       "ciMissing": 0
     },
-    "compliance": 100,
     "version": "0.2.0",
     "ciValid": true,
     "ciMissing": false,
@@ -47,7 +46,6 @@
       "ciInvalid": 0,
       "ciMissing": 0
     },
-    "compliance": 0,
     "version": "0.1.0",
     "ciValid": true,
     "ciMissing": false,
@@ -55,7 +53,6 @@
   },
   "branchProtectionResult": {
     "enabled": true,
-    "compliance": 100,
     "version": "0.2.0",
     "data": [
       {
@@ -78,7 +75,14 @@
       "projectsCorrectlyProtected": 1
     }
   },
-  "threshold": 50,
-  "compliance": 66.66666666666667,
-  "passed": true
+  "minPoints": 80,
+  "passed": true,
+  "plumberScore": {
+    "profileId": "scoring-v3",
+    "counts": { "critical": 0, "high": 0, "medium": 1, "low": 0 },
+    "rawPoints": 94,
+    "finalPoints": 94,
+    "score": "A",
+    "criticalMalusApplied": false
+  }
 }

--- a/provider/gitlab.go
+++ b/provider/gitlab.go
@@ -113,8 +113,8 @@ func (p *GitLabProvider) PostAnalysisActions(cmd *cobra.Command, result *control
 			// pipeline (#220).
 			fmt.Fprintf(os.Stderr, "Skipping merge request comment: data collection was incomplete; not overwriting with a partial result.\n")
 		} else if mrIID := glabCI.DetectMergeRequestIID(); mrIID != 0 {
-			fmt.Fprintf(os.Stderr, "Merge request pipeline detected (MR !%d), posting compliance comment...\n", mrIID)
-			if err := control.ManageMergeRequestComment(result.ProjectID, mrIID, result, conf.PlumberConfig, s.Compliance, s.Threshold, conf, s.Score, s.ScoreMode, s.ScorePoint); err != nil {
+			fmt.Fprintf(os.Stderr, "Merge request pipeline detected (MR !%d), posting Plumber comment...\n", mrIID)
+			if err := control.ManageMergeRequestComment(result.ProjectID, mrIID, result, conf.PlumberConfig, s.Passed, s.GateLine, conf, s.Score, s.ScoreMode, s.ScorePoint); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to post merge request comment: %v\n", err)
 			} else {
 				fmt.Fprintf(os.Stderr, "Merge request comment posted successfully\n")
@@ -126,8 +126,8 @@ func (p *GitLabProvider) PostAnalysisActions(cmd *cobra.Command, result *control
 		if !shouldUpdate {
 			fmt.Fprintf(os.Stderr, "Skipping badge update (%s)\n", skipReason)
 		} else {
-			fmt.Fprintf(os.Stderr, "Updating project compliance badge...\n")
-			if err := control.ManageProjectBadge(result.ProjectID, s.Compliance, s.Threshold, conf, s.Score, s.ScoreMode); err != nil {
+			fmt.Fprintf(os.Stderr, "Updating project badge...\n")
+			if err := control.ManageProjectBadge(result.ProjectID, conf, s.Score); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to update project badge: %v\n", err)
 			} else {
 				fmt.Fprintf(os.Stderr, "Project badge updated successfully\n")

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -62,11 +62,12 @@ type CIEnvMapping struct {
 	CommitSHA string
 }
 
-// PostActionSummary bundles the compliance values needed by PostAnalysisActions
-// to avoid exceeding the parameter count limit.
+// PostActionSummary bundles the gate outcome needed by PostAnalysisActions
+// to avoid exceeding the parameter count limit. Passed is the active gate's
+// verdict; GateLine is its human-readable rendering for the MR comment.
 type PostActionSummary struct {
-	Compliance float64
-	Threshold  float64
+	Passed     bool
+	GateLine   string
 	Score      *control.PlumberScoreResult
 	ScoreMode  bool
 	ScorePoint bool
@@ -106,7 +107,7 @@ type Provider interface {
 	WritePBOMCycloneDX(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool) error
 
 	// PostAnalysisActions runs provider-specific post-analysis side-effects
-	// such as posting MR comments or updating a compliance badge. Providers
+	// such as posting MR comments or updating the project badge. Providers
 	// that have no post-analysis actions return nil.
 	PostAnalysisActions(cmd *cobra.Command, result *control.AnalysisResult, conf *configuration.Configuration, s PostActionSummary) error
 

--- a/templates/plumber.yml
+++ b/templates/plumber.yml
@@ -30,9 +30,15 @@ spec:
       description: Path to Plumber config file (relative to repo root). If not set, local `.plumber.yaml` if present, then global config `/.plumber.yaml` if present, then default plumber config.
       default: ""
 
-    # Compliance configuration
+    # Gate configuration
+    min_points:
+      description: "Minimum Plumber Score points required to pass (0-100). Default: 100 — any finding fails, same as the previous default behavior. Leave empty to keep the default."
+      default: ""
+    min_score:
+      description: "Minimum Plumber Score letter required to pass (A-E), e.g. B fails on C, D, E. When set without min_points, the letter alone gates."
+      default: ""
     threshold:
-      description: Minimum compliance percentage required to pass (0-100)
+      description: "Deprecated: minimum percentage of passing controls (0-100). Use min_points / min_score to gate on the Plumber Score instead. The default (100) is equivalent to the default score gate and is treated as unset."
       type: number
       default: 100
 
@@ -70,7 +76,7 @@ spec:
       default: false
       type: boolean
     mr_comment:
-      description: Post/update a compliance summary comment on the merge request (requires api scope on the token)
+      description: Post/update a Plumber summary comment on the merge request (requires api scope on the token)
       default: false
       type: boolean
     badge:
@@ -106,7 +112,7 @@ spec:
 ---
 
 # Plumber Component
-# Analyzes GitLab CI/CD pipelines for compliance issues
+# Analyzes GitLab CI/CD pipelines for security issues
 #
 # Prerequisites:
 #   1. Create a GitLab token (PAT or Project/Group Access Token) with:
@@ -140,7 +146,7 @@ spec:
 #   include:
 #     - component: gitlab.com/getplumber/plumber/plumber@v0.3.4
 #       inputs:
-#         threshold: 80
+#         min_points: 80
 #         output_file: results.json
 #         gitlab_token: $MY_CUSTOM_TOKEN_VAR
 
@@ -166,6 +172,8 @@ spec:
     PLUMBER_ANALYZE_GITLAB_URL: $[[ inputs.server_url ]]
     PLUMBER_ANALYZE_PROJECT: $[[ inputs.project_path ]]
     PLUMBER_ANALYZE_BRANCH: $[[ inputs.branch ]]
+    PLUMBER_ANALYZE_MIN_POINTS: $[[ inputs.min_points ]]
+    PLUMBER_ANALYZE_MIN_SCORE: $[[ inputs.min_score ]]
     PLUMBER_ANALYZE_THRESHOLD: $[[ inputs.threshold ]]
     PLUMBER_ANALYZE_PRINT: $[[ inputs.print_output ]]
     PLUMBER_ANALYZE_OUTPUT: $[[ inputs.output_file ]]
@@ -188,6 +196,11 @@ spec:
     # already expanded to the real token value, avoiding the circular reference
     # that occurs if GITLAB_TOKEN is set from $PLUMBER_TOKEN in variables.
     - export GITLAB_TOKEN="$PLUMBER_TOKEN"
+    # threshold is deprecated; its typed default (100) is exactly equivalent
+    # to the default score gate (min-points 100), so treat it as unset. Only
+    # a custom threshold reaches the CLI (and triggers the deprecation
+    # warning there).
+    - if [ "${PLUMBER_ANALYZE_THRESHOLD:-}" = "100" ]; then unset PLUMBER_ANALYZE_THRESHOLD; fi
     - plumber analyze
   artifacts:
     paths:


### PR DESCRIPTION
Closes #320

## What

Makes the **Plumber Score the single grade and CI gate**, removing the severity-blind compliance percentage that confusingly coexisted with it.

### New score gate
- `--min-points <0-100>`: fail (exit 1) when `finalPoints` is below the value. **Default 100** — any finding fails, which is mathematically identical to the old default `--threshold 100`, so default behavior is unchanged.
- `--min-score <A-E>`: fail when the letter is below the given one. When set without `--min-points`, the letter alone gates. Both set: both must pass.
- New `ScoreGateError` maps to exit 1; exit codes keep their shape (2 runtime, 3 degraded/warnings).

### Deprecated `--threshold`
- Still works (the passing-controls percentage is computed internally for it), prints a deprecation warning, and errors when combined with the score gate flags.
- GitHub Action / GitLab component `threshold` inputs follow the same path; the component's typed default (100) is unset in the job script so only custom values reach the CLI.

### Removed from every surface
- JSON report: top-level `compliance` and per-control `compliance` fields are gone. `passed` now means "active gate met", spelled out next to it via `minPoints` / `minScore` (or `threshold` when the deprecated flag is used).
- Terminal: compliance table and per-control percentage headers removed; the status line carries the gate verdict (e.g. `PASSED ✓ (score A — 100.0/100 pts, required ≥ 100 pts)`).
- MR comment: compliance column and threshold status line replaced by pass/fail per control and the gate verdict. The hidden comment identifier is intentionally unchanged so existing comments keep updating in place.
- Project badge: letter score only (`ComplianceBadgeURL` removed).
- GitHub Action: `compliance` output removed, `min-points`/`min-score` inputs added, job summary shows the check verdict + score, artifact default renamed `plumber-compliance` → `plumber-report`.

## Breaking changes
- JSON `compliance` fields removed; `passed` semantics redefined (score gate).
- Action output `compliance` removed; artifact default name changed.
- Verified the hosted score service tolerates the new report: it only reads `plumberScore.score` / `plumberScore.finalPoints`; the platform ingestion contract is forward-tolerant (missing `compliance` decodes to 0, never rejects).

## Tests
- New `cmd/gate_test.go` covers the points gate, letter gate, combined gates, default parity, the deprecated threshold path, and gate-line rendering.
- Legacy JSON tests updated to lock the *absence* of per-control `compliance`.
- `go test ./...` green; exercised the built binary end to end: `--min-score C` (pass), `--min-score A` (exit 1), `--threshold 90` (warns, legacy gate), `--threshold 50 --min-points 80` (exit 2, mutual exclusion).

Docs on getplumber.io are updated in a companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)