### PR TITLE
chore: issue templates use issue types instead of labels/title prefixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,12 +1,11 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: "[BUG]"
-labels: bug
+title: ''
+type: Bug
 assignees: ''
 
 ---
-
 ## **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,12 +1,11 @@
 ---
 name: Feature request
 about: Suggest a new feature or improvement for Plumber
-title: "[FEAT]"
-labels: 'enhancement'
+title: ''
+type: Feature
 assignees: ''
 
 ---
-
 ## **Is your feature request related to a problem? Please describe.**
 
 <!-- 


### PR DESCRIPTION
Follow-up to the label cleanup:

- `bug_report.md`: drop the `[BUG]` title prefix and the deleted `bug` label; set `type: Bug` instead.
- `feature_request.md`: drop the `[FEAT]` title prefix and the deleted `enhancement` label; set `type: Feature` instead.

New issues created from these templates now get the org-level issue type automatically, matching the migration of existing issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)