### PR TITLE
feat(gitlab): allow an embedding host to inject a shared HTTP client

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -1,6 +1,7 @@
 package configuration
 
 import (
+	"net/http"
 	"time"
 )
 
@@ -26,6 +27,14 @@ type Configuration struct {
 
 	// HTTP client settings
 	HTTPClientTimeout time.Duration // Timeout for HTTP clients (REST and GraphQL)
+
+	// HTTPClient, when non-nil, is used verbatim by the GitLab REST/GraphQL/HTTP
+	// client constructors instead of building the default retry-wrapped client.
+	// It exists so an EMBEDDING host (the Plumber platform, ADR-0021) can inject
+	// its single, shared, rate-limited/cached client per (provider, instance)
+	// (INVARIANTS rule J). The CLI's own runs leave this nil and get the default
+	// client unchanged — this field is purely additive and transparent.
+	HTTPClient *http.Client
 
 	// GitLab API retry configuration
 	GitlabRetryMaxRetries     int           // Maximum number of retries for GitLab API requests

--- a/gitlab/client.go
+++ b/gitlab/client.go
@@ -26,10 +26,15 @@ func GetNewGitlabClient(token string, instanceUrl string, conf *configuration.Co
 	// Sanitize the instance URL to remove any trailing slashes
 	sanitizedInstance := strings.TrimSuffix(instanceUrl, "/")
 
-	// Create HTTP client with retry logic and timeout
-	httpClient := &http.Client{
-		Transport: WrapTransportWithRetry(http.DefaultTransport, conf),
-		Timeout:   conf.HTTPClientTimeout,
+	// Use the host-injected client when present (ADR-0021 rule J: one shared,
+	// rate-limited/cached client per provider+instance); otherwise build the
+	// default retry-wrapped client — unchanged behavior for the CLI's own runs.
+	httpClient := conf.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Transport: WrapTransportWithRetry(http.DefaultTransport, conf),
+			Timeout:   conf.HTTPClientTimeout,
+		}
 	}
 
 	// Initialize the GitLab client depending on the token type
@@ -60,10 +65,14 @@ func GetGraphQLClient(url string, conf *configuration.Configuration) *graphql.Cl
 	// Build GraphQL url
 	url += gitlabGraphQLPath
 
-	// Create HTTP client with retry logic
-	httpClient := &http.Client{
-		Transport: WrapTransportWithRetry(http.DefaultTransport, conf),
-		Timeout:   conf.HTTPClientTimeout,
+	// Use the host-injected client when present (rule J); otherwise build the
+	// default retry-wrapped client — unchanged for the CLI's own runs.
+	httpClient := conf.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Transport: WrapTransportWithRetry(http.DefaultTransport, conf),
+			Timeout:   conf.HTTPClientTimeout,
+		}
 	}
 
 	// Initialize the GraphQL client
