### PR TITLE
test(config): cover GitLab trustedUrls narrowing with includePlumberDefaults false

### DIFF
--- a/configuration/resolve_test.go
+++ b/configuration/resolve_test.go
@@ -465,6 +465,39 @@ gitlab:
 	}
 }
 
+// TestLoadPlumberConfigFromBytes_OverlayNarrowsTrustedUrls is the GitLab
+// containerImageMustComeFromAuthorizedSources mirror of
+// TestLoadPlumberConfigFromBytes_OverlayNarrowsTrustedActions: the
+// narrowing direction (includePlumberDefaults: false) must resolve to
+// ONLY the user's entries, with the curated base trustedUrls absent.
+// This is the security-critical direction: a regression that unions the
+// curated list back in would silently re-widen container-image trust.
+func TestLoadPlumberConfigFromBytes_OverlayNarrowsTrustedUrls(t *testing.T) {
+	firstBase := firstCuratedTrustedURL(t)
+
+	overlay := []byte(`extends: plumber:default
+gitlab:
+  controls:
+    containerImageMustComeFromAuthorizedSources:
+      includePlumberDefaults: false
+      trustedUrls:
+        - myregistry/*
+`)
+	cfg, _, _, err := LoadPlumberConfigFromBytes(overlay, "narrow-overlay-gitlab")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got := cfg.GitLab.Controls.ContainerImageMustComeFromAuthorizedSources.TrustedUrls
+	if !reflect.DeepEqual(got, []string{"myregistry/*"}) {
+		t.Fatalf("includePlumberDefaults:false must narrow to only user entries, got %v", got)
+	}
+	for _, u := range got {
+		if u == firstBase {
+			t.Fatalf("curated base entry %q must be absent when includePlumberDefaults is false", firstBase)
+		}
+	}
+}
+
 // TestLoadPlumberConfigFromBytes_NullOverlaySectionInheritsBase is the
 // end-to-end regression guard for the "null overlay wipes base" bug: an
 // overlay that extends plumber:default and leaves gitlab.controls empty


### PR DESCRIPTION
## Summary

Follow-up to the test-coverage finding left on #365 (merged without it): the GitLab `containerImageMustComeFromAuthorizedSources` branch of `materializeAuthorizedSources` had no end-to-end test for the narrowing direction (`includePlumberDefaults: false`).

This adds `TestLoadPlumberConfigFromBytes_OverlayNarrowsTrustedUrls`, mirroring the existing GitHub test (`OverlayNarrowsTrustedActions`): an overlay extending `plumber:default` with `includePlumberDefaults: false` and its own `trustedUrls` must resolve to only the user's entries, with the curated base list absent. This is the security-critical direction, since a regression here would silently re-widen container-image trust.

## Verification

- New test passes via the full `LoadPlumberConfigFromBytes` path.
- Mutation check: temporarily hardcoding the GitLab branch to union the base list (`unionAllowlist(baseList, oc.TrustedUrls, true)`) makes the test fail, confirming it guards the exact regression described in the finding.
- `go test ./configuration/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)