### PR TITLE
fix(gate): restore the pre-0.4.0 pass for GitHub repositories without (usable) workflows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,13 +26,13 @@ inputs:
     description: "GitHub Enterprise Server host, e.g. ghes.example.com. Default: github.com."
     default: ""
   min-points:
-    description: "Minimum Plumber Score points to pass (0-100). Default: 100 — any finding fails, same as the previous default on repos with workflows. Note: a repo with no workflows now fails the gate (nothing scoreable) where the old compliance gate passed it."
+    description: "Minimum Plumber Score points to pass (0-100). Default: 100 — any finding fails, same as the previous default behavior. A repo with no workflows passes when its enabled controls report no findings; the gate only force-fails when zero controls are enabled."
     default: ""
   min-score:
     description: "Minimum Plumber Score letter to pass (A-E), e.g. B fails on C, D, E. When set without min-points, the letter alone gates."
     default: ""
   threshold:
-    description: "Deprecated: minimum percentage of passing controls (0-100). Use min-points / min-score to gate on the Plumber Score instead. The value 100 is treated as unset (same as the GitLab component): the default score gate also fails on any finding, and additionally fails a repo with no workflows."
+    description: "Deprecated: minimum percentage of passing controls (0-100). Use min-points / min-score to gate on the Plumber Score instead. The value 100 is treated as unset (same as the GitLab component): the default score gate also fails on any finding."
     default: ""
   config-file:
     description: "Path to a .plumber.yaml config. Default: the repo's .plumber.yaml (required — the run fails if absent; generate one with 'plumber config generate')."
@@ -184,9 +184,9 @@ runs:
         # The default gate is the Plumber Score (min-points 100: any finding
         # fails). threshold is deprecated and only forwarded when set to a
         # custom value: an explicit 100 is treated as unset and gates on the
-        # score instead (mirrors the GitLab component). The score gate also
-        # fails a repo with no workflows — nothing scoreable — which the old
-        # GitHub compliance gate passed.
+        # score instead (mirrors the GitLab component). A repo with no
+        # workflows passes when its enabled controls report no findings; the
+        # gate only force-fails when zero controls are enabled.
         [ -n "$IN_MIN_POINTS" ] && args+=(--min-points "$IN_MIN_POINTS")
         [ -n "$IN_MIN_SCORE" ]  && args+=(--min-score "$IN_MIN_SCORE")
         if [ -n "$IN_THRESHOLD" ] && [ "$IN_THRESHOLD" != "100" ]; then

--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -1248,10 +1248,6 @@ type complianceSummary struct {
 	score        *control.PlumberScoreResult
 	scoreMode    bool
 	scorePoint   bool
-	// ciMissing / ciInvalid: nothing was scoreable. Zero findings on an
-	// absent or unparseable CI configuration must not pass the score gate.
-	ciMissing bool
-	ciInvalid bool
 }
 
 // pointsGateActive reports whether the points gate applies: either it was set
@@ -1271,15 +1267,14 @@ func (s complianceSummary) gateErr() error {
 		}
 		return nil
 	}
-	if s.ciMissing {
-		return &ScoreGateError{CiMissing: true}
-	}
-	if s.ciInvalid {
-		return &ScoreGateError{CiInvalid: true}
-	}
-	// Zero controls evaluated (provider-mismatched or empty .plumber.yaml,
-	// skip-all filter): zero findings score 100 pts, but nothing was checked,
-	// so fail closed exactly like the missing/invalid-CI cases above.
+	// Zero controls evaluated: zero findings score 100 pts, but nothing was
+	// checked, so fail closed. This is the ONLY nothing-scoreable case that
+	// fails: a provider-mismatched or empty .plumber.yaml, a skip-all
+	// filter, and — on GitLab, whose ComputeCompliance zeroes the control
+	// count on a missing/invalid CI — a CI-less project. On GitHub a repo
+	// with no (or unparseable) workflows keeps its control count and PASSES
+	// on a clean score: the pre-0.4.0 behavior, restored on purpose so
+	// fleet scanners (plumber radar) don't fail on CI-less repositories.
 	if s.controlCount == 0 {
 		return &ScoreGateError{NoControls: true}
 	}