@@ -81,6 +90,11 @@ func GetGraphQLClient(url string, conf *configuration.Configuration) *graphql.Cl
 
 // GetHTTPClient creates a simple HTTP client with retry logic
 func GetHTTPClient(conf *configuration.Configuration) *http.Client {
+	// Use the host-injected client when present (rule J).
+	if conf != nil && conf.HTTPClient != nil {
+		return conf.HTTPClient
+	}
+
 	timeout := 30 * time.Second
 	if conf != nil && conf.HTTPClientTimeout > 0 {
 		timeout = conf.HTTPClientTimeout

--- a/gitlab/client_test.go
+++ b/gitlab/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -77,5 +78,43 @@ func TestGetGraphQLClient_UsesInjectedTransport(t *testing.T) {
 	_ = client.Run(context.Background(), graphql.NewRequest("query{__typename}"), &struct{}{})
 	if !spy.called {
 		t.Fatal("the graphql client did not route through the injected transport")
+	}
+}
+
+// recordingTransport delegates to a real transport but records that it ran, so
+// an integration test can prove a full Fetch went through the injected client.
+type recordingTransport struct {
+	inner http.RoundTripper
+	hit   bool
+}
+
+func (r *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.hit = true
+	return r.inner.RoundTrip(req)
+}
+
+// End-to-end (offline) of the exact path the embedding platform will use: a real
+// Fetch function collecting from a canned GitLab server, routed through the
+// injected client — proving injection + parsing work together, not just that a
+// transport was touched.
+func TestFetchProjectBranches_ThroughInjectedClient(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[{"name":"main"},{"name":"dev"}]`) // < perPage → one page
+	}))
+	defer ts.Close()
+
+	rec := &recordingTransport{inner: http.DefaultTransport}
+	conf := &configuration.Configuration{HTTPClient: &http.Client{Transport: rec}}
+
+	branches, err := FetchProjectBranches(42, "glpat-000000000000", ts.URL, conf)
+	if err != nil {
+		t.Fatalf("FetchProjectBranches through injected client: %v", err)
+	}
+	if len(branches) != 2 || branches[0] != "main" || branches[1] != "dev" {
+		t.Fatalf("want [main dev] parsed from the canned server, got %v", branches)
+	}
+	if !rec.hit {
+		t.Fatal("the fetch did not route through the injected client")
 	}
 }

--- a/gitlab/client_test.go
+++ b/gitlab/client_test.go
@@ -1,0 +1,81 @@
+package gitlab
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/machinebox/graphql"
+)
+
+// spyRoundTripper records whether it was invoked and returns a canned response,
+// so a test can assert an injected client's transport is actually used without
+// any network access.
+type spyRoundTripper struct {
+	called bool
+	body   string
+}
+
+func (s *spyRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	s.called = true
+	body := s.body
+	if body == "" {
+		body = "{}"
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// An injected client (ADR-0021 rule J: the platform supplies one shared,
+// rate-limited/cached client per (provider, instance)) must be used verbatim,
+// transport and all — never rebuilt.
+func TestGetHTTPClient_UsesInjectedClient(t *testing.T) {
+	injected := &http.Client{}
+	conf := &configuration.Configuration{HTTPClient: injected}
+	if got := GetHTTPClient(conf); got != injected {
+		t.Fatal("GetHTTPClient must return the injected *http.Client unchanged")
+	}
+}
+
+// Default path (CLI's own runs, HTTPClient nil) must be byte-for-byte the old
+// behavior — same timeout, non-nil client. Guards against a transparency regression.
+func TestGetHTTPClient_DefaultWhenNil(t *testing.T) {
+	conf := &configuration.Configuration{HTTPClientTimeout: 7 * time.Second}
+	got := GetHTTPClient(conf)
+	if got == nil {
+		t.Fatal("default client must not be nil")
+	}
+	if got.Timeout != 7*time.Second {
+		t.Fatalf("default path changed: want 7s timeout, got %v", got.Timeout)
+	}
+}
+
+func TestGetNewGitlabClient_UsesInjectedTransport(t *testing.T) {
+	spy := &spyRoundTripper{body: `{"version":"0.0.0","revision":"test"}`}
+	conf := &configuration.Configuration{HTTPClient: &http.Client{Transport: spy}}
+	client, err := GetNewGitlabClient("glpat-000000000000", "https://gitlab.example.com", conf)
+	if err != nil {
+		t.Fatalf("GetNewGitlabClient: %v", err)
+	}
+	_, _, _ = client.Version.GetVersion() //nolint:dogsled // only the transport hit matters
+	if !spy.called {
+		t.Fatal("the gitlab client did not route through the injected transport")
+	}
+}
+
+func TestGetGraphQLClient_UsesInjectedTransport(t *testing.T) {
+	spy := &spyRoundTripper{body: `{"data":{}}`}
+	conf := &configuration.Configuration{HTTPClient: &http.Client{Transport: spy}}
+	client := GetGraphQLClient("https://gitlab.example.com", conf)
+	_ = client.Run(context.Background(), graphql.NewRequest("query{__typename}"), &struct{}{})
+	if !spy.called {
+		t.Fatal("the graphql client did not route through the injected transport")
+	}
+}


### PR DESCRIPTION
## Allow an embedding host to inject a shared HTTP client

Adds an optional **`configuration.Configuration.HTTPClient *http.Client`**. When non-nil, the three GitLab client constructors (`GetNewGitlabClient`, `GetGraphQLClient`, `GetHTTPClient`) use it **verbatim** instead of building the default retry-wrapped client; when nil — the CLI's own runs — behavior is **byte-for-byte unchanged**.

### Why
The Plumber **platform** embeds this collector to sync project data out-of-band. Its architecture mandates **one shared, rate-limited / cached HTTP client per `(provider, instance)`** (no per-call clients) so it never stampedes a customer's GitLab API. Today the constructors build a fresh client on every call and accept no injection, so the platform can't supply its coordinated client. This seam lets it — while keeping a **single collector implementation** shared by CLI and platform (no second, drifting collector).

### Why it's safe / transparent for the CLI
- **No signature changes** to any `Fetch…` function; **no call-site changes** (the seam rides on `conf`, already threaded everywhere).
- **Default path untouched**: `HTTPClient == nil` → the exact same `&http.Client{Transport: WrapTransportWithRetry(...), Timeout: conf.HTTPClientTimeout}` as before (timeouts, retry, TLS/CA — all unchanged).
- The injected client is **transport-only**; auth still flows via the `token` argument (`gitlab.NewClient(token, WithHTTPClient(...))`), so token handling is unchanged.

### Tests (offline)
- injected client is returned by `GetHTTPClient` and routed through by the GitLab **REST** and **GraphQL** clients (spy `RoundTripper`, no network);
- default path (`nil`) still yields a non-nil client with the configured timeout (transparency-regression guard).

`gitlab` + `configuration` packages green; whole module builds (`make build && go build ./...`). Diff is 3 files (`configuration/configuration.go`, `gitlab/client.go`, `gitlab/client_test.go`).
