### PR TITLE
fix(github): resolve default branch even when branchMustBeProtected is off

### DIFF
--- a/cmd/score_push.go
+++ b/cmd/score_push.go
@@ -48,7 +48,7 @@ func effectiveScorePush() (push bool, endpoint string) {
 // fails the run: any problem is a warning. Outside a token-granting CI it can't
 // publish; an explicit --score-push then prints a one-line note instead of
 // skipping silently, so the requested push is never a mystery.
-func maybePushScore(p providerPkg.Provider, conf *configuration.Configuration, payload []byte) {
+func maybePushScore(p providerPkg.Provider, conf *configuration.Configuration, payload []byte, defaultBranch string) {
 	push, endpoint := effectiveScorePush()
 	if !push || len(payload) == 0 {
 		return
@@ -94,7 +94,30 @@ func maybePushScore(p providerPkg.Provider, conf *configuration.Configuration, p
 		scoreWarn(fmt.Sprintf("score push failed: %v", err))
 		return
 	}
-	fmt.Fprintf(os.Stderr, "✓ Plumber Score published: %s/%s/%s\n", endpoint, platform, projectPath)
+	note := ""
+	// The score service keeps only default-branch pushes for the public badge
+	// (per-branch records stay reachable via ?branch=). When this run's branch
+	// is knowably not the default, say so instead of implying the badge changed.
+	if branch := ciRunBranch(p); branch != "" && defaultBranch != "" && branch != defaultBranch {
+		note = fmt.Sprintf(" (but not displayed on the public badge: %q is not the default branch)", branch)
+	}
+	fmt.Fprintf(os.Stderr, "✓ Plumber Score published: %s/%s/%s%s\n", endpoint, platform, projectPath, note)
+}
+
+// ciRunBranch returns the branch this CI run executes on, or "" when unknown
+// (local run, tag pipeline, GitLab MR pipeline). GitHub: GITHUB_REF_NAME when
+// GITHUB_REF_TYPE is "branch" — a PR run reports its merge ref ("N/merge"),
+// which correctly reads as not-the-default-branch. GitLab: CI_COMMIT_BRANCH,
+// set only on branch pipelines. Comparison against the default branch is
+// case-sensitive downstream, matching git ref semantics and the score service.
+func ciRunBranch(p providerPkg.Provider) string {
+	if p.Name() == "github" {
+		if os.Getenv("GITHUB_REF_TYPE") != "branch" {
+			return ""
+		}
+		return strings.TrimSpace(os.Getenv("GITHUB_REF_NAME"))
+	}
+	return strings.TrimSpace(os.Getenv("CI_COMMIT_BRANCH"))
 }
 
 // ciScoreTargetMismatch reports whether the scan analyzed a different project
@@ -293,7 +316,7 @@ func handleScorePublishingOnce(p providerPkg.Provider, conf *configuration.Confi
 		scoreWarn(fmt.Sprintf("could not build the score report payload: %v", err))
 		return
 	}
-	maybePushScore(p, conf, payload)
+	maybePushScore(p, conf, payload, result.DefaultBranch)
 }
 
 // maybeScoreNudge prints an invitation to publish a live badge whenever text

--- a/cmd/score_push_test.go
+++ b/cmd/score_push_test.go
@@ -235,11 +235,147 @@ func TestMaybePushScore_FullFlow(t *testing.T) {
 	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "req")
 
 	conf := &configuration.Configuration{PlumberConfig: &configuration.PlumberConfig{}}
-	maybePushScore(p, conf, []byte(`{"plumberScore":{"score":"A"}}`))
+	maybePushScore(p, conf, []byte(`{"plumberScore":{"score":"A"}}`), "main")
 
 	if gotPath != "/github.com/octo/repo" || gotAuth != "Bearer id-tok" || string(gotBody) != `{"plumberScore":{"score":"A"}}` {
 		t.Fatalf("push not received as expected: path=%q auth=%q body=%q", gotPath, gotAuth, gotBody)
 	}
+}
+
+// TestMaybePushScore_NonDefaultBranchNote proves the success line carries a
+// note when the run's branch is not the repo default: the score service stores
+// such a push per-branch only, so the PUBLIC badge does not change and a bare
+// "published" would be misleading. On the default branch (or when either side
+// is unknown) the line stays bare.
+func TestMaybePushScore_NonDefaultBranchNote(t *testing.T) {
+	p, ok := providerPkg.Get("github")
+	if !ok {
+		t.Skip("github provider not registered")
+	}
+
+	oidc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"value": "id-tok"})
+	}))
+	defer oidc.Close()
+	score := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer score.Close()
+
+	defer func(pp bool, e string) { pushScore, scoreEndpoint = pp, e }(pushScore, scoreEndpoint)
+	pushScore, scoreEndpoint = true, score.URL
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_REPOSITORY", "octo/repo")
+	t.Setenv("GITHUB_SERVER_URL", "https://github.com")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", oidc.URL)
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "req")
+
+	conf := &configuration.Configuration{PlumberConfig: &configuration.PlumberConfig{}}
+	payload := []byte(`{"plumberScore":{"score":"A"}}`)
+
+	push := func(t *testing.T, refType, refName, defaultBranch string) string {
+		t.Helper()
+		t.Setenv("GITHUB_REF_TYPE", refType)
+		t.Setenv("GITHUB_REF_NAME", refName)
+		return captureStderr(t, func() {
+			maybePushScore(p, conf, payload, defaultBranch)
+		})
+	}
+
+	t.Run("non-default branch gets the note", func(t *testing.T) {
+		out := push(t, "branch", "feature-x", "main")
+		if !strings.Contains(out, "Plumber Score published") {
+			t.Fatalf("expected the success line, got: %q", out)
+		}
+		if !strings.Contains(out, "not displayed") || !strings.Contains(out, "feature-x") {
+			t.Fatalf("expected a non-default-branch note naming the branch, got: %q", out)
+		}
+	})
+
+	t.Run("default branch stays bare", func(t *testing.T) {
+		out := push(t, "branch", "main", "main")
+		if !strings.Contains(out, "Plumber Score published") {
+			t.Fatalf("expected the success line, got: %q", out)
+		}
+		if strings.Contains(out, "not displayed") {
+			t.Fatalf("unexpected note on a default-branch run: %q", out)
+		}
+	})
+
+	t.Run("unknown run branch stays bare", func(t *testing.T) {
+		out := push(t, "", "", "main")
+		if strings.Contains(out, "not displayed") {
+			t.Fatalf("unexpected note when the run branch is unknown: %q", out)
+		}
+	})
+
+	t.Run("unknown default branch stays bare", func(t *testing.T) {
+		out := push(t, "branch", "feature-x", "")
+		if strings.Contains(out, "not displayed") {
+			t.Fatalf("unexpected note when the default branch is unknown: %q", out)
+		}
+	})
+}
+
+// TestMaybePushScore_NonDefaultBranchNote_GitLab drives the GitLab side of
+// ciRunBranch (CI_COMMIT_BRANCH): a branch pipeline off the default branch
+// gets the note, the default branch stays bare, and an MR pipeline (empty
+// CI_COMMIT_BRANCH) stays bare because the run branch is unknown.
+func TestMaybePushScore_NonDefaultBranchNote_GitLab(t *testing.T) {
+	p, ok := providerPkg.Get("gitlab")
+	if !ok {
+		t.Skip("gitlab provider not registered")
+	}
+
+	score := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer score.Close()
+
+	defer func(pp bool, e string) { pushScore, scoreEndpoint = pp, e }(pushScore, scoreEndpoint)
+	pushScore, scoreEndpoint = true, score.URL
+	t.Setenv("GITLAB_CI", "true")
+	t.Setenv("CI_PROJECT_PATH", "group/repo")
+	t.Setenv("CI_SERVER_URL", "https://gitlab.com")
+	t.Setenv(gitlabScoreTokenEnv, "tok")
+
+	conf := &configuration.Configuration{PlumberConfig: &configuration.PlumberConfig{}}
+	payload := []byte(`{"plumberScore":{"score":"A"}}`)
+
+	push := func(t *testing.T, commitBranch, defaultBranch string) string {
+		t.Helper()
+		t.Setenv("CI_COMMIT_BRANCH", commitBranch)
+		return captureStderr(t, func() {
+			maybePushScore(p, conf, payload, defaultBranch)
+		})
+	}
+
+	t.Run("non-default branch gets the note", func(t *testing.T) {
+		out := push(t, "feature-x", "main")
+		if !strings.Contains(out, "Plumber Score published") {
+			t.Fatalf("expected the success line, got: %q", out)
+		}
+		if !strings.Contains(out, "not displayed") || !strings.Contains(out, "feature-x") {
+			t.Fatalf("expected a non-default-branch note naming the branch, got: %q", out)
+		}
+	})
+
+	t.Run("default branch stays bare", func(t *testing.T) {
+		out := push(t, "main", "main")
+		if !strings.Contains(out, "Plumber Score published") {
+			t.Fatalf("expected the success line, got: %q", out)
+		}
+		if strings.Contains(out, "not displayed") {
+			t.Fatalf("unexpected note on a default-branch run: %q", out)
+		}
+	})
+
+	t.Run("MR pipeline stays bare", func(t *testing.T) {
+		out := push(t, "", "main")
+		if strings.Contains(out, "not displayed") {
+			t.Fatalf("unexpected note when CI_COMMIT_BRANCH is empty: %q", out)
+		}
+	})
 }
 
 // captureStderr redirects os.Stderr for the duration of fn and returns whatever
