### PR TITLE
fix(build): bump Go toolchain to 1.26.5 / 1.25.12 for GO-2026-5856

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         # Exact patch versions: floating specs (stable/oldstable) resolve
         # to a different toolchain over time without any workflow change.
-        go-version: ['1.26.4', '1.25.11']
+        go-version: ['1.26.5', '1.25.12']
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Prepare embedded config
         run: cp .plumber.yaml internal/defaultconfig/default.yaml
@@ -72,7 +72,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Prepare embedded config
         run: cp .plumber.yaml internal/defaultconfig/default.yaml
@@ -97,7 +97,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Prepare embedded config
         run: cp .plumber.yaml internal/defaultconfig/default.yaml

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/getplumber/plumber
 
 go 1.25.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
Govulncheck now fails on every branch (including this repo's main) since the advisory for [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) landed: an Encrypted Client Hello privacy leak in `crypto/tls`, fixed in Go 1.26.5 / 1.25.12. Our code reaches the vulnerable paths through the GitLab HTTP retry transport (`gitlab/retry.go`), so the finding is real, and toolchain-fixed.

- `go.mod`: `toolchain go1.26.4` → `go1.26.5`
- CI: build matrix `1.26.4 / 1.25.11` → `1.26.5 / 1.25.12`; all single-version jobs → `1.26.5`

Unblocks #322 (its Govulncheck failure is this advisory, not the PR's changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)