### PR TITLE
fix(config): trust getplumber/* actions in the shipped default config

### DIFF
--- a/defaultConfig/.plumber.yaml
+++ b/defaultConfig/.plumber.yaml
@@ -643,6 +643,7 @@ github:
         - VirtusLab/* # Scala CLI
         - gleam-lang/* # Gleam
         # ── Security vendors & supply-chain projects ─────────────────
+        - getplumber/* # Plumber (this tool's own actions)
         - step-security/* # StepSecurity (harden-runner)
         - ossf/* # OpenSSF / Linux Foundation (scorecard-action)
         - sigstore/* # Sigstore / LF (cosign-installer)


### PR DESCRIPTION
## Summary

Adds `getplumber/*` to the `trustedGithubActions` allowlist in the shipped default config (`defaultConfig/.plumber.yaml`), under the "Security vendors & supply-chain projects" group.

Without this, a zero-config user who adopts Plumber's own GitHub Action (`uses: getplumber/plumber@...`) gets flagged by `githubActionMustComeFromAuthorizedSources` unless they add an overlay or the same-org/star heuristics happen to cover them. The tool should trust its own action out of the box.

Notes:
- `internal/defaultconfig/default.yaml` is the git-ignored embed copy regenerated by `make embed`; only the source file is changed here.
- Container images were already covered (`docker.io/getplumber/plumber:*` in `trustedUrls`); this covers the `uses:` action reference.

## Test plan

- `make embed && go test ./configuration/... ./cmd/...` passes, including the self-scan/default parity tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)