@@ -1306,12 +1301,6 @@ func (s complianceSummary) passed() bool {
 func (s complianceSummary) gateLine() string {
 	if s.thresholdSet {
 		return fmt.Sprintf("%.1f%% of controls passing, deprecated threshold %.0f%%", s.compliance, s.threshold)
-	}
-	if s.ciMissing {
-		return "no CI configuration found, nothing to score"
-	}
-	if s.ciInvalid {
-		return "invalid CI configuration, nothing to score"
 	}
 	if s.controlCount == 0 {
 		return "no controls evaluated, nothing to score"

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -79,8 +79,6 @@ func buildComplianceSummary(p provider.Provider, result *control.AnalysisResult,
 		score:        computeScoreResult(result, scoreMode),
 		scoreMode:    scoreMode,
 		scorePoint:   showScorePoint,
-		ciMissing:    result.CiMissing,
-		ciInvalid:    !result.CiValid && !result.CiMissing,
 	}
 }
 

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -20,32 +20,22 @@ type ScoreGateError struct {
 	PointsGate bool
 	Letter     string
 	MinLetter  string
-	// CiMissing / CiInvalid mark a run with nothing scoreable: no findings
-	// means a perfect score, but an absent or unparseable CI configuration
-	// must not read as a clean pass. The old GitLab default gate failed this
-	// too (compliance zeroed on missing/invalid CI); on GitHub, whose
-	// compliance ignored CiMissing, this is an intentional tightening — a
-	// repo with no workflows used to pass and now fails.
-	CiMissing bool
-	CiInvalid bool
-	// NoControls marks the config-side variant of nothing-scoreable: the CI
-	// was read but zero controls were evaluated (a .plumber.yaml that only
-	// configures the other provider, all controls disabled, or a skip-all
-	// filter). Zero findings then means "nothing was checked", not "clean" —
-	// the old GitLab default failed this too (compliance 0 when no control
-	// is considered); on GitHub it is the same intentional tightening as
-	// CiMissing.
+	// NoControls marks a run where zero controls were evaluated: a
+	// .plumber.yaml that only configures the other provider, all controls
+	// disabled, a skip-all filter, or — on GitLab, whose compliance zeroes
+	// the control count on a missing/invalid CI — a project with no usable
+	// CI configuration. Zero findings then means "nothing was checked",
+	// not "clean", so the gate fails. On GitHub, a repository with no (or
+	// unparseable) workflows keeps its control count and passes on a clean
+	// score — the pre-0.4.0 behavior, restored on purpose so fleet
+	// scanners don't fail on CI-less repositories.
 	NoControls bool
 }
 
 func (e *ScoreGateError) Error() string {
 	switch {
-	case e.CiMissing:
-		return "no CI configuration was found to score; the gate fails rather than passing an empty pipeline"
-	case e.CiInvalid:
-		return "the CI configuration is invalid and could not be scored; the gate fails rather than passing an unevaluated pipeline"
 	case e.NoControls:
-		return "no controls were evaluated (none enabled for this provider in .plumber.yaml, or all skipped); the gate fails rather than passing an unchecked pipeline"
+		return "no controls were evaluated (no usable CI configuration, none enabled for this provider in .plumber.yaml, or all skipped); the gate fails rather than passing an unchecked run"
 	case e.PointsGate:
 		return fmt.Sprintf("Plumber Score %.1f pts (%s) is below the required %.1f pts", e.Points, e.Letter, e.MinPoints)
 	default:

--- a/cmd/gate_test.go
+++ b/cmd/gate_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/getplumber/plumber/configuration"
 	"github.com/getplumber/plumber/control"
 	"github.com/getplumber/plumber/provider"
 	"github.com/spf13/cobra"
@@ -108,38 +109,16 @@ func TestGate_BothGatesMustPass(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// gateErr — nothing scoreable (missing / invalid CI)
+// gateErr — nothing scoreable (zero controls evaluated)
 // ---------------------------------------------------------------------------
 
-func TestGate_MissingCIFailsDespitePerfectScore(t *testing.T) {
-	// No CI configuration → zero findings → 100 pts, but the gate must fail.
-	// The old GitLab default (--threshold 100 on compliance 0) failed this
-	// case too; on GitHub, whose compliance ignored CiMissing, this is an
-	// intentional tightening (a CI-less repo used to pass).
-	s := complianceSummary{minPoints: 100, score: scoreWithPoints(100), ciMissing: true}
-	var gateErr *ScoreGateError
-	if !errors.As(s.gateErr(), &gateErr) || !gateErr.CiMissing {
-		t.Fatalf("missing CI must fail the score gate, got %v", s.gateErr())
-	}
-	if !strings.Contains(s.gateLine(), "no CI configuration") {
-		t.Fatalf("gateLine %q must explain the missing CI", s.gateLine())
-	}
-}
-
-func TestGate_InvalidCIFailsDespitePerfectScore(t *testing.T) {
-	s := complianceSummary{minPoints: 100, score: scoreWithPoints(100), ciInvalid: true}
-	var gateErr *ScoreGateError
-	if !errors.As(s.gateErr(), &gateErr) || !gateErr.CiInvalid {
-		t.Fatalf("invalid CI must fail the score gate, got %v", s.gateErr())
-	}
-}
-
 func TestGate_NoControlsFailsDespitePerfectScore(t *testing.T) {
-	// Valid CI but zero controls evaluated (a .plumber.yaml that only
-	// configures the other provider, all controls disabled, or a skip-all
-	// filter): zero findings score 100 pts, but nothing was checked, so the
-	// gate must fail. The old GitLab default failed this too (compliance 0
-	// when no control is considered).
+	// Zero controls evaluated (a .plumber.yaml that only configures the
+	// other provider, all controls disabled, a skip-all filter, or a GitLab
+	// project with no usable CI — GitLab compliance zeroes the count): zero
+	// findings score 100 pts, but nothing was checked, so the gate must
+	// fail. The old GitLab default failed this too (compliance 0 when no
+	// control is considered).
 	s := complianceSummary{minPoints: 100, score: scoreWithPoints(100), controlCount: 0}
 	var gateErr *ScoreGateError
 	if !errors.As(s.gateErr(), &gateErr) || !gateErr.NoControls {
@@ -369,34 +348,69 @@ func mustSetFlag(t *testing.T, cmd *cobra.Command, name, value string) {
 }
 
 // ---------------------------------------------------------------------------
-// buildComplianceSummary — ciMissing / ciInvalid wiring from AnalysisResult
+// buildComplianceSummary — per-provider gate wiring from AnalysisResult
 // ---------------------------------------------------------------------------
 
 func TestBuildComplianceSummary_CiWiring(t *testing.T) {
 	newGateFlagsCmd(t) // reset gate globals: default points gate (min-points 100)
-	p := &provider.GitLabProvider{}
+	gl := &provider.GitLabProvider{}
 	conf := confWithDebugTrace()
 
-	t.Run("missing CI fails the gate", func(t *testing.T) {
-		s := buildComplianceSummary(p, &control.AnalysisResult{CiMissing: true, CiValid: true}, conf)
+	t.Run("GitLab missing CI fails via zero controls", func(t *testing.T) {
+		// GitLab compliance zeroes the control count on a missing CI, so a
+		// CI-less GitLab project keeps failing (its historical verdict).
+		s := buildComplianceSummary(gl, &control.AnalysisResult{CiMissing: true, CiValid: true}, conf)
 		var gateErr *ScoreGateError
-		if !errors.As(s.gateErr(), &gateErr) || !gateErr.CiMissing {
-			t.Fatalf("CiMissing result must fail with ScoreGateError{CiMissing}, got %v", s.gateErr())
+		if !errors.As(s.gateErr(), &gateErr) || !gateErr.NoControls {
+			t.Fatalf("GitLab CiMissing must fail with ScoreGateError{NoControls}, got %v", s.gateErr())
 		}
 	})
 
-	t.Run("invalid CI fails the gate", func(t *testing.T) {
-		s := buildComplianceSummary(p, &control.AnalysisResult{CiValid: false, CiMissing: false}, conf)
+	t.Run("GitLab invalid CI fails via zero controls", func(t *testing.T) {
+		s := buildComplianceSummary(gl, &control.AnalysisResult{CiValid: false, CiMissing: false}, conf)
 		var gateErr *ScoreGateError
-		if !errors.As(s.gateErr(), &gateErr) || !gateErr.CiInvalid {
-			t.Fatalf("invalid-CI result must fail with ScoreGateError{CiInvalid}, got %v", s.gateErr())
+		if !errors.As(s.gateErr(), &gateErr) || !gateErr.NoControls {
+			t.Fatalf("GitLab invalid CI must fail with ScoreGateError{NoControls}, got %v", s.gateErr())
 		}
 	})
 
 	t.Run("valid CI with no findings passes", func(t *testing.T) {
-		s := buildComplianceSummary(p, &control.AnalysisResult{CiValid: true}, conf)
+		s := buildComplianceSummary(gl, &control.AnalysisResult{CiValid: true}, conf)
 		if !s.passed() {
 			t.Fatalf("clean run on valid CI must pass, got %v", s.gateErr())
+		}
+	})
+
+	t.Run("GitHub missing CI passes (pre-0.4.0 behavior restored)", func(t *testing.T) {
+		// GitHub compliance counts enabled controls regardless of CiMissing,
+		// so a repo with no workflows scores clean and passes the default
+		// gate — restored on purpose (fleet scanners must not fail on
+		// CI-less repositories). 0.4.0's unconditional CiMissing fail is
+		// reverted.
+		gh := &provider.GitHubProvider{}
+		enabled := true
+		ghConf := configuration.NewDefaultConfiguration()
+		ghConf.PlumberConfig = &configuration.PlumberConfig{
+			GitHub: &configuration.ProviderConfig{
+				Controls: configuration.ControlsConfig{
+					BranchMustBeProtected: &configuration.BranchProtectionControlConfig{Enabled: &enabled},
+				},
+			},
+		}
+		s := buildComplianceSummary(gh, &control.AnalysisResult{CiMissing: true}, ghConf)
+		if !s.passed() {
+			t.Fatalf("GitHub CI-less repo must pass the default gate again, got %v", s.gateErr())
+		}
+	})
+
+	t.Run("GitHub with zero enabled controls still fails", func(t *testing.T) {
+		gh := &provider.GitHubProvider{}
+		emptyConf := configuration.NewDefaultConfiguration()
+		emptyConf.PlumberConfig = &configuration.PlumberConfig{}
+		s := buildComplianceSummary(gh, &control.AnalysisResult{CiMissing: true}, emptyConf)
+		var gateErr *ScoreGateError
+		if !errors.As(s.gateErr(), &gateErr) || !gateErr.NoControls {
+			t.Fatalf("zero enabled controls must keep failing, got %v", s.gateErr())
 		}
 	})
 }

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -141,7 +141,9 @@ The score is also the pass/fail gate for `plumber analyze` (exit code 1 on failu
 - `--min-score <A-E>`: fail when the letter is below the given one (e.g. `--min-score B` fails on C, D, E). When set without `--min-points`, the letter alone gates.
 - Both set: both must pass.
 
-A run with **nothing scoreable** fails the score gate rather than passing as an empty 100-point pipeline. This covers three cases: no CI configuration found, a CI configuration that could not be parsed, and **zero controls evaluated** (a `.plumber.yaml` that enables no controls for the scanned provider — e.g. a `github:`-only config on a GitLab project — or a filter that skips them all). On GitLab this matches the old default (compliance was 0 in all three cases); **on GitHub it is a behavior change**: the old compliance gate passed a repository with no workflows or no enabled controls, the score gate fails it. Skip Plumber (or use `soft-fail`) on repositories that intentionally have no CI.
+A run where **zero controls were evaluated** fails the score gate rather than passing as an empty 100-point pipeline: a `.plumber.yaml` that enables no controls for the scanned provider (e.g. a `github:`-only config on a GitLab project), a filter that skips them all, and — on GitLab, where a missing or unparseable CI configuration leaves no control evaluated — a project with no usable CI. On GitLab this matches the historical default (compliance was 0 in those cases).
+
+**On GitHub, a repository with no workflows (or workflows Plumber cannot parse) passes the default gate** when its enabled controls report no findings — the pre-0.4.0 behavior, deliberately restored so fleet scanners can sweep repositories that have no CI without failing on them. Note the score is then computed over what could be checked; gate on findings, not on CI presence.
 
 The legacy `--threshold` flag (percentage of passing controls) is **deprecated**: it still works, with a warning, and cannot be combined with the score gate flags. Its old default (100) matches the default score gate on any repository with CI to score, since any finding drops both below 100.
 


### PR DESCRIPTION
Reverts one behavior of the 0.4.0 score gate to keep fleet scanners (plumber radar) working: **on GitHub, a repository with no workflows — or workflows Plumber cannot parse — no longer force-fails.**

## What

- `gateErr` no longer fails on `ciMissing` / `ciInvalid`. A CI-less GitHub repo is scored over its enabled controls (zero findings = 100 pts) and passes the default gate, exactly as before 0.4.0. The JSON report still carries `ciMissing` / `ciValid`, so consumers that care can tell the difference.
- **The zero-controls fail-safe is kept**: a `.plumber.yaml` that enables no controls for the scanned provider, or a skip-all filter, still exits 1 (`ScoreGateError{NoControls}`, message extended to name the no-usable-CI cause).
- **GitLab outcome unchanged**: its compliance computation zeroes the control count on a missing/invalid CI, so CI-less GitLab projects keep failing — now through the `NoControls` lane.
- Deprecated `--threshold` path, exit codes (0/1/2/3), and the JSON structure are untouched. Docs (`docs/scoring.md`) and the Action input descriptions updated to match.

## Why

plumber radar sweeps GitHub organizations; many repositories legitimately have no workflows. 0.4.0's "nothing scoreable fails closed" turns every one of them into exit 1, breaking the sweep. The broader question of how unscoreable runs should behave consistently across providers (missing vs invalid CI, "score unknown", scoring from repo-level controls) is deliberately out of scope here and tracked in #335.

## Tests

- Gate wiring per provider: GitLab missing/invalid CI → `NoControls` fail; GitHub missing CI with enabled controls → passes; GitHub with zero enabled controls → still fails.
- `go test ./...` green.
- E2E with the built binary: repo copy without workflows → **exit 0**, `passed: true`, score A/100, `ciMissing: true` in the report; gitlab-only config on GitHub provider → exit 1 `no controls were evaluated…`; dirty fixture → unchanged `70.0 pts (C) below 100` failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)