@@ -285,7 +421,7 @@ func TestMaybePushScore_LocalNote(t *testing.T) {
 	t.Run("explicit --score-push gets a note", func(t *testing.T) {
 		pushScore, scoreEndpoint = true, ""
 		out := captureStderr(t, func() {
-			maybePushScore(p, &configuration.Configuration{PlumberConfig: &configuration.PlumberConfig{}}, payload)
+			maybePushScore(p, &configuration.Configuration{PlumberConfig: &configuration.PlumberConfig{}}, payload, "main")
 		})
 		if !strings.Contains(out, "--score-push") || !strings.Contains(out, "CI") {
 			t.Fatalf("expected a local-skip note mentioning --score-push and CI, got: %q", out)

--- a/control/task_github.go
+++ b/control/task_github.go
@@ -2,6 +2,7 @@ package control
 
 import (
 	"errors"
+	"os"
 	"strings"
 
 	"github.com/getplumber/plumber/configuration"
@@ -10,6 +11,47 @@ import (
 	"github.com/getplumber/plumber/utils"
 	"github.com/sirupsen/logrus"
 )
+
+// fetchGitHubDefaultBranch is a test seam over the repo-metadata lookup.
+// The default honors PLUMBER_DISABLE_GITHUB_API (same contract as the
+// metadata client) so offline test suites never hit the network.
+var fetchGitHubDefaultBranch = func(host, owner, repo string) (string, error) {
+	if v := os.Getenv(githubpkg.EnvDisableGitHubAPI); v == "1" || v == "true" {
+		return "", nil
+	}
+	return githubpkg.FetchGitHubDefaultBranch(host, owner, repo)
+}
+
+// scanGitHubWorkflowsRemote is a test seam over the remote workflow fetch,
+// which otherwise needs network and auth.
+var scanGitHubWorkflowsRemote = githubpkg.ScanGitHubWorkflowsRemote
+
+// resolveGitHubDefaultBranch overwrites pipeline.DefaultBranch with the
+// forge's answer. The scan seeds the field with the branch being ANALYZED
+// (the --branch flag locally, the fetched ref remotely), which is only a
+// stand-in: the seed is kept when the lookup degrades (no auth, API down),
+// never preferred. This runs
+// regardless of which controls are enabled: the score service only updates
+// the public badge when the pushed report's defaultBranch matches the
+// OIDC-attested branch, so a missing value silently strands every push on
+// a per-branch record.
+func resolveGitHubDefaultBranch(l *logrus.Entry, pipeline *ir.NormalizedPipeline, host, projectPath string) {
+	if pipeline == nil {
+		return
+	}
+	parts := strings.SplitN(projectPath, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return
+	}
+	def, err := fetchGitHubDefaultBranch(host, parts[0], parts[1])
+	if err != nil {
+		l.WithError(err).Debug("default-branch lookup failed; keeping the analyze-branch stand-in")
+		return
+	}
+	if def != "" {
+		pipeline.DefaultBranch = def
+	}
+}
 
 // enrichGitHubBranches populates pipeline.Branches via the GitHub
 // REST API when the user has enabled the branchMustBeProtected
@@ -41,17 +83,9 @@ func enrichGitHubBranches(l *logrus.Entry, pipeline *ir.NormalizedPipeline, host
 		return false
 	}
 
-	// Resolve the repo's actual default branch FIRST: the targeted
-	// fetch list below needs the real default-branch name to know
-	// what to ask for. Best-effort: if the repo metadata fetch fails
-	// we keep whatever the caller pre-populated (the --branch flag
-	// or empty), and the targeted-fetch loop simply skips an empty
-	// name.
-	if pipeline.DefaultBranch == "" {
-		if def, derr := githubpkg.FetchGitHubDefaultBranch(host, parts[0], parts[1]); derr == nil && def != "" {
-			pipeline.DefaultBranch = def
-		}
-	}
+	// pipeline.DefaultBranch is resolved by the caller (see
+	// resolveGitHubDefaultBranch) before this runs; the targeted-fetch
+	// loop simply skips an empty name when that lookup degraded.
 
 	// Build the targeted-fetch set from non-glob patterns plus the
 	// default branch (when defaultMustBeProtected is on). Wildcard
@@ -157,6 +191,8 @@ func RunGitHubAnalysis(conf *configuration.Configuration) (*AnalysisResult, erro
 		l.WithError(perr).Warn("GitHub workflow parse: partial failure (file skipped)")
 	}
 
+	resolveGitHubDefaultBranch(l, pipeline, conf.GithubAPIHost, conf.ProjectPath)
+
 	branchFetchFailed := false
 	if shouldRunControl(controlBranchMustBeProtected, conf) {
 		total := githubpkg.TotalProgressStepsForPipeline(pipeline)
@@ -179,9 +215,11 @@ func RunGitHubAnalysis(conf *configuration.Configuration) (*AnalysisResult, erro
 		total := githubpkg.TotalProgressStepsForPipeline(pipeline)
 		conf.ProgressFunc(total-1, total, "Evaluating policies")
 	}
-	defaultBranch := conf.Branch
+	// The forge-resolved default branch is authoritative; conf.Branch is
+	// the branch being ANALYZED and only stands in when the lookup degraded.
+	defaultBranch := pipeline.DefaultBranch
 	if defaultBranch == "" {
-		defaultBranch = pipeline.DefaultBranch
+		defaultBranch = conf.Branch
 	}
 	result := &AnalysisResult{
 		ProjectPath:    conf.ProjectPath,
@@ -247,7 +285,7 @@ func RunGitHubAnalysisRemote(conf *configuration.Configuration, owner, repo, ref
 	if conf.ProgressFunc != nil {
 		progressFn = githubpkg.ProgressFunc(conf.ProgressFunc)
 	}
-	pipeline, partial, err := githubpkg.ScanGitHubWorkflowsRemote(
+	pipeline, partial, err := scanGitHubWorkflowsRemote(
 		conf.GithubAPIHost,
 		owner, repo, ref,
 		configuration.ProviderNeedsActionMetadata("github"),
@@ -268,6 +306,8 @@ func RunGitHubAnalysisRemote(conf *configuration.Configuration, owner, repo, ref
 		l.WithError(perr).Warn("GitHub workflow parse: partial failure (file skipped)")
 	}
 
+	resolveGitHubDefaultBranch(l, pipeline, conf.GithubAPIHost, owner+"/"+repo)
+
 	branchFetchFailed := false
 	if shouldRunControl(controlBranchMustBeProtected, conf) {
 		total := githubpkg.TotalProgressStepsForPipeline(pipeline)
@@ -287,9 +327,12 @@ func RunGitHubAnalysisRemote(conf *configuration.Configuration, owner, repo, ref
 		total := githubpkg.TotalProgressStepsForPipeline(pipeline)
 		conf.ProgressFunc(total-1, total, "Evaluating policies")
 	}
-	defaultBranch := ref
+	// Same precedence as the local path: the forge-resolved default branch
+	// wins; ref is the analyzed ref and only stands in when the lookup
+	// degraded.
+	defaultBranch := pipeline.DefaultBranch
 	if defaultBranch == "" {
-		defaultBranch = pipeline.DefaultBranch
+		defaultBranch = ref
 	}
 	result := &AnalysisResult{
 		ProjectPath:    owner + "/" + repo,

--- a/control/task_github_test.go
+++ b/control/task_github_test.go
@@ -1,11 +1,14 @@
 package control
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/getplumber/plumber/configuration"
+	githubpkg "github.com/getplumber/plumber/github"
+	"github.com/getplumber/plumber/internal/ir"
 )
 
 func TestRunGitHubAnalysis_EndToEnd(t *testing.T) {
@@ -79,6 +82,202 @@ jobs:
 	// tracked in their own suites.
 	if hits["ISSUE-102:ci/lint"]+hits["ISSUE-102:ci/test"] != 1 {
 		t.Errorf("expected exactly 1 ISSUE-102 finding, got %+v", hits)
+	}
+}
+
+// writeMinimalWorkflow lays down a one-job workflow so the scan finds CI.
+func writeMinimalWorkflow(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	wfDir := filepath.Join(tmp, ".github", "workflows")
+	if err := os.MkdirAll(wfDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workflow := `name: CI
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+`
+	if err := os.WriteFile(filepath.Join(wfDir, "ci.yml"), []byte(workflow), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return tmp
+}
+
+// swapDefaultBranchFetch replaces the package seam for the repo-metadata
+// default-branch lookup. Restores via t.Cleanup.
+func swapDefaultBranchFetch(t *testing.T, fn func(host, owner, repo string) (string, error)) {
+	t.Helper()
+	orig := fetchGitHubDefaultBranch
+	fetchGitHubDefaultBranch = fn
+	t.Cleanup(func() { fetchGitHubDefaultBranch = orig })
+}
+
+// Regression for the "public score badge stays unknown" bug: the report's
+// defaultBranch must be resolved from the forge even when the
+// branchMustBeProtected control is disabled (the only place that used to
+// fetch it), otherwise the score service cannot attribute a default-branch
+// push and never updates the public badge.
+func TestRunGitHubAnalysis_ResolvesDefaultBranch_WithoutBranchProtectionControl(t *testing.T) {
+	var gotOwner, gotRepo string
+	swapDefaultBranchFetch(t, func(host, owner, repo string) (string, error) {
+		gotOwner, gotRepo = owner, repo
+		return "master", nil
+	})
+
+	conf := &configuration.Configuration{
+		ProjectPath:   "toptal/chewy",
+		GitRepoRoot:   writeMinimalWorkflow(t),
+		PlumberConfig: &configuration.PlumberConfig{},
+	}
+
+	result, err := RunGitHubAnalysis(conf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotOwner != "toptal" || gotRepo != "chewy" {
+		t.Errorf("expected fetch for toptal/chewy, got %q/%q", gotOwner, gotRepo)
+	}
+	if result.DefaultBranch != "master" {
+		t.Errorf("expected DefaultBranch %q, got %q", "master", result.DefaultBranch)
+	}
+}
+
+// The forge-resolved default branch is authoritative: --branch selects the
+// branch to ANALYZE and must not masquerade as the repo default when the
+// real one is known.
+func TestRunGitHubAnalysis_ForgeDefaultBranchWinsOverAnalyzeBranch(t *testing.T) {
+	swapDefaultBranchFetch(t, func(host, owner, repo string) (string, error) {
+		return "main", nil
+	})
+
+	conf := &configuration.Configuration{
+		ProjectPath:   "owner/repo",
+		Branch:        "feature-x",
+		GitRepoRoot:   writeMinimalWorkflow(t),
+		PlumberConfig: &configuration.PlumberConfig{},
+	}
+
+	result, err := RunGitHubAnalysis(conf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.DefaultBranch != "main" {
+		t.Errorf("expected DefaultBranch %q, got %q", "main", result.DefaultBranch)
+	}
+	if result.AnalyzeBranch != "feature-x" {
+		t.Errorf("expected AnalyzeBranch %q, got %q", "feature-x", result.AnalyzeBranch)
+	}
+}
+
+// When the lookup degrades (no auth, API down) the analyze branch remains
+// the best available stand-in, matching the pre-existing behavior.
+func TestRunGitHubAnalysis_DefaultBranchFallsBackToAnalyzeBranch(t *testing.T) {
+	swapDefaultBranchFetch(t, func(host, owner, repo string) (string, error) {
+		return "", errors.New("api unreachable")
+	})
+
+	conf := &configuration.Configuration{
+		ProjectPath:   "owner/repo",
+		Branch:        "main",
+		GitRepoRoot:   writeMinimalWorkflow(t),
+		PlumberConfig: &configuration.PlumberConfig{},
+	}
+
+	result, err := RunGitHubAnalysis(conf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.DefaultBranch != "main" {
+		t.Errorf("expected DefaultBranch fallback %q, got %q", "main", result.DefaultBranch)
+	}
+}
+
+// swapRemoteScan replaces the package seam for the remote workflow fetch so
+// RunGitHubAnalysisRemote tests never need network or auth. Restores via
+// t.Cleanup.
+func swapRemoteScan(t *testing.T, fn func(host, owner, repo, ref string, enrich, scanMutableExec bool, progressFn githubpkg.ProgressFunc) (*ir.NormalizedPipeline, []error, error)) {
+	t.Helper()
+	orig := scanGitHubWorkflowsRemote
+	scanGitHubWorkflowsRemote = fn
+	t.Cleanup(func() { scanGitHubWorkflowsRemote = orig })
+}
+
+// remoteScanStub mirrors the production remote scan's seeding contract:
+// pipeline.DefaultBranch starts as the fetched ref.
+func remoteScanStub(host, owner, repo, ref string, enrich, scanMutableExec bool, progressFn githubpkg.ProgressFunc) (*ir.NormalizedPipeline, []error, error) {
+	return &ir.NormalizedPipeline{
+		Provider:      ir.ProviderGitHub,
+		ProjectPath:   owner + "/" + repo,
+		DefaultBranch: ref,
+	}, nil, nil
+}
+
+// Remote-path mirror of the forge-wins test: the analyzed ref must not
+// masquerade as the repo default when the real one is known.
+func TestRunGitHubAnalysisRemote_ForgeDefaultBranchWinsOverRef(t *testing.T) {
+	swapRemoteScan(t, remoteScanStub)
+	swapDefaultBranchFetch(t, func(host, owner, repo string) (string, error) {
+		return "main", nil
+	})
+
+	conf := &configuration.Configuration{PlumberConfig: &configuration.PlumberConfig{}}
+	result, err := RunGitHubAnalysisRemote(conf, "owner", "repo", "feature-x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.DefaultBranch != "main" {
+		t.Errorf("expected DefaultBranch %q, got %q", "main", result.DefaultBranch)
+	}
+	if result.AnalyzeBranch != "feature-x" {
+		t.Errorf("expected AnalyzeBranch %q, got %q", "feature-x", result.AnalyzeBranch)
+	}
+}
+
+// Remote-path mirror of the degraded-lookup fallbacks: the fetched ref stays
+// the stand-in on both the error and the empty-answer shapes.
+func TestRunGitHubAnalysisRemote_DefaultBranchFallsBackToRef(t *testing.T) {
+	for name, fetch := range map[string]func(host, owner, repo string) (string, error){
+		"error":        func(string, string, string) (string, error) { return "", errors.New("api unreachable") },
+		"empty answer": func(string, string, string) (string, error) { return "", nil },
+	} {
+		t.Run(name, func(t *testing.T) {
+			swapRemoteScan(t, remoteScanStub)
+			swapDefaultBranchFetch(t, fetch)
+
+			conf := &configuration.Configuration{PlumberConfig: &configuration.PlumberConfig{}}
+			result, err := RunGitHubAnalysisRemote(conf, "owner", "repo", "feature-x")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.DefaultBranch != "feature-x" {
+				t.Errorf("expected DefaultBranch fallback %q, got %q", "feature-x", result.DefaultBranch)
+			}
+		})
+	}
+}
+
+// The degraded lookup can also answer ("", nil) — 401/404 from the API, or
+// the PLUMBER_DISABLE_GITHUB_API guard. Same fallback as the error path.
+func TestRunGitHubAnalysis_DefaultBranchFallsBackOnEmptyAnswer(t *testing.T) {
+	swapDefaultBranchFetch(t, func(host, owner, repo string) (string, error) {
+		return "", nil
+	})
+
+	conf := &configuration.Configuration{
+		ProjectPath:   "owner/repo",
+		Branch:        "main",
+		GitRepoRoot:   writeMinimalWorkflow(t),
+		PlumberConfig: &configuration.PlumberConfig{},
+	}
+
+	result, err := RunGitHubAnalysis(conf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.DefaultBranch != "main" {
+		t.Errorf("expected DefaultBranch fallback %q, got %q", "main", result.DefaultBranch)
 	}
 }
 

--- a/github/github_metadata.go
+++ b/github/github_metadata.go
@@ -17,10 +17,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// EnvDisableGitHubAPI, when set to a truthy value, forces the
-// GitHub metadata client into degraded mode regardless of gh auth
-// state. Set to "1" by the test suite to keep unit tests offline
-// and fast; production code does not read this variable.
+// EnvDisableGitHubAPI, when set to a truthy value, forces every
+// GitHub API consumer that honors it (the metadata client, the
+// default-branch lookup seam in control) into degraded mode
+// regardless of gh auth state. Set to "1" by the test suites to
+// keep unit tests offline and fast.
 const EnvDisableGitHubAPI = "PLUMBER_DISABLE_GITHUB_API"
 
 // EnvMetadataToken, when set, supplies the token the metadata client uses


### PR DESCRIPTION
## Problem

Repos that disable the `branchMustBeProtected` control get a public Plumber Score badge stuck on "unknown" even though `score-push` reports success.

Observed on toptal/chewy (run 30797478441): the CLI printed `Plumber Score published` with score A, but https://score.getplumber.io/github.com/toptal/chewy shows "unknown" while the per-branch record (`?branch=master`) shows A.

Root cause: on the GitHub path, the repo default branch was only fetched inside the `branchMustBeProtected` enrichment. With that control disabled (chewy turns it off because the default `GITHUB_TOKEN` cannot read protection settings), the report ships `defaultBranch: ""`. The score service only promotes a push to the public badge when the report's `defaultBranch` is non-empty and equals the OIDC-attested branch, so every push landed as a branch-only record.

## Fix

- New `resolveGitHubDefaultBranch` in `control/task_github.go`, called unconditionally in both `RunGitHubAnalysis` and `RunGitHubAnalysisRemote`, after the workflow scan and before branch enrichment. Best-effort: a failed or degraded lookup keeps the previous behavior.
- The forge answer now overwrites the scan seed, and `result.DefaultBranch` prefers it over `--branch` / `ref` (those select the branch to analyze; they only stand in when the lookup degrades). Previously a run with `--branch feature-x` reported `defaultBranch: feature-x`, which could wrongly promote a feature-branch push to the public badge; the healthy path now closes that.
- Test seam `fetchGitHubDefaultBranch`; its default honors `PLUMBER_DISABLE_GITHUB_API` so test suites stay offline.

## Behavior change to be aware of

With `branchMustBeProtected` enabled and `--branch <name>` set, the `defaultMustBeProtected` clause now evaluates the repo's real default branch instead of the `--branch` value. This is a correctness fix but can shift findings/scores for users who relied on the old conflation.

## Not addressed here (follow-up)

- Server side: the score service trusts the client-claimed `defaultBranch` for badge promotion. A pinned old CLI or hand-edited report can still misattribute; the authoritative fix is for the service to resolve the default branch itself (score service repo).

## UX addition

The publish line now carries a short precision when the run is knowably on a non-default branch, instead of implying the public badge changed:

```
✓ Plumber Score published: https://score.getplumber.io/github.com/octo/repo (but not displayed on the public badge: "feature-x" is not the default branch)
```

Run branch detection: `GITHUB_REF_NAME` when `GITHUB_REF_TYPE` is `branch` (a PR run reports its `N/merge` ref, which correctly reads as non-default), `CI_COMMIT_BRANCH` on GitLab. When either the run branch or the default branch is unknown, the line stays bare.

## Verification

- 6 new tests in `control/task_github_test.go`: local path (resolution without the control, forge-wins precedence, error fallback, empty-answer fallback) and remote path (forge wins over ref, degraded fallbacks), written red first via `fetchGitHubDefaultBranch` / `scanGitHubWorkflowsRemote` seams.
- 2 new tests in `cmd/score_push_test.go` covering the note on both providers: GitHub (`GITHUB_REF_TYPE`/`GITHUB_REF_NAME`) and GitLab (`CI_COMMIT_BRANCH`), including bare-line cases (default branch, unknown run branch, unknown default branch, MR pipeline).
- Full suite, `golangci-lint`, and `make deadcode` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
