### PR TITLE
feat(identity): expose the finding-identity recipe and make job mean a job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,22 @@ jobs:
       # always exits 0, so fail on any output. Built from an immutable
       # commit pin like golangci-lint; sum.golang.org verifies the
       # download cryptographically.
+      #
+      # finding/identity is exempt: it publishes the finding-identity recipe
+      # for consumers outside this module (#403), so reachability from our own
+      # main says nothing about whether its API is used. Its surface is pinned
+      # by finding/identity/identity_test.go instead.
+      #
+      # The analyzer runs on its own line, and only its output is filtered.
+      # Piping it straight into `grep -v ... || true` would make a broken run
+      # (module download failure, toolchain mismatch, a package that does not
+      # compile) indistinguishable from a clean one: the `|| true` needed for
+      # the healthy path, where grep suppresses every line, would swallow the
+      # tool's own failure and pass the step with the safety net switched off.
       - name: deadcode
         run: |
-          out=$(go run golang.org/x/tools/cmd/deadcode@09747cdf594a7924dcecb506312be3bd6e437962 ./...) # v0.30.0
+          raw=$(go run golang.org/x/tools/cmd/deadcode@09747cdf594a7924dcecb506312be3bd6e437962 ./...) # v0.30.0
+          out=$(printf '%s\n' "$raw" | grep -v '^finding/identity/' || true)
           if [ -n "$out" ]; then echo "$out"; echo "dead code detected"; exit 1; fi
 
   govulncheck:

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,23 @@ lint: embed
 # always exits 0, so fail on any output. The tool is built from an
 # immutable commit pin (v0.30.0) verified by sum.golang.org; bump the
 # hash and this version note together.
+#
+# finding/identity is exempt: it publishes the finding-identity recipe for
+# consumers outside this module (getplumber/plumber #403), so reachability
+# from our own main says nothing about whether its API is used. Its surface
+# is pinned by finding/identity/identity_test.go instead. Keep the exemption
+# to that one package.
+#
+# The analyzer runs on its own line, under set -e, and only its output is
+# filtered. Piping it straight into `grep -v ... || true` would make a broken
+# run (module download failure, toolchain mismatch, a package that does not
+# compile) indistinguishable from a clean one: the `|| true` needed for the
+# healthy path, where grep suppresses every line, would swallow the tool's own
+# failure and report success with the safety net switched off.
 deadcode: embed
-	@out=$$(go run golang.org/x/tools/cmd/deadcode@09747cdf594a7924dcecb506312be3bd6e437962 ./...); \
+	@set -e; \
+	raw=$$(go run golang.org/x/tools/cmd/deadcode@09747cdf594a7924dcecb506312be3bd6e437962 ./...); \
+	out=$$(printf '%s\n' "$$raw" | grep -v '^finding/identity/' || true); \
 	if [ -n "$$out" ]; then echo "$$out"; echo "deadcode: unreachable functions found"; exit 1; fi
 
 # Vulnerability scan. First run mirrors CI (reachability: what our code can

--- a/cmd/csv.go
+++ b/cmd/csv.go
@@ -38,9 +38,10 @@ import (
 // and the problems are grouped at the bottom. Catalog order is preserved within
 // each group.
 //
-// The "context" column is Finding.Job as-is (a CI job name for job-scoped
-// findings, but some rules put a branch / include path / file there instead), so
-// the header avoids the false claim "job" would make when the value isn't a job.
+// The "context" column is Finding.Job: the CI job a finding sits in, or empty
+// when the finding is not about a job (a branch, an include, a required
+// template, component or action). Those findings carry what they are about in
+// their structured payload and in the identity block of the JSON report.
 func buildCSV(entries []control.ControlEntry, result *control.AnalysisResult) [][]string {
 	header := []string{"code", "fingerprint", "controlName", "status", "severity", "message", "context", "file", "line", "url", "docUrl"}
 	byControl := control.FindingsByControl(result.Findings)

--- a/cmd/legacy_json.go
+++ b/cmd/legacy_json.go
@@ -186,8 +186,22 @@ func projectFinding(f opaengine.Finding, jobKey string) map[string]any {
 	if f.Fingerprint != "" {
 		out["fingerprint"] = f.Fingerprint
 	}
+	// The fingerprint above is a hash, so it cannot tell a consumer WHICH
+	// fields it was built from, and this function strips message, file and
+	// line, so those inputs are not recoverable from the issue entry either.
+	// The identity block carries the selected field set itself, which is what
+	// lets a platform group findings into long-lived issues across runs
+	// without re-deriving (and eventually diverging from) the recipe. Its
+	// version travels with it: see finding/identity.RecipeVersion.
+	if fields, ok := f.Identity(); ok {
+		out["identity"] = map[string]any{
+			"version":            fields.Version,
+			"fields":             fields.Pairs(),
+			"subjectFromMessage": fields.SubjectFromMessage,
+		}
+	}
 	for k, v := range f.Data {
-		if k == "docUrl" || k == "url" || k == "fingerprint" {
+		if k == "docUrl" || k == "url" || k == "fingerprint" || k == "identity" {
 			continue
 		}
 		out[k] = v
@@ -275,11 +289,6 @@ func enrichBranchProtection505IssueMaps(issues []map[string]any, result *control
 		}
 		branchName, _ := issue["branchName"].(string)
 		if branchName == "" {
-			if j, ok := issue["job"].(string); ok {
-				branchName = j
-			}
-		}
-		if branchName == "" {
 			continue
 		}
 		if result == nil || result.ProtectionData == nil {
@@ -348,7 +357,11 @@ func enrichForbiddenVersion404IssueMaps(issues []map[string]any, result *control
 		if code != string(control.CodeIncludeForbiddenVersion) {
 			continue
 		}
-		src, _ := issue["job"].(string)
+		// The rule emits includePath, not job: an include is not a job, and
+		// includePath is what the identity recipe selects for this finding
+		// (finding/identity). It carries the same include-source value job
+		// used to carry, so reading it here restores the enrichment.
+		src, _ := issue["includePath"].(string)
 		if src == "" {
 			continue
 		}
@@ -475,6 +488,22 @@ func buildImageAuthorizedSourcesBlock(c legacyCommon, result *control.AnalysisRe
 	}
 }
 
+// nonCompliantBranchNames collects the branches that fired ISSUE-505, read from
+// the finding's branchName payload. Not from Finding.Job: that field is a CI
+// job name, and a branch is not a job, so branch rules leave it empty.
+func nonCompliantBranchNames(findings []opaengine.Finding) map[string]bool {
+	out := map[string]bool{}
+	for _, f := range findings {
+		if f.Code != string(control.CodeBranchNonCompliant) {
+			continue
+		}
+		if name, ok := f.Data["branchName"].(string); ok && name != "" {
+			out[name] = true
+		}
+	}
+	return out
+}
+
 func buildBranchProtectionBlock(c legacyCommon, result *control.AnalysisResult, pc *configuration.PlumberConfig, findings []opaengine.Finding) map[string]any {
 	total, toProtect, protected, unprotected := _branchProtectionCounts(result, pc)
 	nonCompliant := 0
@@ -521,12 +550,7 @@ func buildBranchProtectionBlock(c legacyCommon, result *control.AnalysisResult, 
 		// fired a non-compliance finding — compliant branches keep
 		// the slim {branchName, default, protected} shape so the JSON
 		// stays focused on what reviewers need to act on.
-		nonCompliantBranches := map[string]bool{}
-		for _, f := range findings {
-			if f.Code == string(control.CodeBranchNonCompliant) {
-				nonCompliantBranches[f.Job] = true
-			}
-		}
+		nonCompliantBranches := nonCompliantBranchNames(findings)
 		// Iterate the branches with the default branch first, then the
 		// rest sorted alphabetically — matches v0.2.x's display order
 		// where the project's flagship branch leads the data list.
@@ -734,7 +758,7 @@ func buildForbiddenVersionsBlock(c legacyCommon, result *control.AnalysisResult,
 	if usingAuthorized < 0 {
 		usingAuthorized = 0
 	}
-	issues := projectFindings(findings, "job")
+	issues := projectFindings(findings, "")
 	enrichForbiddenVersion404IssueMaps(issues, result)
 	return map[string]any{
 		"issues": issues,
@@ -758,7 +782,7 @@ func buildRequirementGroupsBlock(c legacyCommon, cfg *configuration.RequiredComp
 	requirementGroups, satisfied := _resolveRequirementGroups(groups, result)
 	return map[string]any{
 		"requirementGroups": requirementGroups,
-		"issues":            projectFindings(findings, "job"),
+		"issues":            projectFindings(findings, ""),
 		"overriddenIssues":  []any{},
 		"metrics": map[string]any{
 			"totalGroups":       len(requirementGroups),
@@ -782,7 +806,7 @@ func buildRequirementGroupsTemplateBlock(c legacyCommon, cfg *configuration.Requ
 	requirementGroups, satisfied := _resolveRequirementGroups(groups, result)
 	return map[string]any{
 		"requirementGroups": requirementGroups,
-		"issues":            projectFindings(findings, "job"),
+		"issues":            projectFindings(findings, ""),
 		"overriddenIssues":  []any{},
 		"metrics": map[string]any{
 			"totalGroups":       len(requirementGroups),

--- a/cmd/legacy_json_enrich_test.go
+++ b/cmd/legacy_json_enrich_test.go
@@ -1,11 +1,15 @@
 package cmd
 
 import (
+	"context"
 	"testing"
 
 	"github.com/getplumber/plumber/configuration"
 	"github.com/getplumber/plumber/control"
 	"github.com/getplumber/plumber/gitlab"
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
+	"github.com/getplumber/plumber/internal/ir"
+	"github.com/getplumber/plumber/policies"
 )
 
 func TestEnrichBranchProtection505IssueMaps_LegacyDisplays(t *testing.T) {
@@ -42,7 +46,6 @@ func TestEnrichBranchProtection505IssueMaps_LegacyDisplays(t *testing.T) {
 		"code":       string(control.CodeBranchNonCompliant),
 		"docUrl":     "x",
 		"branchName": "main",
-		"job":        "main",
 	}}
 	enrichBranchProtection505IssueMaps(issues, result, pc)
 	iss := issues[0]
@@ -89,9 +92,9 @@ func TestEnrichForbiddenVersion404IssueMaps_OriginFields(t *testing.T) {
 		},
 	}
 	issues := []map[string]any{{
-		"code":   string(control.CodeIncludeForbiddenVersion),
-		"docUrl": "x",
-		"job":    "file@1.0.0",
+		"code":        string(control.CodeIncludeForbiddenVersion),
+		"docUrl":      "x",
+		"includePath": "file@1.0.0",
 	}}
 	enrichForbiddenVersion404IssueMaps(issues, result)
 	iss := issues[0]
@@ -109,5 +112,89 @@ func TestEnrichForbiddenVersion404IssueMaps_OriginFields(t *testing.T) {
 	}
 	if iss["originHash"] != uint64(99) {
 		t.Fatalf("originHash: got %v", iss["originHash"])
+	}
+}
+
+// TestBuildForbiddenVersionsBlock_EnrichmentSurvivesRealFindings is the
+// regression guard the job-field-semantics change was missing: it is the
+// only test that runs the OPA engine over an ISSUE-404 fixture and pipes the
+// resulting findings through buildForbiddenVersionsBlock, joining the two
+// halves that a real regression once let drift apart (the rule started
+// emitting includePath while the enrichment still read job, and nothing
+// caught it because no test exercised both together). It asserts that the
+// origin-collector enrichment (gitlabIncludeLocation, version) still lands
+// on the issue once the rule's payload changes.
+func TestBuildForbiddenVersionsBlock_EnrichmentSurvivesRealFindings(t *testing.T) {
+	t.Parallel()
+	engine := opaengine.New()
+	if err := engine.LoadFromFSFiltered(policies.FS, nil); err != nil {
+		t.Fatalf("load embedded policies: %v", err)
+	}
+	cfg := map[string]any{
+		"includesForbiddenVersions": map[string]any{
+			"forbiddenVersions": []string{"main"},
+		},
+	}
+	pipeline := &ir.NormalizedPipeline{
+		Provider: ir.ProviderGitLab,
+		Includes: []ir.Include{
+			{Kind: "project", Source: "group/project@main", Ref: "main"},
+		},
+	}
+	findings, err := engine.Evaluate(context.Background(), pipeline, cfg)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	var forbidden []opaengine.Finding
+	for _, f := range findings {
+		if f.Code == "ISSUE-404" {
+			forbidden = append(forbidden, f)
+		}
+	}
+	if len(forbidden) != 1 {
+		t.Fatalf("expected 1 ISSUE-404 finding, got %d (%v)", len(forbidden), findings)
+	}
+	if forbidden[0].Job != "" {
+		t.Fatalf("ISSUE-404 finding carries job = %q, want empty", forbidden[0].Job)
+	}
+
+	result := &control.AnalysisResult{
+		PipelineOriginData: &gitlab.GitlabPipelineOriginData{
+			Origins: []gitlab.GitlabPipelineOriginDataFull{
+				{
+					GitlabPipelineOriginDataGeneric: gitlab.GitlabPipelineOriginDataGeneric{
+						OriginType: "project",
+						GitlabIncludeOrigin: gitlab.IncludeOriginWithoutRef{
+							Location: "group/project@main",
+							Type:     "project",
+							Project:  "group/project",
+						},
+						OriginHash: 42,
+					},
+					GitlabPipelineOriginDataProjectSpecific: gitlab.GitlabPipelineOriginDataProjectSpecific{
+						Version: "main",
+					},
+				},
+			},
+		},
+	}
+
+	block := buildForbiddenVersionsBlock(legacyCommon{}, result, forbidden)
+	issues, ok := block["issues"].([]map[string]any)
+	if !ok || len(issues) != 1 {
+		t.Fatalf("issues = %#v, want exactly one issue map", block["issues"])
+	}
+	iss := issues[0]
+	if _, has := iss["job"]; has {
+		t.Errorf("issue carries a job key = %v, want it absent for a finding that is not about a job", iss["job"])
+	}
+	if iss["includePath"] != "group/project@main" {
+		t.Fatalf("includePath: got %v", iss["includePath"])
+	}
+	if iss["gitlabIncludeLocation"] != "group/project@main" {
+		t.Fatalf("gitlabIncludeLocation enrichment did not survive: got %v", iss["gitlabIncludeLocation"])
+	}
+	if iss["version"] != "main" {
+		t.Fatalf("version enrichment did not survive: got %v", iss["version"])
 	}
 }

--- a/cmd/legacy_json_github.go
+++ b/cmd/legacy_json_github.go
@@ -476,7 +476,7 @@ func buildRequiredActionsBlock(c legacyCommon, cfg *configuration.RequiredAction
 	requirementGroups, satisfied := _resolveRequiredActionGroups(groups, result)
 	return map[string]any{
 		"requirementGroups": requirementGroups,
-		"issues":            projectFindings(findings, "job"),
+		"issues":            projectFindings(findings, ""),
 		"metrics": map[string]any{
 			"totalGroups":       len(requirementGroups),
 			"satisfiedGroups":   satisfied,

--- a/cmd/legacy_json_test.go
+++ b/cmd/legacy_json_test.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+	"encoding/json"
+	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/getplumber/plumber/control"
+	"github.com/getplumber/plumber/finding/identity"
+	"github.com/getplumber/plumber/gitlab"
 	opaengine "github.com/getplumber/plumber/internal/engine/opa"
 )
 
@@ -57,6 +62,26 @@ func TestProjectFindingJobKey(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// The job key disappears from an issue entry on its own once the rule stops
+// emitting one, because projectFinding guards on a non-empty Job. That makes
+// the output contract depend on rule payload rather than on the builder's
+// argument, so it is pinned here.
+func TestProjectFindingOmitsJobForANonJobFinding(t *testing.T) {
+	f := opaengine.Finding{
+		Code: "ISSUE-408", Fingerprint: "deadbeefcafef00d",
+		Data: map[string]any{"componentPath": "components/sast/sast"},
+	}
+
+	got := projectFinding(f, "job")
+
+	if _, has := got["job"]; has {
+		t.Errorf("job = %v, want the key absent for a finding that is not about a job", got["job"])
+	}
+	if got["componentPath"] != "components/sast/sast" {
+		t.Errorf("componentPath = %v, want the component path", got["componentPath"])
 	}
 }
 
@@ -154,6 +179,187 @@ func TestProjectFindingOmitsEmptyFingerprint(t *testing.T) {
 	}
 }
 
+// The fingerprint is a hash, so a consumer that groups findings into long-lived
+// issues cannot see WHICH fields it was built from. projectFinding strips
+// message, file and line from the issue entry, so those inputs are not
+// recoverable from the report either. The identity block carries the selected
+// field set itself, which is what makes the grouping derivable downstream.
+func TestProjectFindingEmitsIdentityFieldSet(t *testing.T) {
+	f := opaengine.Finding{
+		Code: "ISSUE-701", File: ".github/workflows/ci.yml", Job: "build",
+		Message: "prose", Line: 12, Fingerprint: "deadbeefcafef00d",
+		Data: map[string]any{"uses": "owner/act@v1", "step": "Check out"},
+	}
+
+	got := projectFinding(f, "job")
+
+	block, ok := got["identity"].(map[string]any)
+	if !ok {
+		t.Fatalf("identity = %v, want a block carrying the selected fields", got["identity"])
+	}
+	if block["version"] != identity.RecipeVersion {
+		t.Errorf("identity.version = %v, want %d", block["version"], identity.RecipeVersion)
+	}
+	want := []identity.Field{
+		{Key: "code", Value: "ISSUE-701"},
+		{Key: "file", Value: ".github/workflows/ci.yml"},
+		{Key: "job", Value: "build"},
+		{Key: "uses", Value: "owner/act@v1"},
+		{Key: "step", Value: "Check out"},
+	}
+	if fields, ok := block["fields"].([]identity.Field); !ok || !slices.Equal(fields, want) {
+		t.Errorf("identity.fields = %v, want %v", block["fields"], want)
+	}
+}
+
+// The identity block exists to be read out of Plumber's serialized output by a
+// consumer in another module, and docs/FINGERPRINT.md publishes its wire shape
+// as a contract. Every other assertion in this file inspects Go values, which
+// cannot see the encoding: dropping the json tags on identity.Field would turn
+// `key`/`value` into `Key`/`Value`, every consumer reading fields[].key would
+// get nothing, and the suite would stay green. So this one goes through JSON.
+func TestProjectFindingIdentityMarshalsToTheDocumentedShape(t *testing.T) {
+	f := opaengine.Finding{
+		Code: "ISSUE-701", File: ".github/workflows/ci.yml", Job: "build",
+		Message: "prose", Fingerprint: "deadbeefcafef00d",
+		Data: map[string]any{"uses": "owner/act@v1", "step": "Check out"},
+	}
+
+	raw, err := json.Marshal(projectFinding(f, "job"))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	block, ok := got["identity"].(map[string]any)
+	if !ok {
+		t.Fatalf("identity = %v, want an object; raw: %s", got["identity"], raw)
+	}
+	// Numbers come back as float64 through a JSON round trip, which is what a
+	// consumer parsing the report actually sees.
+	if block["version"] != float64(identity.RecipeVersion) {
+		t.Errorf("identity.version = %v, want %d", block["version"], identity.RecipeVersion)
+	}
+	if block["subjectFromMessage"] != false {
+		t.Errorf("identity.subjectFromMessage = %v, want false", block["subjectFromMessage"])
+	}
+	want := []any{
+		map[string]any{"key": "code", "value": "ISSUE-701"},
+		map[string]any{"key": "file", "value": ".github/workflows/ci.yml"},
+		map[string]any{"key": "job", "value": "build"},
+		map[string]any{"key": "uses", "value": "owner/act@v1"},
+		map[string]any{"key": "step", "value": "Check out"},
+	}
+	if !reflect.DeepEqual(block["fields"], want) {
+		t.Errorf("identity.fields = %#v,\nwant %#v", block["fields"], want)
+	}
+}
+
+// The message fallback has to survive the encoding too: it is the flag telling
+// a consumer which findings a copy-edit would re-key.
+func TestProjectFindingIdentityMarshalsTheMessageFallback(t *testing.T) {
+	f := opaengine.Finding{
+		Code: "ISSUE-803", Job: "build", Message: "job \"build\" runs with overly broad permissions",
+		Fingerprint: "deadbeefcafef00d",
+	}
+
+	raw, err := json.Marshal(projectFinding(f, "job"))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	block := got["identity"].(map[string]any)
+	if block["subjectFromMessage"] != true {
+		t.Errorf("identity.subjectFromMessage = %v, want true", block["subjectFromMessage"])
+	}
+	fields, ok := block["fields"].([]any)
+	if !ok {
+		t.Fatalf("identity.fields = %v, want an array", block["fields"])
+	}
+	last := fields[len(fields)-1]
+	if !reflect.DeepEqual(last, map[string]any{"key": "message", "value": f.Message}) {
+		t.Errorf("subject pair = %#v, want the message fallback", last)
+	}
+}
+
+// The file is stripped from the issue entry itself but is part of the identity,
+// so a consumer must not have to recover it from the url. This is the field
+// whose absence made the report unusable for grouping.
+func TestProjectFindingIdentityCarriesTheStrippedFile(t *testing.T) {
+	f := opaengine.Finding{
+		Code: "ISSUE-701", File: ".github/workflows/ci.yml", Job: "build",
+		Fingerprint: "deadbeefcafef00d", Data: map[string]any{"uses": "owner/act@v1"},
+	}
+
+	got := projectFinding(f, "job")
+
+	if _, has := got["file"]; has {
+		t.Fatalf("the legacy issue shape grew a file key: %v", got["file"])
+	}
+	block := got["identity"].(map[string]any)
+	for _, p := range block["fields"].([]identity.Field) {
+		if p.Key == "file" && p.Value == ".github/workflows/ci.yml" {
+			return
+		}
+	}
+	t.Errorf("identity.fields does not carry the file: %v", block["fields"])
+}
+
+// A rule that emits no structured key falls back to its message, which the
+// issue entry also strips. The identity block reports both the fallback value
+// and the fact that it is one, so a consumer knows this finding is re-keyed by
+// a copy-edit.
+func TestProjectFindingIdentityReportsTheMessageFallback(t *testing.T) {
+	f := opaengine.Finding{
+		Code: "ISSUE-803", Job: "build", Message: "job \"build\" runs with overly broad permissions",
+		Fingerprint: "deadbeefcafef00d",
+	}
+
+	got := projectFinding(f, "job")
+
+	block := got["identity"].(map[string]any)
+	if block["subjectFromMessage"] != true {
+		t.Errorf("subjectFromMessage = %v, want true", block["subjectFromMessage"])
+	}
+	fields := block["fields"].([]identity.Field)
+	last := fields[len(fields)-1]
+	if last.Key != "message" || last.Value != f.Message {
+		t.Errorf("subject pair = %+v, want the message fallback", last)
+	}
+}
+
+// A codeless finding has no identity, so the key must be absent rather than an
+// empty block: consumers distinguish "absent" from "empty".
+func TestProjectFindingOmitsIdentityForCodelessFinding(t *testing.T) {
+	got := projectFinding(opaengine.Finding{Job: "build", Message: "x"}, "job")
+
+	if _, has := got["identity"]; has {
+		t.Errorf("codeless finding emitted identity = %v, want the key absent", got["identity"])
+	}
+}
+
+// Data must not be able to overwrite the derived block: a rule payload carrying
+// an "identity" key would otherwise forge the grouping key.
+func TestProjectFindingDataCannotOverrideIdentity(t *testing.T) {
+	f := opaengine.Finding{
+		Code: "ISSUE-701", Job: "build", Fingerprint: "realfingerprint0",
+		Data: map[string]any{"identity": "forged", "uses": "owner/act@v1"},
+	}
+
+	got := projectFinding(f, "job")
+
+	if _, ok := got["identity"].(map[string]any); !ok {
+		t.Errorf("identity = %v, want the derived block to win over Data", got["identity"])
+	}
+}
+
 // Data must not be able to overwrite the stamped value: a rule payload that
 // happened to carry a "fingerprint" key would otherwise forge the identifier.
 func TestProjectFindingDataCannotOverrideFingerprint(t *testing.T) {
@@ -166,5 +372,90 @@ func TestProjectFindingDataCannotOverrideFingerprint(t *testing.T) {
 
 	if got["fingerprint"] != "realfingerprint0" {
 		t.Errorf("fingerprint = %v, want the stamped value to win over Data", got["fingerprint"])
+	}
+}
+
+// The v0.2.x branch block exposes the full protection settings only on branches
+// that fired a non-compliance finding, and it finds them by matching the
+// finding to the branch. That match must read branchName from the payload: the
+// job field is empty for a branch finding, because a branch is not a job.
+func TestBranchProtectionBlockMatchesNonCompliantBranchByPayload(t *testing.T) {
+	f := opaengine.Finding{
+		Code: string(control.CodeBranchNonCompliant),
+		Data: map[string]any{"branchName": "main", "allowForcePush": true},
+	}
+
+	got := nonCompliantBranchNames([]opaengine.Finding{f})
+
+	if !got["main"] {
+		t.Errorf("nonCompliantBranchNames = %v, want main flagged", got)
+	}
+}
+
+// A finding without a branchName cannot name a branch, so it must not produce a
+// phantom "" entry that would match no branch and hide the real ones.
+func TestNonCompliantBranchNamesIgnoresAPayloadWithoutABranch(t *testing.T) {
+	f := opaengine.Finding{Code: string(control.CodeBranchNonCompliant)}
+
+	if got := nonCompliantBranchNames([]opaengine.Finding{f}); len(got) != 0 {
+		t.Errorf("nonCompliantBranchNames = %v, want empty", got)
+	}
+}
+
+// ISSUE-404 no longer emits a job field: an include is not a job, and
+// includePath is what the identity recipe now selects for this rule
+// (finding/identity). The enrichment step must follow that move and read
+// the include source from includePath, not from the retired job field, or
+// it silently drops every origin-derived key (version, latestVersion,
+// gitlabIncludeLocation, gitlabIncludeType, gitlabIncludeProject, nested,
+// originHash, componentName, plumberOriginPath, plumberTemplateName) from
+// the JSON report.
+func TestEnrichForbiddenVersion404IssueMaps_ReadsIncludePath(t *testing.T) {
+	t.Parallel()
+	result := &control.AnalysisResult{
+		PipelineOriginData: &gitlab.GitlabPipelineOriginData{
+			Origins: []gitlab.GitlabPipelineOriginDataFull{
+				{
+					GitlabPipelineOriginDataGeneric: gitlab.GitlabPipelineOriginDataGeneric{
+						OriginType: "project",
+						GitlabIncludeOrigin: gitlab.IncludeOriginWithoutRef{
+							Location: "templates/deploy.yml@group/project",
+							Type:     "file",
+							Project:  "group/project",
+						},
+						OriginHash: 42,
+					},
+					GitlabPipelineOriginDataProjectSpecific: gitlab.GitlabPipelineOriginDataProjectSpecific{
+						Version: "main",
+						Nested:  false,
+					},
+				},
+			},
+		},
+	}
+	// Post-change shape: the rule emits includePath and no job key at all.
+	issues := []map[string]any{{
+		"code":        string(control.CodeIncludeForbiddenVersion),
+		"docUrl":      "x",
+		"includePath": "templates/deploy.yml@group/project",
+	}}
+
+	enrichForbiddenVersion404IssueMaps(issues, result)
+
+	iss := issues[0]
+	if iss["version"] != "main" {
+		t.Errorf("version: got %v, want %q", iss["version"], "main")
+	}
+	if iss["gitlabIncludeLocation"] != "templates/deploy.yml@group/project" {
+		t.Errorf("gitlabIncludeLocation: got %v", iss["gitlabIncludeLocation"])
+	}
+	if iss["gitlabIncludeType"] != "file" {
+		t.Errorf("gitlabIncludeType: got %v", iss["gitlabIncludeType"])
+	}
+	if iss["gitlabIncludeProject"] != "group/project" {
+		t.Errorf("gitlabIncludeProject: got %v", iss["gitlabIncludeProject"])
+	}
+	if iss["originHash"] != uint64(42) {
+		t.Errorf("originHash: got %v, want 42", iss["originHash"])
 	}
 }

--- a/cmd/sarif.go
+++ b/cmd/sarif.go
@@ -293,7 +293,7 @@ func sarifMessage(f opaengine.Finding, info *control.ErrorCodeInfo) string {
 // for two reasons. The message is shared by every output — terminal, JSON,
 // CSV, GitLab SAST — where a backtick is literal noise, not formatting. And
 // a rule that emits no structured subject key falls back to its message for
-// the fingerprint (fingerprintSubjectKeys), so rewording it in Rego re-files
+// the fingerprint (finding/identity.SubjectKeys), so rewording it in Rego re-files
 // the alert and drops any dismissal; rendering here leaves the fingerprint
 // input untouched.
 //

--- a/docs/FINGERPRINT.md
+++ b/docs/FINGERPRINT.md
@@ -11,6 +11,61 @@ The two identifiers serve different questions:
 | `controlName` + `status` | How is this check doing on this run? |
 | `fingerprint` | Is this particular finding still there? |
 
+## One recipe, two consumers
+
+The valuable part is not the hash, it is the **selection**: which fields
+identify one finding instance across runs. Plumber hashes that selection into
+the short `fingerprint` its export formats carry. A consumer grouping findings
+into long-lived issues needs the same selection, but as data it can store and
+query rather than an opaque hash.
+
+Both read it from one place, the public package
+[`finding/identity`](../finding/identity), so they cannot drift:
+
+| API | Returns |
+| --- | --- |
+| `identity.Of(f)` | the identity **field set** as data (`Fields`, with `Pairs()` for the ordered key/value pairs) |
+| `identity.Fingerprint(f)` | the short hash of exactly what `Of` selected |
+| `identity.SubjectKeys()` | the subject-key priority list below |
+| `identity.RecipeVersion` | the version of the selection |
+| `identity.FromMap(m)` | a finding read back from Plumber's serialized JSON, when that JSON is a whole finding rather than an exported issue entry (see below) |
+
+The two sides never have to agree on a hash, only on the selection.
+
+### The recipe version
+
+`identity.RecipeVersion` is currently **2**. Store it next to anything you key
+off the selection.
+
+It tracks identity **outcomes**, not just the code in the package, so it moves
+in two cases:
+
+| Change | Example |
+| --- | --- |
+| The algorithm changes | a new subject key, a reordering of the priority list, a field entering or leaving the identity |
+| A control changes what it emits | a rule starts or stops emitting a subject key, moving its findings between prose identity and structured identity |
+
+The second case is the one that hides: nothing in `finding/identity` changes,
+so its tests stay green while real fingerprints move. The per-control pins in
+`policies/rules_test.go` are what fire there, and a failure in one of them is
+the prompt to bump.
+
+**Treat a bump as a breaking change, made deliberately.** A re-keyed finding
+reads downstream as the old issue disappearing and a new one appearing in its
+place. A consumer that stores the field set can see what moved; a consumer
+holding only the hash (SARIF, OCSF, CSV) cannot, and this constant is its only
+signal.
+
+| Version | What changed |
+| --- | --- |
+| 1 | The recipe as first shipped. |
+| 2 | Eleven finding blocks that had no structured key, or that smuggled their subject through the `job` field, now name what they are about: ISSUE-401 (`hardcodedJob`), ISSUE-402 GitLab / ISSUE-403 / ISSUE-404 (`includePath`), ISSUE-405 / ISSUE-406 (`templatePath`), ISSUE-408 / ISSUE-409 (`componentPath`), ISSUE-417 (`requiredAction`), and ISSUE-501 / ISSUE-505 keep `branchName` while dropping `job`. Ten of the eleven also dropped `job`; ISSUE-401's `job` is a real job name and was kept. The algorithm is unchanged; their fingerprints are not. |
+
+The SARIF `partialFingerprints["plumber/v1"]` key is the name of that SARIF
+entry, not the recipe version. It stays at `v1` across bumps, because renaming
+it would make Code Scanning treat every alert as new, which is the opposite of
+what the entry is for.
+
 ## How it is computed
 
 ```
@@ -43,8 +98,9 @@ Finding as emitted by the rule
     v
 [3] pick the subject
     |
-    +-- carries one of: uses, branchName, componentName, image,
-    |   serviceImage, link, tag, variableName, scriptLine, detail?
+    +-- carries one of: uses, branchName, includePath, templatePath,
+    |   componentPath, requiredAction, image, serviceImage, link, tag,
+    |   variableName, hardcodedJob, scriptLine, detail?
     |
     +-- yes -->  subject = "key=value"     first match only, rest ignored
     |                                      survives a message rewording
@@ -64,7 +120,7 @@ Finding as emitted by the rule
 | --- | --- | --- |
 | `code` | yes | The issue identity (`ISSUE-701`) |
 | `file` | yes | Where the finding lives, stable across edits |
-| `job` | yes | The job, branch, or include scope |
+| `job` | yes | The CI job the finding sits in, empty when the finding is not about a job (see below) |
 | subject | yes | What the rule flagged (see below) |
 | `step` | yes, when present | Separates two steps in one job using the same action |
 | `line` | no | Moves whenever unrelated code above the finding is edited |
@@ -73,6 +129,14 @@ Finding as emitted by the rule
 | `latestVersion` | no | Moves whenever upstream cuts a release |
 | `metadata` | no | Refetched from the API on every run |
 | `reasons`, `status` | no | Track current settings rather than identity |
+
+### The job segment
+
+`job` is the name of a CI job. It is empty when the finding is not about a job:
+a branch, an include, a required template, component or action. Those findings
+identify on their subject key instead. Before recipe version 2 several rules
+put a branch name, an include source or a required path in this field, which
+made identity depend on a mislabelled value.
 
 ### The subject
 
@@ -89,15 +153,23 @@ holding the same value cannot collide.
 | --- | --- | --- |
 | 1 | `uses` | `grafana/shared-workflows/actions/get-vault-secrets@main` |
 | 2 | `branchName` | `main` |
-| 3 | `componentName` | `secret-detection` |
-| 4 | `image` | `golang:1.25` (a Dockerfile `FROM` base) |
-| 5 | `serviceImage` | `docker:27-dind` |
-| 6 | `link` | `registry.gitlab.com/security-products/secrets:7` |
-| 7 | `tag` | `latest` |
-| 8 | `variableName` | `CI_DEBUG_TRACE` |
-| 9 | `scriptLine` | `curl -sSL https://example.com/i.sh \| bash` |
-| 10 | `detail` | `allow_failure: true masks scan failures` |
+| 3 | `includePath` | `gitlab.example.com/components/sast/sast` |
+| 4 | `templatePath` | `templates/go/go` |
+| 5 | `componentPath` | `components/sast/sast` |
+| 6 | `requiredAction` | `org/sast-scan` |
+| 7 | `image` | `golang:1.25` (a Dockerfile `FROM` base) |
+| 8 | `serviceImage` | `docker:27-dind` |
+| 9 | `link` | `registry.gitlab.com/security-products/secrets:7` |
+| 10 | `tag` | `latest` |
+| 11 | `variableName` | `CI_DEBUG_TRACE` |
+| 12 | `hardcodedJob` | `deploy-prod` |
+| 13 | `scriptLine` | `curl -sSL https://example.com/i.sh \| bash` |
+| 14 | `detail` | `allow_failure: true masks scan failures` |
 | fallback | `message` | used only when the finding carries none of the above |
+
+The list is `identity.SubjectKeys()`; the fallback reports itself as the key
+`message`, which is not a member of the list: a rule can only fall back to it,
+never select it.
 
 Worked example. This real finding carries both `link` and `tag`:
 
@@ -157,15 +229,51 @@ the resulting name is hashed, so the identifier still survives line drift.
 
 ### A rule with no structured subject
 
-Roughly a third of the rules emit only the canonical fields. Their subject is
-the message, which still discriminates but ties the identifier to the wording:
+A rule that emits only the canonical fields has the message as its subject,
+which still discriminates but ties the identifier to the wording:
 
 ```
-ISSUE-401  job=leak-repro-214  message="job \"leak-repro-214\" is hardcoded ..."
+ISSUE-803  job=build  message="job \"build\" runs with overly broad permissions ..."
 ```
+
+`identity.Of` reports these as `Subject.Key == "message"` and
+`SubjectFromMessage == true`, so a consumer can tell prose-based identity apart
+from the structured kind and know which findings a copy-edit would re-key.
 
 Giving such a rule a structured payload moves it to the subject path and
-changes its fingerprints once.
+changes its fingerprints once. Recipe version 2 changed eleven finding blocks
+in total (see the version table above); ten of those also dropped the `job`
+field, and nine of the eleven moved off prose identity onto a structured
+subject key for the first time: the required-template (ISSUE-405, ISSUE-406)
+and required-component (ISSUE-408, ISSUE-409) controls now emit `templatePath`
+/ `componentPath`, hardcoded-jobs (ISSUE-401) emits `hardcodedJob`,
+forbidden-include-version (ISSUE-404) and required-actions (ISSUE-417) emit
+`includePath` / `requiredAction`, and the GitLab include block of ISSUE-402
+plus ISSUE-403 emit `includePath`. The remaining two of the eleven,
+ISSUE-501 and ISSUE-505, already had `branchName` as their subject before this
+version; they only dropped `job`, so they are not part of the nine.
+
+Four collapses were introduced along the way, each dropping one input from
+identity on purpose:
+
+- The DNF group index (ISSUE-405 / ISSUE-408 / ISSUE-417), which shifts
+  whenever a user reorders `requiredGroups`.
+- The forbidden `ref` (ISSUE-404), since the same include drifting from one
+  forbidden version to another is the same unresolved problem.
+- The ref (ISSUE-403 and the ISSUE-402 GitLab block): identity is now
+  `code + file + includePath`. `inc.source` excludes the ref, so the same
+  include source pinned at two different refs produced two fingerprints
+  before this version and produces one now.
+- The overridden-job count (ISSUE-406 and ISSUE-409): identity is now
+  `code + templatePath` (or `componentPath`) alone. The prose message
+  embedded that count, so two includes matching the same required path with
+  different override counts now share one fingerprint.
+
+Each of these is a deliberate narrowing, not a bug: the consumer-facing
+consequence is that a single report can contain two issue entries that share
+one `fingerprint` and one identical `identity.fields`. Group by the
+fingerprint rather than assuming one row per value (see Limits and stability
+below).
 
 ### A repository-level finding
 
@@ -173,11 +281,12 @@ Controls that evaluate repository settings rather than a file have no `file`,
 and their subject comes from the payload:
 
 ```
-ISSUE-505  file=""  job=main  branchName=main
+ISSUE-505  file=""  branchName=main
 ```
 
-Two branches produce different fingerprints because `branchName` and `job`
-differ.
+Two branches produce different fingerprints because `branchName` differs; this
+finding is not about a job, so `job` is empty and contributes nothing to the
+hash.
 
 ### A finding with no code
 
@@ -191,7 +300,7 @@ value in whichever format a consumer reads:
 
 | Format | Location |
 | --- | --- |
-| JSON (`--output`) | `fingerprint` on each issue entry |
+| JSON (`--output`) | `fingerprint` on each issue entry, next to the `identity` block below |
 | CSV (`--csv`) | `fingerprint` column |
 | SARIF (`--sarif`) | `partialFingerprints["plumber/v1"]` |
 | GitLab SAST (`--glsast`) | an `identifiers[]` entry of type `plumber-fingerprint` |
@@ -207,16 +316,86 @@ an edited file as new findings.
   job that reference the same action with no `name:` are indistinguishable and
   share a fingerprint. Group by it; do not assume one row per value.
 - Rules on the message fallback stay sensitive to their own wording.
+- **A subject key holding a non-string is skipped, not coerced**, and the
+  finding drops to the message fallback. A JSON round trip turns a numeric
+  `tag: 7` into a float64, so this is reachable from real payload. Both sides
+  of the recipe read it the same way, so the CLI and a consumer still agree;
+  `subjectFromMessage` is what makes the degradation visible. Coercing would be
+  the better answer, but it would re-key every finding it applies to, so it is
+  a `RecipeVersion` decision rather than a free fix.
+- **A coded finding with no subject key and no message** is identified by
+  `code`, `file` and `job` alone, so every such finding of that control in one
+  job shares a fingerprint. Deterministic, and the narrowest identity the
+  recipe produces.
 - `scriptLine` holds the script text, not a line number, so blank lines and
   re-indentation elsewhere in the file do not affect it. One rule
   (`unverified_scripts`, ISSUE-411) stores the line untrimmed, so leading or
   trailing whitespace on that one line is part of its identity;
   `unsafe_variable_expansion` trims first.
 - **Changing the recipe changes every value.** Adding an input, reordering the
-  subject keys, or rewording a fallback rule's message all shift the
-  identifiers, which a consumer reads as findings resolving and reappearing.
-  Treat the recipe as a contract.
+  subject keys, giving a control a subject key it did not have, or rewording a
+  fallback rule's message all shift the identifiers, which a consumer reads as
+  findings resolving and reappearing. Treat the recipe as a contract, and bump
+  `identity.RecipeVersion` with it. Rewording a fallback rule is the one case
+  the version cannot express finding by finding: it re-keys only that rule's
+  findings, so weigh it against the churn before doing it.
 
-The computation lives in `internal/engine/opa/engine.go`
-(`computeFingerprint`, `fingerprintSubject`, `StampFingerprints`) and is
-stamped once per run, immediately after findings are finalized.
+The selection lives in `finding/identity` (`Of`, `Fingerprint`, `SubjectKeys`,
+`RecipeVersion`), a public package, so a consumer outside this module derives
+the same identity Plumber does. `internal/engine/opa` reads it through
+`Finding.Identity()` and `StampFingerprints`, which stamps the hash once per
+run, immediately after findings are finalized.
+
+### Reading the identity from Plumber's output
+
+Every issue entry in the JSON report (`--output`) carries the field set that
+was selected for it, so a consumer stores it directly instead of re-deriving
+it:
+
+```json
+{
+  "code": "ISSUE-701",
+  "fingerprint": "250f3b7fb7136386",
+  "job": "build_debian/build",
+  "uses": "element-hq/packages.element.io@master",
+  "identity": {
+    "version": 2,
+    "subjectFromMessage": false,
+    "fields": [
+      { "key": "code",  "value": "ISSUE-701" },
+      { "key": "file",  "value": ".github/workflows/build_debian.yaml" },
+      { "key": "job",   "value": "build_debian/build" },
+      { "key": "uses",  "value": "element-hq/packages.element.io@master" }
+    ]
+  }
+}
+```
+
+Read `fields` and `version` together. When `RecipeVersion` moves, the stored
+version is what tells you which findings need re-keying rather than treating
+them as gone. `subjectFromMessage` marks the findings whose identity is still
+tied to their rule's prose, so a copy-edit re-keys them.
+
+The block exists because the issue entry itself is a trimmed shape: it drops
+`message`, `file` and `line` (see `projectFinding` in `cmd/legacy_json.go`), so
+those inputs are not recoverable from the entry, and neither format that keeps
+them (`--ocsf`) keeps the structured payload. **Reading the `identity` block is
+the supported way to derive a finding's identity from Plumber output**; running
+`identity.FromMap` over an exported issue entry is not, because the entry is not
+a whole finding.
+
+### Deriving the identity in Go
+
+For a consumer holding a complete finding (all canonical fields plus the
+structured payload) rather than an exported issue entry:
+
+```go
+import "github.com/getplumber/plumber/finding/identity"
+
+fields, ok := identity.Of(identity.FromMap(whole))
+if ok {
+    pairs := fields.Pairs()    // the selected key/value pairs, in order
+    v := fields.Version        // the RecipeVersion that produced them
+    _, _ = pairs, v
+}
+```

--- a/docs/superpowers/plans/2026-08-07-job-field-semantics.md
+++ b/docs/superpowers/plans/2026-08-07-job-field-semantics.md
@@ -1,0 +1,980 @@
+# `Finding.Job` Means A Job: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `Finding.Job` hold a CI job name and nothing else, moving the ten
+finding blocks that put a branch, an include source or a required path there
+onto structured subject keys instead.
+
+**Architecture:** Rego rules stop emitting `"job"` where the value is not a job,
+and each such rule emits a key naming what its finding is about. The identity
+recipe in `finding/identity` selects that key as the subject, so identity keeps
+its discrimination without leaning on a mislabelled field. Output formats need
+no changes: `projectFinding` and the OCSF writer already omit the key when
+`Job` is empty.
+
+**Tech Stack:** Go 1.25 / 1.26, Open Policy Agent (Rego v1), `make test`,
+`make lint`, `make deadcode`.
+
+## Global Constraints
+
+- Design spec: `docs/superpowers/specs/2026-08-07-job-field-semantics-design.md`.
+- `identity.RecipeVersion` stays **2**. Do not bump it: this work ships in the
+  same release as the re-key already in PR #404, so the affected set moves once.
+- The selection algorithm in `finding/identity` does not change. Only the
+  priority list and the rule payloads change.
+- No rule may emit `"job": ""`. Omit the key entirely.
+- ISSUE-401 `hardcoded_jobs` keeps `"job": job.name`. It is not part of this
+  change.
+- No em dashes in comments, commit messages or docs.
+- Every commit must leave `make test`, `make lint` and `make deadcode` green.
+
+---
+
+### Task 1: Reorder the subject-key priority list
+
+**Files:**
+- Modify: `finding/identity/identity.go` (the `subjectKeys` var)
+- Test: `finding/identity/identity_test.go`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: the key names later tasks emit from Rego: `includePath`,
+  `templatePath`, `componentPath`, `requiredAction`. `identity.SubjectKeys()`
+  returns them in priority order.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `finding/identity/identity_test.go`, replace the body of
+`TestSubjectKeys_CoverTheStructuredControls` with the new list and add one new
+test below it:
+
+```go
+// Every control that names what it is about must have its key in the list, or
+// its findings ride on reformulable prose.
+func TestSubjectKeys_CoverTheStructuredControls(t *testing.T) {
+	keys := identity.SubjectKeys()
+	for _, want := range []string{
+		"uses", "branchName", "includePath", "templatePath", "componentPath",
+		"requiredAction", "hardcodedJob",
+	} {
+		if !slices.Contains(keys, want) {
+			t.Errorf("subject key %q missing from the recipe: %v", want, keys)
+		}
+	}
+}
+
+// componentName is payload, not identity. ISSUE-402 and ISSUE-403 emit it as an
+// empty string for any include that is not a component, and it holds a bare
+// name where includePath holds the full source. Two components named "deploy"
+// in different groups would collide on the bare name.
+func TestSubjectKeys_ExcludesComponentName(t *testing.T) {
+	if slices.Contains(identity.SubjectKeys(), "componentName") {
+		t.Errorf("componentName is payload, not a subject key: %v", identity.SubjectKeys())
+	}
+}
+
+// A finding carrying both keys must identify on the full source.
+func TestOf_IncludePathOutranksComponentName(t *testing.T) {
+	f := identity.Finding{
+		Code: "ISSUE-403", File: ".gitlab-ci.yml",
+		Data: map[string]any{
+			"componentName": "deploy",
+			"includePath":   "gitlab.example.com/components/deploy/deploy",
+		},
+	}
+
+	got, _ := identity.Of(f)
+
+	if got.Subject.Key != "includePath" {
+		t.Errorf("subject = %+v, want the includePath key", got.Subject)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./finding/... -run 'TestSubjectKeys|TestOf_IncludePathOutranks' -v`
+
+Expected: `TestSubjectKeys_CoverTheStructuredControls` fails on the missing
+`componentPath` and `requiredAction`, `TestSubjectKeys_ExcludesComponentName`
+fails because `componentName` is still in the list, and
+`TestOf_IncludePathOutranksComponentName` fails with
+`subject = {Key:componentName Value:deploy}`.
+
+- [ ] **Step 3: Update the priority list**
+
+In `finding/identity/identity.go`:
+
+```go
+var subjectKeys = []string{
+	"uses", "branchName", "includePath", "templatePath", "componentPath",
+	"requiredAction", "image", "serviceImage", "link", "tag", "variableName",
+	"hardcodedJob", "scriptLine", "detail",
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./finding/... -v`
+Expected: PASS. The golden fingerprint tests must still pass: they use `uses`
+and the message fallback, neither of which moved.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add finding/identity/identity.go finding/identity/identity_test.go
+git commit -m "refactor(identity): order the subject keys by specificity
+
+includePath outranks componentName because a full include source beats a
+bare component name, and componentName leaves the list entirely: it is
+payload, empty for any include that is not a component, and no control
+depends on it for identity.
+
+Refs #403"
+```
+
+---
+
+### Task 2: Component family (ISSUE-408, ISSUE-409)
+
+**Files:**
+- Modify: `policies/component_missing.rego`
+- Modify: `policies/component_overridden.rego`
+- Test: `policies/rules_test.go` (`assertSubjectKey`, `assertNoJob`,
+  `TestIssue408_ComponentMissing`, `TestIssue409_ComponentOverridden`)
+
+**Interfaces:**
+- Consumes: `identity.SubjectKeys()` containing `componentPath` (Task 1).
+- Produces: `assertNoJob(t *testing.T, findings []opaengine.Finding, code string)`,
+  used by Tasks 3 to 6.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `policies/rules_test.go`, add this helper directly below `assertSubjectKey`:
+
+```go
+// assertNoJob pins that a control leaves Finding.Job empty. The field is a CI
+// job name and a hashed identity input; a control that puts a branch, an
+// include source or a required path there both mislabels its output and makes
+// identity depend on the mislabelling.
+func assertNoJob(t *testing.T, findings []opaengine.Finding, code string) {
+	t.Helper()
+	for _, f := range findings {
+		if f.Code == code && f.Job != "" {
+			t.Errorf("%s: job = %q, want empty: this finding is not about a job", code, f.Job)
+		}
+	}
+}
+```
+
+In `TestIssue408_ComponentMissing`, replace the `hits` collection (which keys on
+`f.Job`) and the trailing `assertSubjectKey` call with:
+
+```go
+	hits := map[string]bool{}
+	for _, f := range findings {
+		if f.Code == "ISSUE-408" {
+			name, _ := f.Data["componentPath"].(string)
+			hits[name] = true
+		}
+	}
+	if !hits["components/secret-detection/secret-detection"] {
+		t.Fatalf("expected secret-detection flagged, got %v", hits)
+	}
+	if !hits["your-org/full-security/full-security"] {
+		t.Fatalf("expected full-security flagged, got %v", hits)
+	}
+	if hits["components/sast/sast"] {
+		t.Fatalf("unexpected flag on present component: %v", hits)
+	}
+	assertSubjectKey(t, findings, "ISSUE-408", "componentPath",
+		[]string{"components/secret-detection/secret-detection", "your-org/full-security/full-security"})
+	assertNoJob(t, findings, "ISSUE-408")
+```
+
+In `TestIssue409_ComponentOverridden`, replace the trailing `assertSubjectKey`
+call with:
+
+```go
+	assertSubjectKey(t, findings, "ISSUE-409", "componentPath", []string{"components/sast/sast"})
+	assertNoJob(t, findings, "ISSUE-409")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./policies/ -run 'TestIssue408_ComponentMissing|TestIssue409_ComponentOverridden' -v`
+
+Expected: both fail. `componentPath` is not emitted yet, so `hits` is keyed on
+the empty string and `assertNoJob` reports
+`job = "components/sast/sast", want empty`.
+
+- [ ] **Step 3: Update the rules**
+
+In `policies/component_missing.rego`, replace the finding object with:
+
+```rego
+	finding := {
+		"code":     "ISSUE-408",
+		"severity": "high",
+		"message":  sprintf("required component %q is missing from the pipeline (group %d)", [required, i]),
+		# No "job": a missing component is not a job. componentPath names what
+		# this finding is about and is what the identity recipe selects
+		# (finding/identity). The group index stays out: it moves whenever the
+		# user reorders requiredGroups, which is not a new finding.
+		"componentPath": required,
+	}
+```
+
+In `policies/component_overridden.rego`:
+
+```rego
+	finding := {
+		"code":     "ISSUE-409",
+		"severity": "high",
+		"message":  sprintf("required component %q is imported but %d of its job(s) are overridden locally", [required, count(inc.overriddenJobs)]),
+		# No "job": an overridden component is not a job. componentPath names
+		# what this finding is about, so its identity does not depend on the
+		# message above, whose override count moves as jobs are added.
+		"componentPath": required,
+	}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./policies/ -run 'TestIssue40[89]' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole suite**
+
+Run: `make test`
+Expected: PASS. If `cmd` fails, a JSON fixture is asserting `job` on one of
+these blocks; update the fixture to drop the key.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add policies/component_missing.rego policies/component_overridden.rego policies/rules_test.go
+git commit -m "fix(policies): stop putting a component path in the job field
+
+ISSUE-408 and ISSUE-409 are about a required component, not a job. They
+now emit componentPath and leave job empty, so identity names what it
+identifies instead of leaning on a mislabelled field. componentPath also
+disambiguates from componentName, which holds a bare name elsewhere.
+
+Refs #403"
+```
+
+---
+
+### Task 3: Template family (ISSUE-405, ISSUE-406)
+
+**Files:**
+- Modify: `policies/template_missing.rego`
+- Modify: `policies/template_overridden.rego`
+- Test: `policies/rules_test.go` (`TestIssue405_TemplateMissing`,
+  `TestIssue406_TemplateOverridden`)
+
+**Interfaces:**
+- Consumes: `assertNoJob` (Task 2), `templatePath` already in the priority list
+  (Task 1).
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `TestIssue405_TemplateMissing`, replace the `hits` collection and the
+trailing `assertSubjectKey` call with:
+
+```go
+	hits := map[string]bool{}
+	for _, f := range findings {
+		if f.Code == "ISSUE-405" {
+			path, _ := f.Data["templatePath"].(string)
+			hits[path] = true
+		}
+	}
+	if !hits["templates/trivy/trivy"] {
+		t.Fatalf("expected trivy template flagged, got %v", hits)
+	}
+	if hits["templates/go/go"] {
+		t.Fatalf("unexpected flag on present template: %v", hits)
+	}
+	assertSubjectKey(t, findings, "ISSUE-405", "templatePath", []string{"templates/trivy/trivy"})
+	assertNoJob(t, findings, "ISSUE-405")
+```
+
+In `TestIssue406_TemplateOverridden`, append after the existing
+`assertSubjectKey` call:
+
+```go
+	assertNoJob(t, findings, "ISSUE-406")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./policies/ -run 'TestIssue40[56]' -v`
+Expected: both fail with `job = "templates/trivy/trivy", want empty` and
+`job = "templates/go/go", want empty`.
+
+- [ ] **Step 3: Update the rules**
+
+In `policies/template_missing.rego`, replace the finding object with:
+
+```rego
+	finding := {
+		"code":     "ISSUE-405",
+		"severity": "high",
+		"message":  sprintf("required template %q is missing from the pipeline (group %d)", [required, i]),
+		# No "job": a missing template is not a job. templatePath names what
+		# this finding is about and is what the identity recipe selects
+		# (finding/identity). The group index stays out: it moves whenever the
+		# user reorders requiredGroups, which is not a new finding.
+		"templatePath": required,
+	}
+```
+
+In `policies/template_overridden.rego`:
+
+```rego
+	finding := {
+		"code":     "ISSUE-406",
+		"severity": "high",
+		"message":  sprintf("required template %q is imported but %d of its job(s) are overridden locally", [required, count(inc.overriddenJobs)]),
+		# No "job": an overridden template is not a job. templatePath names what
+		# this finding is about, so its identity does not depend on the message
+		# above, whose override count moves as jobs are added.
+		"templatePath": required,
+	}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./policies/ -run 'TestIssue40[56]' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add policies/template_missing.rego policies/template_overridden.rego policies/rules_test.go
+git commit -m "fix(policies): stop putting a template path in the job field
+
+ISSUE-405 and ISSUE-406 are about a required template, not a job.
+
+Refs #403"
+```
+
+---
+
+### Task 4: Include family (ISSUE-402 GitLab block, ISSUE-403, ISSUE-404)
+
+**Files:**
+- Modify: `policies/ref_confusion.rego` (the GitLab include block only, the one
+  matching `input.pipeline.includes`)
+- Modify: `policies/includes_outdated.rego`
+- Modify: `policies/includes_forbidden_version.rego`
+- Test: `policies/rules_test.go`
+  (`TestIssue404_IncludesForbiddenVersion`, plus two new tests)
+
+**Interfaces:**
+- Consumes: `assertNoJob` (Task 2), `includePath` in the priority list (Task 1).
+- Produces: nothing new.
+
+Note: `ref_confusion.rego` has two finding blocks. Only the second one, which
+iterates `input.pipeline.includes`, is changed. The first iterates
+`input.pipeline.jobs` and its `"job": job.name` is correct.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `TestIssue404_IncludesForbiddenVersion`, append after the existing
+`assertSubjectKey` call:
+
+```go
+	assertNoJob(t, findings, "ISSUE-404")
+```
+
+Add two new tests at the end of `policies/rules_test.go`:
+
+```go
+// ISSUE-403 is about an include, not a job. Its identity used to be the include
+// source smuggled through the job field, with componentName (a bare name, empty
+// for non-component includes) as the only structured key.
+func TestIssue403_OutdatedIncludeIdentifiesOnTheIncludePath(t *testing.T) {
+	engine := opaengine.New()
+	if err := engine.LoadFromFSFiltered(policies.FS, nil); err != nil {
+		t.Fatalf("load embedded policies: %v", err)
+	}
+	pipeline := &ir.NormalizedPipeline{
+		Provider: ir.ProviderGitLab,
+		Includes: []ir.Include{
+			{Kind: "component", Source: "gitlab.example.com/components/sast/sast", Ref: "1.0.0", Current: "1.1.0"},
+		},
+	}
+	findings, err := engine.Evaluate(context.Background(), pipeline, nil)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	assertSubjectKey(t, findings, "ISSUE-403", "includePath",
+		[]string{"gitlab.example.com/components/sast/sast"})
+	assertNoJob(t, findings, "ISSUE-403")
+}
+
+// ISSUE-402's GitLab block is about an include. Its GitHub block, which flags an
+// ambiguous action ref inside a job, keeps its job name and its uses subject.
+func TestIssue402_AmbiguousIncludeIdentifiesOnTheIncludePath(t *testing.T) {
+	engine := opaengine.New()
+	if err := engine.LoadFromFSFiltered(policies.FS, nil); err != nil {
+		t.Fatalf("load embedded policies: %v", err)
+	}
+	pipeline := &ir.NormalizedPipeline{
+		Provider: ir.ProviderGitLab,
+		Includes: []ir.Include{
+			{Kind: "component", Source: "gitlab.example.com/components/sast/sast", Ref: "v1", RefIsAmbiguous: true},
+		},
+	}
+	findings, err := engine.Evaluate(context.Background(), pipeline, nil)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	assertSubjectKey(t, findings, "ISSUE-402", "includePath",
+		[]string{"gitlab.example.com/components/sast/sast"})
+	assertNoJob(t, findings, "ISSUE-402")
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./policies/ -run 'TestIssue40[234]' -v`
+
+Expected: all three fail. ISSUE-403 and ISSUE-402 report
+`identity subject is "componentName"=...` or the message fallback, and
+`assertNoJob` reports the include source in `job`.
+
+- [ ] **Step 3: Update the rules**
+
+In `policies/includes_forbidden_version.rego`, remove the `"job"` line so the
+finding object reads:
+
+```rego
+	finding := {
+		"code":     "ISSUE-404",
+		"severity": "medium",
+		"message":  sprintf("%s uses forbidden version '%s'", [inc.source, inc.ref]),
+		# No "job": an include is not a job. includePath names what this finding
+		# is about and is what the identity recipe selects (finding/identity).
+		# The ref stays out: the same include drifting from one forbidden
+		# version to another is the same unresolved problem.
+		"includePath": inc.source,
+	}
+```
+
+In `policies/includes_outdated.rego`, remove the `"job"` line and add
+`"includePath"`:
+
+```rego
+	finding := {
+		"code":     "ISSUE-403",
+		"severity": "medium",
+		"message":  sprintf("%s uses version '%s' (latest: %s)", [inc.source, inc.ref, inc.current]),
+		# No "job": an include is not a job. includePath names what this finding
+		# is about (finding/identity). componentName stays as payload: it is a
+		# bare name, empty for any include that is not a component.
+		"includePath":           inc.source,
+		"file":                  object.get(inc, "originFile", ""),
+		"line":                  object.get(inc, "originLine", 0),
+		"version":               inc.ref,
+		"latestVersion":         inc.current,
+		"gitlabIncludeLocation": inc.source,
+		"gitlabIncludeType":     inc.kind,
+		"nested":                object.get(inc, "nested", false),
+		"componentName":         object.get(inc, "componentName", ""),
+		"originHash":            object.get(inc, "originHash", 0),
+	}
+```
+
+In `policies/ref_confusion.rego`, in the **second** finding block only (the one
+under `inc := input.pipeline.includes[i]`), remove the `"job"` line and add
+`"includePath"`:
+
+```rego
+	finding := {
+		"code":                  "ISSUE-402",
+		"severity":              "medium",
+		"message":               sprintf("%s pins ref '%s' — it resolves as both a tag AND a branch in the source project, so which revision runs is ambiguous; pin to a commit SHA to disambiguate", [inc.source, inc.ref]),
+		# No "job": an include is not a job. includePath names what this finding
+		# is about (finding/identity). componentName stays as payload.
+		"includePath":           inc.source,
+		"file":                  object.get(inc, "originFile", ""),
+		"line":                  object.get(inc, "originLine", 0),
+		"version":               inc.ref,
+		"gitlabIncludeLocation": inc.source,
+		"gitlabIncludeType":     inc.kind,
+		"nested":                object.get(inc, "nested", false),
+		"componentName":         object.get(inc, "componentName", ""),
+		"originHash":            object.get(inc, "originHash", 0),
+	}
+```
+
+Leave the message text exactly as it is, including its em dash: it is existing
+user-facing copy and rewording it would re-key nothing here (identity no longer
+reads the message) but would churn the report for no reason.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./policies/ -run 'TestIssue40[234]' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole suite**
+
+Run: `make test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add policies/ref_confusion.rego policies/includes_outdated.rego policies/includes_forbidden_version.rego policies/rules_test.go
+git commit -m "fix(policies): identify include findings by the include path
+
+ISSUE-402's GitLab block, ISSUE-403 and ISSUE-404 are about an include,
+not a job. They now emit includePath and leave job empty. ISSUE-402 and
+ISSUE-403 had no working structured key at all: componentName is empty
+for any include that is not a component, so their identity rode on the
+prose message.
+
+Refs #403"
+```
+
+---
+
+### Task 5: Required actions (ISSUE-417)
+
+**Files:**
+- Modify: `policies/required_actions.rego`
+- Test: `policies/rules_test.go`, `TestIssue416_RequiredActionMissing` (starts at
+  line 4789; the name says 416 but the code it asserts is ISSUE-417). Every
+  ISSUE-417 assertion lives in this one table-driven test, at lines 4820, 4852,
+  4879, 4903, 4929 and 4947. Only two of them read `f.Job`.
+
+**Interfaces:**
+- Consumes: `assertNoJob` (Task 2), `requiredAction` in the priority list
+  (Task 1).
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test**
+
+In `TestIssue416_RequiredActionMissing`, the first subtest collects hits by job
+(line 4821). Replace that collection so it reads the structured key:
+
+```go
+				requiredAction, _ := f.Data["requiredAction"].(string)
+				hits[requiredAction] = true
+```
+
+The `want` list on line 4832 already holds the three expected values and does
+not change: `"myorg/sast-scan"`, `"myorg/policy/.github/workflows/policy.yml"`,
+`"myorg/full-security"`.
+
+At line 4903, replace the job comparison:
+
+```go
+			if f.Code == "ISSUE-417" && f.Data["requiredAction"] == "myorg/sast-scan" {
+```
+
+Then add to the end of the first subtest:
+
+```go
+		assertSubjectKey(t, findings, "ISSUE-417", "requiredAction", []string{
+			"myorg/sast-scan",
+			"myorg/policy/.github/workflows/policy.yml",
+			"myorg/full-security",
+		})
+		assertNoJob(t, findings, "ISSUE-417")
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./policies/ -run TestIssue417 -v`
+Expected: FAIL with `identity subject is "message"=...` and
+`job = "org/sast-scan", want empty`.
+
+- [ ] **Step 3: Update the rule**
+
+In `policies/required_actions.rego`, replace the finding object with:
+
+```rego
+	finding := {
+		"code":     "ISSUE-417",
+		"severity": "high",
+		"message":  sprintf("required action or reusable workflow %q is not referenced by any workflow (group %d)", [required, i]),
+		# No "job": a missing required action is not a job. requiredAction names
+		# what this finding is about and is what the identity recipe selects
+		# (finding/identity). groupIndex stays as payload: it moves whenever the
+		# user reorders requiredGroups, which is not a new finding.
+		"requiredAction": required,
+		"required":       required,
+		"groupIndex":     i,
+	}
+```
+
+`required` is kept as payload for consumers already reading it; only
+`requiredAction` participates in identity.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./policies/ -run TestIssue417 -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add policies/required_actions.rego policies/rules_test.go
+git commit -m "fix(policies): identify required-action findings by the action
+
+ISSUE-417 is about a required action or reusable workflow, not a job. It
+emitted a required key that was never in the subject-key list, so its
+identity rode on the prose message including the group index.
+
+Refs #403"
+```
+
+---
+
+### Task 6: Branch family (ISSUE-501, ISSUE-505) and the branch aggregation
+
+**Files:**
+- Modify: `policies/branch_unprotected.rego`
+- Modify: `policies/branch_non_compliant.rego`
+- Modify: `cmd/legacy_json.go` (the `nonCompliantBranches` loop, around line 539)
+- Test: `policies/rules_test.go` (the ISSUE-501 and ISSUE-505 assertions that key
+  on `f.Job`), `cmd/legacy_json_test.go`
+
+**Interfaces:**
+- Consumes: `assertNoJob` (Task 2), `branchName` already first-class in the
+  priority list.
+- Produces: nothing new.
+
+This is the one task with a load-bearing consumer. `cmd/legacy_json.go` builds
+`nonCompliantBranches` by keying on `f.Job`; with `job` empty every branch would
+key on `""` and no branch would receive the full protection-settings shape.
+
+- [ ] **Step 1: Write the failing test for the aggregation**
+
+In `cmd/legacy_json_test.go`, add:
+
+```go
+// The v0.2.x branch block exposes the full protection settings only on branches
+// that fired a non-compliance finding, and it finds them by matching the
+// finding to the branch. That match must read branchName from the payload: the
+// job field is empty for a branch finding, because a branch is not a job.
+func TestBranchProtectionBlockMatchesNonCompliantBranchByPayload(t *testing.T) {
+	f := opaengine.Finding{
+		Code: string(control.CodeBranchNonCompliant),
+		Data: map[string]any{"branchName": "main", "allowForcePush": true},
+	}
+
+	got := nonCompliantBranchNames([]opaengine.Finding{f})
+
+	if !got["main"] {
+		t.Errorf("nonCompliantBranchNames = %v, want main flagged", got)
+	}
+}
+
+// A finding without a branchName cannot name a branch, so it must not produce a
+// phantom "" entry that would match no branch and hide the real ones.
+func TestNonCompliantBranchNamesIgnoresAPayloadWithoutABranch(t *testing.T) {
+	f := opaengine.Finding{Code: string(control.CodeBranchNonCompliant)}
+
+	if got := nonCompliantBranchNames([]opaengine.Finding{f}); len(got) != 0 {
+		t.Errorf("nonCompliantBranchNames = %v, want empty", got)
+	}
+}
+```
+
+Note: `cmd` has no test that builds the branch block itself, so this helper is
+the automated guard for the aggregation. The block-level shape is verified in
+Task 7 against the real GitLab project, which produces ISSUE-505 findings.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./cmd/ -run TestBranchProtectionBlockMatchesNonCompliantBranchByPayload -v`
+Expected: FAIL to compile, `undefined: nonCompliantBranchNames`.
+
+- [ ] **Step 3: Extract and fix the aggregation**
+
+In `cmd/legacy_json.go`, replace the inline loop:
+
+```go
+		nonCompliantBranches := map[string]bool{}
+		for _, f := range findings {
+			if f.Code == string(control.CodeBranchNonCompliant) {
+				nonCompliantBranches[f.Job] = true
+			}
+		}
+```
+
+with a call to a named helper, and add the helper next to
+`buildBranchProtectionBlock`:
+
+```go
+		nonCompliantBranches := nonCompliantBranchNames(findings)
+```
+
+```go
+// nonCompliantBranchNames collects the branches that fired ISSUE-505, read from
+// the finding's branchName payload. Not from Finding.Job: that field is a CI job
+// name, and a branch is not a job, so branch rules leave it empty.
+func nonCompliantBranchNames(findings []opaengine.Finding) map[string]bool {
+	out := map[string]bool{}
+	for _, f := range findings {
+		if f.Code != string(control.CodeBranchNonCompliant) {
+			continue
+		}
+		if name, ok := f.Data["branchName"].(string); ok && name != "" {
+			out[name] = true
+		}
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./cmd/ -run TestBranchProtectionBlockMatchesNonCompliantBranchByPayload -v`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing rule tests**
+
+In `policies/rules_test.go`, in the ISSUE-505 test, replace the three lines that
+key on `f.Job` (`issue505ByJob[f.Job]`, the duplicate check, and
+`hits[f.Job] = true`) with a payload read:
+
+```go
+			branch, _ := f.Data["branchName"].(string)
+			if issue505ByJob[branch].Code != "" {
+				t.Fatalf("expected at most one ISSUE-505 per branch, got duplicate for %q", branch)
+			}
+			issue505ByJob[branch] = f
+			hits[branch] = true
+```
+
+In the ISSUE-501 test, replace the `f.Job != "feature"` assertion with:
+
+```go
+			if name, _ := f.Data["branchName"].(string); name != "feature" {
+				t.Fatalf("ISSUE-501 should target the unprotected branch, got %q", name)
+			}
+```
+
+Then append `assertNoJob` to both tests:
+
+```go
+	assertNoJob(t, findings, "ISSUE-501")
+```
+
+```go
+	assertNoJob(t, findings, "ISSUE-505")
+```
+
+- [ ] **Step 6: Run the tests to verify they fail**
+
+Run: `go test ./policies/ -run 'TestIssue50[15]' -v`
+Expected: FAIL with `job = "feature", want empty` and `job = "main", want empty`.
+
+- [ ] **Step 7: Update the rules**
+
+In `policies/branch_unprotected.rego`, remove the `"job"` line:
+
+```rego
+	finding := {
+		"code":     "ISSUE-501",
+		"severity": "critical",
+		"message":  sprintf("branch %q must be protected", [branch.name]),
+		# No "job": a branch is not a job. branchName names what this finding is
+		# about and is what the identity recipe selects (finding/identity).
+		"type":       "unprotected",
+		"branchName": branch.name,
+	}
+```
+
+In `policies/branch_non_compliant.rego`, remove the `"job"` line and leave every
+other key untouched:
+
+```rego
+	finding := {
+		"code":     "ISSUE-505",
+		"severity": "high",
+		"message":  sprintf("Branch '%s' has non-compliant protection settings", [branch.name]),
+		# No "job": a branch is not a job. branchName names what this finding is
+		# about and is what the identity recipe selects (finding/identity).
+		"type":                          "non_compliant",
+		"branchName":                    branch.name,
+		"reasons":                       reasons,
+		"allowForcePush":                object.get(branch, "allowForcePush", false),
+		"allowForcePushDisplay":         object.get(branch, "allowForcePush", false),
+		"minMergeAccessLevel":           object.get(branch, "minMergeAccessLevel", 0),
+		"authorizedMinMergeAccessLevel": object.get(input.config.branchMustBeProtected, "minMergeAccessLevel", 0),
+		"minPushAccessLevel":            object.get(branch, "minPushAccessLevel", 0),
+		"authorizedMinPushAccessLevel":  object.get(input.config.branchMustBeProtected, "minPushAccessLevel", 0),
+	}
+```
+
+- [ ] **Step 8: Run the whole suite**
+
+Run: `make test`
+Expected: PASS. `cmd` covers the branch block; if a JSON fixture there asserts
+the old shape, the aggregation fix is what keeps it correct, so a failure here
+means the helper is not wired in.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add policies/branch_unprotected.rego policies/branch_non_compliant.rego policies/rules_test.go cmd/legacy_json.go cmd/legacy_json_test.go
+git commit -m "fix(policies): stop putting a branch name in the job field
+
+ISSUE-501 and ISSUE-505 are about a branch, not a job; branchName already
+carries their identity. The JSON branch block matched non-compliant
+branches through Finding.Job, so it now reads branchName from the payload
+instead, behind a named helper with its own test.
+
+Refs #403"
+```
+
+---
+
+### Task 7: Documentation, the JSON contract test, and end-to-end verification
+
+**Files:**
+- Modify: `docs/FINGERPRINT.md`
+- Modify: `cmd/csv.go` (the `context` column comment, around line 41)
+- Test: `cmd/legacy_json_test.go`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1 to 6.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the failing JSON contract test**
+
+In `cmd/legacy_json_test.go`, add:
+
+```go
+// The job key disappears from an issue entry on its own once the rule stops
+// emitting one, because projectFinding guards on a non-empty Job. That makes
+// the output contract depend on rule payload rather than on the builder's
+// argument, so it is pinned here.
+func TestProjectFindingOmitsJobForANonJobFinding(t *testing.T) {
+	f := opaengine.Finding{
+		Code: "ISSUE-408", Fingerprint: "deadbeefcafef00d",
+		Data: map[string]any{"componentPath": "components/sast/sast"},
+	}
+
+	got := projectFinding(f, "job")
+
+	if _, has := got["job"]; has {
+		t.Errorf("job = %v, want the key absent for a finding that is not about a job", got["job"])
+	}
+	if got["componentPath"] != "components/sast/sast" {
+		t.Errorf("componentPath = %v, want the component path", got["componentPath"])
+	}
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `go test ./cmd/ -run TestProjectFindingOmitsJobForANonJobFinding -v`
+Expected: PASS immediately, because `projectFinding` already guards on
+`f.Job != ""`. This test is a contract pin, not a driver. Confirm it can fail by
+temporarily changing the guard to `if jobKey != ""`, re-running (expect FAIL),
+then restoring it.
+
+- [ ] **Step 3: Update the CSV column comment**
+
+In `cmd/csv.go`, replace the paragraph describing the `context` column:
+
+```go
+// The "context" column is Finding.Job: the CI job a finding sits in, or empty
+// when the finding is not about a job (a branch, an include, a required
+// template or component). Those findings carry what they are about in their
+// structured payload and in the identity block of the JSON report.
+```
+
+- [ ] **Step 4: Update docs/FINGERPRINT.md**
+
+Replace the subject-key priority table with the new order and drop the
+`componentName` row:
+
+| Priority | Key | Example value |
+| --- | --- | --- |
+| 1 | `uses` | `grafana/shared-workflows/actions/get-vault-secrets@main` |
+| 2 | `branchName` | `main` |
+| 3 | `includePath` | `gitlab.example.com/components/sast/sast` |
+| 4 | `templatePath` | `templates/go/go` |
+| 5 | `componentPath` | `components/sast/sast` |
+| 6 | `requiredAction` | `org/sast-scan` |
+| 7 | `image` | `golang:1.25` (a Dockerfile `FROM` base) |
+| 8 | `serviceImage` | `docker:27-dind` |
+| 9 | `link` | `registry.gitlab.com/security-products/secrets:7` |
+| 10 | `tag` | `latest` |
+| 11 | `variableName` | `CI_DEBUG_TRACE` |
+| 12 | `hardcodedJob` | `deploy-prod` |
+| 13 | `scriptLine` | `curl -sSL https://example.com/i.sh \| bash` |
+| 14 | `detail` | `allow_failure: true masks scan failures` |
+
+Update the same list inside the ASCII path diagram in the "The paths" section.
+
+Extend the RecipeVersion 2 history row so it names the whole set:
+
+```markdown
+| 2 | Ten finding blocks that had no structured key, or that smuggled their subject through the `job` field, now name what they are about: ISSUE-401 (`hardcodedJob`), ISSUE-402 GitLab / ISSUE-403 / ISSUE-404 (`includePath`), ISSUE-405 / ISSUE-406 (`templatePath`), ISSUE-408 / ISSUE-409 (`componentPath`), ISSUE-417 (`requiredAction`), and ISSUE-501 / ISSUE-505 keep `branchName` while dropping `job`. The algorithm is unchanged; their fingerprints are not. |
+```
+
+Add a short subsection under "Inputs" stating what `job` means:
+
+```markdown
+### The job segment
+
+`job` is the name of a CI job. It is empty when the finding is not about a job:
+a branch, an include, a required template, component or action. Those findings
+identify on their subject key instead. Before recipe version 2 several rules
+put a branch name, an include source or a required path in this field, which
+made identity depend on a mislabelled value.
+```
+
+- [ ] **Step 5: Run the full verification**
+
+```bash
+make test
+make lint
+make deadcode
+```
+
+Expected: all green.
+
+- [ ] **Step 6: End-to-end comparison against real projects**
+
+Rebuild and re-run the comparison used earlier in PR #404, over the six GitHub
+repositories and the GitLab instance. Confirm that:
+- no finding outside the ten blocks changes its fingerprint,
+- the ten do change, exactly once,
+- ISSUE-505 findings still produce the full protection shape in the JSON
+  branch block.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/FINGERPRINT.md cmd/csv.go cmd/legacy_json_test.go
+git commit -m "docs(fingerprint): record that job means a job
+
+Documents the reordered subject-key list, what the job segment means and
+when it is empty, and extends the recipe version 2 history to the full set
+of blocks that moved.
+
+Refs #403"
+```
+
+---
+
+## Final step: squash
+
+Once every task is complete and verified, rebase on `origin/main` and squash the
+branch into a single commit, as agreed on PR #404. Fold the design spec and this
+plan into that commit or drop them from the branch, depending on whether the
+maintainer wants the process artifacts carried in the PR.

--- a/docs/superpowers/specs/2026-08-07-job-field-semantics-design.md
+++ b/docs/superpowers/specs/2026-08-07-job-field-semantics-design.md
@@ -1,0 +1,218 @@
+# Design: `Finding.Job` means a job
+
+Date: 2026-08-07
+Status: approved, not yet implemented
+Context: getplumber/plumber #403, PR #404
+
+## Problem
+
+`Finding.Job` is a first-class input to the finding-identity recipe. The hashed
+string is:
+
+```
+sha256( code \n file \n job \n subject [\n step] )[:16]
+```
+
+Ten finding blocks put something that is not a job into that field: a branch
+name, an include source, or a required template/component path. The value is
+therefore load-bearing for identity while being mislabelled everywhere it
+surfaces.
+
+The codebase already knows this. `cmd/csv.go` names its column `context` rather
+than `job`, with the comment "some rules put a branch / include path / file
+there instead, so the header avoids the false claim `job` would make when the
+value isn't a job". `cmd/legacy_json.go` passes `""` as the output key for the
+branch and two include blocks, hiding the value in JSON while the hash keeps
+using it.
+
+The consequence that forces the issue: as long as identity leans on the
+overloaded `job`, the field cannot be corrected without re-keying findings a
+second time.
+
+## Evidence
+
+An audit of all 77 finding blocks (66 distinct codes) in `policies/*.rego`,
+grouped by the expression assigned to `"job"`:
+
+| Expression | Blocks | Is it a job? |
+| --- | --- | --- |
+| `job.name`, `sig.job`, `jobname` | 57 | yes |
+| key absent | 10 | not applicable, repository-level |
+| `required` | 5 | no, a required template/component path |
+| `inc.source` | 3 | no, an include source |
+| `branch.name` | 2 | no, a branch |
+
+The unit of change is the finding block, not the control code: ISSUE-402 has two
+blocks, and only its GitLab include block is affected. Its GitHub step-level
+block uses `job.name` and is correct.
+
+Consumers of `Finding.Job`:
+
+| Consumer | Use |
+| --- | --- |
+| identity recipe | third hashed segment, always |
+| `cmd/legacy_json.go` | per-block output key, `"job"` or `""` to hide |
+| `cmd/legacy_json.go:541` | **load-bearing**: builds `nonCompliantBranches` by keying on `f.Job` |
+| `cmd/csv.go` | the `context` column |
+| `cmd/ocsf.go` | `rec["job"]`, already guarded by `if f.Job != ""` |
+| `internal/engine/opa` `enrichFindingsWithJobLocation` | looks up `byName[f.Job]` to resolve file/line/step |
+| `cmd/sarif.go` `sarifCodeSpanJob` | re-quotes the job name inside the message |
+| sorting | `cmd/legacy_json.go:230`, `cmd/render_details.go:432` |
+
+`cmd/glsast.go` looks like a second identity (`code|file|job|message`) but is
+derived from `Fingerprint`, falling back to that string only for unstamped
+findings. It is not a divergent path.
+
+## Decisions
+
+1. **`Finding.Job` is the name of a CI job, empty when the finding is not about
+   a job.** Rejected alternative: rename the field to `context` and let it stay
+   polymorphic. The value is duplicated in the subject key, so `context` would
+   preserve a field carrying no unique information, and the platform would get a
+   polymorphic key instead of a typed one.
+2. **All ten blocks are fixed in this change**, not only the five whose value is
+   currently exposed in JSON. Doing half leaves the field polymorphic and
+   re-keys the rest a second time under a later version.
+3. **`job` is dropped from outputs, not replaced by a derived display value.**
+   Rejected alternative: compute a render-time `context` (job, else the subject
+   value) so flat formats keep a pointer. The CSV `context` cell goes empty for
+   these rows, which is accepted.
+4. **`componentName` leaves the subject-key priority list.** It is emitted by
+   ISSUE-402/403 as `object.get(inc, "componentName", "")`, so it is empty for
+   any include that is not a component, and it duplicates a segment of the
+   source. Once those blocks emit `includePath` it can never win the subject.
+   It stays in the payload as informational data.
+5. **Regression guard is per-control test pins**, not a source scanner or a
+   runtime invariant. Each of the ten blocks gets a pin asserting both its
+   subject key and that `job` is empty.
+
+## Design
+
+### Per-block changes
+
+"Absent" below means the Rego rule omits the `"job"` key from the finding
+object entirely, which yields `Finding.Job == ""` after unmarshalling. No rule
+emits `"job": ""`.
+
+| Block | `job` today | after | Subject key | Key status |
+| --- | --- | --- | --- | --- |
+| ISSUE-501 `branch_unprotected` | `branch.name` | absent | `branchName` | exists |
+| ISSUE-505 `branch_non_compliant` | `branch.name` | absent | `branchName` | exists |
+| ISSUE-402 GitLab include block | `inc.source` | absent | `includePath` | new |
+| ISSUE-403 `includes_outdated` | `inc.source` | absent | `includePath` | new |
+| ISSUE-404 `includes_forbidden_version` | `inc.source` | absent | `includePath` | added earlier in PR #404 |
+| ISSUE-405 `template_missing` | `required` | absent | `templatePath` | added earlier in PR #404 |
+| ISSUE-406 `template_overridden` | `required` | absent | `templatePath` | added earlier in PR #404 |
+| ISSUE-408 `component_missing` | `required` | absent | `componentPath` | renamed from `componentName` |
+| ISSUE-409 `component_overridden` | `required` | absent | `componentPath` | renamed from `componentName` |
+| ISSUE-417 `required_actions` | `required` | absent | `requiredAction` | new, replaces the unlisted `required` |
+
+ISSUE-401 `hardcoded_jobs` is deliberately not in this set: its `job` is a real
+job name. Its `hardcodedJob` key remains a duplicate of `job`, whose only
+purpose is to keep identity off the prose message.
+
+### Recipe
+
+`finding/identity`'s priority list becomes:
+
+```
+uses, branchName, includePath, templatePath, componentPath, requiredAction,
+image, serviceImage, link, tag, variableName, hardcodedJob, scriptLine, detail
+```
+
+`componentName` is removed. The ordering rule is unchanged: most specific wins,
+so a full include source outranks a bare component name.
+
+The selection algorithm does not change. `RecipeVersion` stays at **2**: this
+change ships in the same release as the re-key already in PR #404, so the whole
+affected set moves exactly once.
+
+### Output changes
+
+- No JSON builder changes are needed. `projectFinding` already guards
+  `if f.Job != "" && jobKey != ""`, so the `job` key disappears from those issue
+  objects as soon as the rules stop emitting it. Each object keeps its
+  structured subject key and its `identity` block, so no information is lost.
+  A test pins that the key is gone for one affected block, since the behaviour
+  now depends on rule output rather than on the builder's argument.
+- `cmd/legacy_json.go:541` reads `f.Data["branchName"]` instead of `f.Job` when
+  building `nonCompliantBranches`. Without this, every branch keys on `""` and
+  no branch receives the full protection-settings shape.
+- `cmd/csv.go`: the `context` column is empty for these rows. Its comment,
+  which currently documents the overload, is rewritten to state that `context`
+  is a job name or empty.
+- `cmd/ocsf.go`: no change. It already omits the key when `Job` is empty.
+- `cmd/sarif.go`: no change. `sarifCodeSpanJob` already returns the message
+  unchanged when `Job` is empty, so those messages lose the code span around
+  the name. Accepted as cosmetic.
+- `enrichFindingsWithJobLocation`: no change. The lookup already fails for these
+  findings because the value never matches a job name, so emptying it changes
+  no behaviour.
+
+### Identity consequences
+
+All ten blocks re-key once. Six of them are already re-keying in PR #404.
+
+ISSUE-402 (GitLab block), ISSUE-403 and ISSUE-417 have no working structured
+subject today, so their identity rides entirely on prose. Fixing them removes
+the same defect #403 exists to remove; they were missed in the issue's list.
+
+Four deliberate collapses, consistent with the reasoning already documented
+for the DNF group index:
+
+- ISSUE-405, ISSUE-408 and ISSUE-417 carry no `file`, so identity becomes
+  `code + required path`. Two DNF groups requiring the same path share one
+  fingerprint.
+- ISSUE-404 loses the ref from identity, which lived only in the prose. The
+  same include pinned to two different forbidden refs is one finding.
+- ISSUE-403 and the ISSUE-402 GitLab block: identity is now
+  `code + file + includePath`. `inc.source` excludes the ref, so the same
+  include source pinned at two different refs produced two fingerprints
+  before this change and produces one after it.
+- ISSUE-406 and ISSUE-409: identity is now `code + templatePath` (or
+  `componentPath`) alone. The prose message embedded the overridden-job
+  count, so two includes matching the same required path with different
+  override counts now share one fingerprint.
+
+Consumer-facing consequence: for any of these four, a single report can
+contain two issue entries that share one `fingerprint` and one identical
+`identity.fields`.
+
+## Non-goals
+
+- Pruning the `componentName` payload key from ISSUE-402/403, or emitting it
+  only for component includes. It is pre-existing output and a separate
+  contract decision.
+- Any change to the selection algorithm in `finding/identity`.
+- Any change to `Finding.Job` for the 57 blocks where it is a genuine job name.
+
+## Testing
+
+- `assertSubjectKey` in `policies/rules_test.go` gains an assertion that `job`
+  is empty, and every one of the ten blocks gets a pin pairing its subject key
+  with that emptiness. This is the regression guard from decision 5.
+- Tests that currently key on `f.Job` for affected controls are switched to the
+  structured value: `TestIssue405_TemplateMissing`,
+  `TestIssue408_ComponentMissing`, and the ISSUE-501/ISSUE-505 assertions.
+- A JSON test that `projectFinding` emits no `job` key for a finding that is not
+  about a job. The behaviour now depends on rule payload rather than on the
+  builder's argument, so it is pinned rather than assumed.
+- Unit tests for the extracted `nonCompliantBranchNames` helper, covering both a
+  payload carrying `branchName` and one without it. `cmd` has no test that
+  builds the branch block itself, so the helper is the automated guard for the
+  load-bearing aggregation; the assembled block shape is checked end to end
+  against the real GitLab project, which produces ISSUE-505 findings.
+- Golden fingerprint tests in `finding/identity` are untouched: the algorithm
+  does not change.
+- End-to-end: re-run the old-versus-new comparison over the six GitHub
+  repositories and the GitLab instance used earlier in PR #404, confirming that
+  only the intended blocks move.
+
+## Risks
+
+- The branch aggregation is the one genuinely load-bearing use of `Job`. If the
+  replacement misses, the JSON branch shape silently degrades rather than
+  failing loudly, which is why it gets its own test.
+- Consumers reading `issues[].job` from the four affected JSON blocks lose that
+  key. They can read the structured subject key or the `identity` block in the
+  same object.

--- a/finding/identity/identity.go
+++ b/finding/identity/identity.go
@@ -1,0 +1,263 @@
+// Package identity holds Plumber's finding-identity recipe: the one selection
+// of fields that says which findings are the same finding instance across runs.
+//
+// Two consumers need that answer and must never answer it differently. The CLI
+// hashes the selection into the short `fingerprint` every export format carries
+// (JSON, CSV, SARIF, GitLab SAST, OCSF). A platform grouping findings into
+// long-lived issues needs the same selection, but as data it can store and
+// query rather than an opaque hash. So the selection lives here, once, and both
+// read it: Of returns the identity field set, Fingerprint hashes exactly what
+// Of returned. They cannot drift.
+//
+// What the recipe selects, and why:
+//
+//   - code, file, job: the canonical coordinates of a finding.
+//   - one subject key: what the rule actually flagged (an action ref, a
+//     component path, a variable). Taken from the rule's structured payload in
+//     the priority order of SubjectKeys, first match only. Preferring this over
+//     the prose message is what makes identity survive a message rewording.
+//   - step, when the workflow resolved one: the last discriminator between two
+//     steps of one job that reference the same action.
+//
+// What it deliberately leaves out: line and url (they move whenever unrelated
+// code above the finding is edited), advisories (grows as CVEs are published),
+// latestVersion (moves on any upstream release), metadata (refetched every
+// run), and reasons/status (they track current settings, not identity). Any of
+// those in the identity would make an unchanged finding look new.
+//
+// See docs/FINGERPRINT.md for the full contract, and RecipeVersion for what a
+// change to the selection costs.
+package identity
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"slices"
+	"strings"
+)
+
+// RecipeVersion is the version of the identity recipe. It tracks identity
+// OUTCOMES, not just the code in this package, so bump it whenever findings
+// come out keyed differently than they did before:
+//
+//   - the algorithm here changes: a new subject key, a reordering of
+//     SubjectKeys, a field entering or leaving the identity; or
+//   - a control starts or stops emitting a subject key, which moves its
+//     findings between prose identity and structured identity just as much.
+//
+// The second case is the easy one to miss: nothing in this package changes, so
+// its tests stay green. The per-control pins in policies/rules_test.go are what
+// fire there.
+//
+// Treat a bump as a breaking change, made deliberately. A re-keyed finding is
+// read downstream as the old issue disappearing and a new one appearing in its
+// place, and a consumer holding only the hash (SARIF, OCSF, CSV) has no other
+// signal that it happened. Stored next to a grouped finding, this constant is
+// that signal.
+//
+// History:
+//
+//	1  The recipe as first shipped: canonical coordinates, the SubjectKeys
+//	   priority list, the resolved step.
+//	2  Eleven finding blocks changed what they identify on:
+//	     - ISSUE-401 gained hardcodedJob. It kept job too: that field holds
+//	       a real job name here, so it was correctly left in the identity.
+//	     - ISSUE-402 GitLab / ISSUE-403 / ISSUE-404 gained includePath,
+//	       ISSUE-405 / ISSUE-406 gained templatePath, ISSUE-408 / ISSUE-409
+//	       gained componentPath, and ISSUE-417 gained requiredAction. Each
+//	       of these also lost job: the field used to smuggle that same
+//	       subject through a mislabelled job value, which the new key
+//	       replaces.
+//	     - ISSUE-501 / ISSUE-505 kept their existing branchName and lost
+//	       job, for the same reason: job held the branch name, not a job.
+//	   Ten of the eleven blocks lost job; only ISSUE-401 kept it. The
+//	   algorithm is unchanged; their fingerprints are not.
+const RecipeVersion = 2
+
+// fingerprintLength is how many hex characters of the digest the short
+// fingerprint keeps. 16 hex chars (64 bits) is short enough to read in a CSV
+// cell and wide enough that collisions are not a practical concern at the
+// number of findings one repository produces.
+const fingerprintLength = 16
+
+// messageKey is the subject key reported when a rule emits none of the
+// structured keys and identity falls back to its prose message. It is not a
+// member of SubjectKeys: a rule cannot select it, only fall back to it.
+const messageKey = "message"
+
+// subjectKeys lists the structured payload keys that say what a finding is
+// ABOUT, in priority order. The first one a finding carries wins and every
+// other is ignored, even when present.
+//
+// The order is deliberate: the most specific value wins. If `tag` outranked
+// `link`, every image tagged `latest` in a project would share the subject
+// `tag=latest`, whereas the full reference keeps `grafana/vale:latest` and
+// `nginx:latest` apart.
+var subjectKeys = []string{
+	"uses", "branchName", "includePath", "templatePath", "componentPath",
+	"requiredAction", "image", "serviceImage", "link", "tag", "variableName",
+	"hardcodedJob", "scriptLine", "detail",
+}
+
+// SubjectKeys returns the subject-key priority list. The caller gets a copy, so
+// sorting or trimming the result cannot re-key the findings this process
+// computes afterwards.
+func SubjectKeys() []string { return slices.Clone(subjectKeys) }
+
+// Finding is the view of a finding the recipe reads. The CLI fills it from its
+// own finding type; anything reading Plumber's serialized output builds it with
+// FromMap. There is no Line or URL field on purpose: they are not inputs, and a
+// type that carried them would suggest otherwise.
+type Finding struct {
+	Code    string
+	File    string
+	Job     string
+	Message string
+	// Data is the rule's structured payload: the subject keys above, the
+	// resolved `step`, and anything else the rule emitted.
+	Data map[string]any
+}
+
+// FromMap builds a Finding from a serialized finding: the flat JSON object
+// Plumber writes, where the canonical fields and the structured payload sit
+// side by side at the top level. Everything that is not a canonical field stays
+// in Data, so a subject key added by a later rule is readable without a change
+// here, and so is the volatile payload, which the recipe simply never selects.
+//
+// FromMap expects a whole serialized finding, not an exported issue entry from
+// a *Result block in Plumber's JSON report: an issue entry has no file and no
+// message, so running FromMap over one silently produces a different identity
+// for any finding that has a file or that falls back to the prose subject.
+func FromMap(m map[string]any) Finding {
+	f := Finding{Data: map[string]any{}}
+	for k, v := range m {
+		switch k {
+		case "code":
+			f.Code, _ = v.(string)
+		case "file":
+			f.File, _ = v.(string)
+		case "job":
+			f.Job, _ = v.(string)
+		case "message":
+			f.Message, _ = v.(string)
+		default:
+			f.Data[k] = v
+		}
+	}
+	return f
+}
+
+// Field is one key/value pair of a finding's identity.
+type Field struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// Fields is the identity field set of one finding: everything the recipe
+// selected, as data. Pairs renders it in the order it contributes to identity.
+type Fields struct {
+	Code string `json:"code"`
+	File string `json:"file"`
+	Job  string `json:"job"`
+	// Subject is the one key/value pair that says what the finding is about.
+	// Its Key is the winning member of SubjectKeys, or "message" when the rule
+	// emitted none of them.
+	Subject Field `json:"subject"`
+	// SubjectFromMessage reports that Subject holds the prose fallback rather
+	// than a structured key. Such a finding's identity is tied to the wording of
+	// its rule, so rewording that rule re-keys it.
+	SubjectFromMessage bool `json:"subjectFromMessage"`
+	// Step is the resolved step name, empty when the finding has none.
+	Step string `json:"step,omitempty"`
+	// Version is the RecipeVersion that produced this field set, so a consumer
+	// storing it can tell later which selection it was built from.
+	Version int `json:"version"`
+}
+
+// Pairs returns the selected key/value pairs in the order they contribute to
+// identity. The step pair is present only when the finding resolved one, so a
+// finding without a step is not confused with one whose step is empty.
+func (f Fields) Pairs() []Field {
+	pairs := []Field{
+		{Key: "code", Value: f.Code},
+		{Key: "file", Value: f.File},
+		{Key: "job", Value: f.Job},
+		f.Subject,
+	}
+	if f.Step != "" {
+		pairs = append(pairs, Field{Key: "step", Value: f.Step})
+	}
+	return pairs
+}
+
+// Of returns the identity field set of a finding. ok is false for a codeless
+// finding: there is nothing stable to report it against, so it has no identity
+// and gets no fingerprint.
+//
+// A coded finding always has an identity, even a narrow one. With no subject
+// key and no message the subject is an empty "message" pair and the finding is
+// identified by code, file and job alone, so every such finding of that control
+// in one job shares a fingerprint. That is deterministic, not an error.
+func Of(f Finding) (Fields, bool) {
+	if f.Code == "" {
+		return Fields{}, false
+	}
+	fields := Fields{
+		Code:    f.Code,
+		File:    f.File,
+		Job:     f.Job,
+		Step:    stringValue(f.Data, "step"),
+		Version: RecipeVersion,
+	}
+	for _, k := range subjectKeys {
+		if v := stringValue(f.Data, k); v != "" {
+			fields.Subject = Field{Key: k, Value: v}
+			return fields, true
+		}
+	}
+	fields.Subject = Field{Key: messageKey, Value: f.Message}
+	fields.SubjectFromMessage = true
+	return fields, true
+}
+
+// Fingerprint returns the short, line-independent identifier of a finding: the
+// hash of the very field set Of selects. Empty for a codeless finding.
+func Fingerprint(f Finding) string {
+	fields, ok := Of(f)
+	if !ok {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(fields.canonical()))
+	return hex.EncodeToString(sum[:])[:fingerprintLength]
+}
+
+// canonical renders the field set as the newline-joined string that is hashed.
+// The structured subject contributes "key=value" so two different keys holding
+// the same value cannot collide; the message fallback contributes the message
+// alone, which is what the published fingerprints were computed from.
+func (f Fields) canonical() string {
+	subject := f.Subject.Value
+	if !f.SubjectFromMessage {
+		subject = f.Subject.Key + "=" + f.Subject.Value
+	}
+	segments := []string{f.Code, f.File, f.Job, subject}
+	if f.Step != "" {
+		segments = append(segments, f.Step)
+	}
+	return strings.Join(segments, "\n")
+}
+
+// stringValue reads a non-empty string from a payload bag, tolerating both a
+// missing key and a value the rule emitted as something other than a string.
+//
+// A non-string is skipped, not coerced, and a subject key that is skipped drops
+// the finding to prose identity. That is reachable from real payload: a JSON
+// round trip turns a numeric `tag: 7` into a float64. Both sides of the recipe
+// read it the same way, so the CLI and a consumer still agree, and
+// Fields.SubjectFromMessage makes the degradation visible rather than silent.
+// Coercing instead would be a better answer, but it would re-key every finding
+// it applies to, so it is a RecipeVersion decision rather than a free fix.
+func stringValue(data map[string]any, key string) string {
+	v, _ := data[key].(string)
+	return v
+}

--- a/finding/identity/identity_test.go
+++ b/finding/identity/identity_test.go
@@ -1,0 +1,334 @@
+package identity_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/getplumber/plumber/finding/identity"
+)
+
+// The whole point of the package: a consumer that needs to group findings into
+// issues across runs gets the selected fields as data, not only a hash.
+func TestOf_ReturnsTheSelectedFieldsAsData(t *testing.T) {
+	f := identity.Finding{
+		Code:    "ISSUE-701",
+		File:    ".github/workflows/ci.yml",
+		Job:     "build",
+		Message: "job \"build\" references action \"owner/act@v1\" with a mutable ref",
+		Data:    map[string]any{"uses": "owner/act@v1", "step": "Check out"},
+	}
+	got, ok := identity.Of(f)
+	if !ok {
+		t.Fatalf("Of reported no identity for a coded finding")
+	}
+	if got.Code != "ISSUE-701" || got.File != ".github/workflows/ci.yml" || got.Job != "build" {
+		t.Errorf("canonical fields not selected: %+v", got)
+	}
+	if got.Subject.Key != "uses" || got.Subject.Value != "owner/act@v1" {
+		t.Errorf("subject = %+v, want uses=owner/act@v1", got.Subject)
+	}
+	if got.Step != "Check out" {
+		t.Errorf("step = %q, want %q", got.Step, "Check out")
+	}
+	// The version is part of what Of returns, not just a package constant: a
+	// consumer stores the two together, and a Fields carrying version 0 would
+	// silently defeat the detection a later bump exists to trigger. Pinned here
+	// on the structured-subject branch, and again on the fallback branch, since
+	// Of returns from two places.
+	if got.Version != identity.RecipeVersion {
+		t.Errorf("Version = %d, want %d", got.Version, identity.RecipeVersion)
+	}
+}
+
+// Pairs is the wire form the platform stores: the selected key/value pairs, in
+// the order they contribute to identity.
+func TestFields_PairsAreOrderedAndComplete(t *testing.T) {
+	f := identity.Finding{
+		Code: "ISSUE-701", File: "ci.yml", Job: "build",
+		Data: map[string]any{"uses": "owner/act@v1", "step": "Post PR comment"},
+	}
+	fields, _ := identity.Of(f)
+	want := []identity.Field{
+		{Key: "code", Value: "ISSUE-701"},
+		{Key: "file", Value: "ci.yml"},
+		{Key: "job", Value: "build"},
+		{Key: "uses", Value: "owner/act@v1"},
+		{Key: "step", Value: "Post PR comment"},
+	}
+	if got := fields.Pairs(); !slices.Equal(got, want) {
+		t.Errorf("Pairs() = %+v, want %+v", got, want)
+	}
+}
+
+// A finding with no resolved step contributes no step pair, so consumers do not
+// have to special-case an empty value.
+func TestFields_PairsOmitTheStepWhenAbsent(t *testing.T) {
+	fields, _ := identity.Of(identity.Finding{Code: "ISSUE-701", Job: "build", Message: "x"})
+	for _, p := range fields.Pairs() {
+		if p.Key == "step" {
+			t.Errorf("step pair emitted for a finding without a step: %+v", fields.Pairs())
+		}
+	}
+}
+
+// Exactly one subject key is selected: the first one present in priority order,
+// so two keys on one finding cannot both carry identity.
+func TestOf_SelectsTheHighestPrioritySubjectKey(t *testing.T) {
+	f := identity.Finding{
+		Code: "ISSUE-103", Job: "scan",
+		Data: map[string]any{"tag": "7", "link": "registry.gitlab.com/security-products/secrets:7"},
+	}
+	got, _ := identity.Of(f)
+	if got.Subject.Key != "link" {
+		t.Errorf("subject key = %q, want link (higher priority than tag)", got.Subject.Key)
+	}
+	for _, p := range got.Pairs() {
+		if p.Key == "tag" {
+			t.Errorf("a second subject key entered the identity: %+v", got.Pairs())
+		}
+	}
+}
+
+// Rules that emit no structured key fall back to the message, and the fallback
+// is reported as such so a consumer can tell prose-based identity apart.
+func TestOf_FallsBackToTheMessage(t *testing.T) {
+	got, _ := identity.Of(identity.Finding{Code: "ISSUE-801", Job: "build", Message: "first problem"})
+	if got.Subject.Key != "message" || got.Subject.Value != "first problem" {
+		t.Errorf("subject = %+v, want message=first problem", got.Subject)
+	}
+	if !got.SubjectFromMessage {
+		t.Errorf("SubjectFromMessage = false; want true for a rule with no structured key")
+	}
+	// The other return path out of Of: a finding that never matched a subject
+	// key must carry the version too.
+	if got.Version != identity.RecipeVersion {
+		t.Errorf("Version = %d, want %d", got.Version, identity.RecipeVersion)
+	}
+}
+
+// Volatile payload changes for reasons unrelated to the finding, so it must not
+// reach the identity at all.
+func TestOf_ExcludesVolatilePayload(t *testing.T) {
+	f := identity.Finding{
+		Code: "ISSUE-703", File: "ci.yml", Job: "build", Message: "known CVE",
+		Data: map[string]any{
+			"uses": "owner/act@v1", "advisories": "GHSA-1", "latestVersion": "2.3.0",
+			"metadata": map[string]any{"stars": 3}, "reasons": []string{"a"}, "status": "fail",
+			"line": float64(12), "url": "https://example.com/ci.yml#L12",
+		},
+	}
+	fields, _ := identity.Of(f)
+	for _, p := range fields.Pairs() {
+		switch p.Key {
+		case "advisories", "latestVersion", "metadata", "reasons", "status", "line", "url":
+			t.Errorf("volatile key %q entered the identity: %+v", p.Key, fields.Pairs())
+		}
+	}
+}
+
+// A subject key holding something other than a string is skipped rather than
+// coerced, and the finding degrades to prose identity. A JSON round trip turns
+// a numeric `tag: 7` into a float64, so this is reachable from real payload.
+// Both sides of the recipe read the value the same way, so nothing diverges,
+// and SubjectFromMessage makes the degradation visible; it is pinned here
+// because the alternative (coercing) would re-key every finding it applies to
+// and is therefore a versioned decision, not a free fix.
+func TestOf_SkipsANonStringSubjectValue(t *testing.T) {
+	f := identity.Finding{
+		Code: "ISSUE-103", Job: "scan", Message: "image uses a mutable tag",
+		Data: map[string]any{"tag": float64(7)},
+	}
+
+	got, _ := identity.Of(f)
+
+	if got.Subject.Key != "message" || !got.SubjectFromMessage {
+		t.Errorf("subject = %+v (fromMessage=%v), want the message fallback", got.Subject, got.SubjectFromMessage)
+	}
+}
+
+// A coded finding with neither a subject key nor a message still has an
+// identity: code, file and job. Not an error case, just the narrowest one, so
+// every finding of that control in one job shares a fingerprint.
+func TestOf_CodeFileJobAloneIsAnIdentity(t *testing.T) {
+	got, ok := identity.Of(identity.Finding{Code: "ISSUE-701", File: "", Job: "build"})
+	if !ok {
+		t.Fatalf("no identity for a coded finding")
+	}
+	if got.Subject.Key != "message" || got.Subject.Value != "" {
+		t.Errorf("subject = %+v, want an empty message subject", got.Subject)
+	}
+	if identity.Fingerprint(identity.Finding{Code: "ISSUE-701", Job: "build"}) == "" {
+		t.Errorf("no fingerprint for a finding identified by code/file/job alone")
+	}
+}
+
+// Codeless findings have nothing stable to report against, so they have no
+// identity at all.
+func TestOf_CodelessFindingHasNoIdentity(t *testing.T) {
+	if _, ok := identity.Of(identity.Finding{Message: "x"}); ok {
+		t.Errorf("Of reported an identity for a codeless finding")
+	}
+}
+
+// The platform reads findings back from serialized JSON, where every input the
+// recipe needs is flattened at the top level.
+func TestFromMap_ReadsASerializedFinding(t *testing.T) {
+	m := map[string]any{
+		"code": "ISSUE-701", "file": "ci.yml", "job": "build", "line": float64(12),
+		"message": "prose", "uses": "owner/act@v1", "step": "Check out",
+	}
+	got, ok := identity.Of(identity.FromMap(m))
+	if !ok {
+		t.Fatalf("no identity for a serialized coded finding")
+	}
+	if got.Code != "ISSUE-701" || got.File != "ci.yml" || got.Job != "build" {
+		t.Errorf("canonical fields not read from the map: %+v", got)
+	}
+	if got.Subject.Key != "uses" || got.Subject.Value != "owner/act@v1" {
+		t.Errorf("subject = %+v, want uses=owner/act@v1", got.Subject)
+	}
+	if got.Step != "Check out" {
+		t.Errorf("step = %q, want %q", got.Step, "Check out")
+	}
+	if got.Version != identity.RecipeVersion {
+		t.Errorf("Version = %d, want %d", got.Version, identity.RecipeVersion)
+	}
+	// The line rides along in the serialized object and must stay out of the
+	// identity: it moves whenever unrelated code above the finding is edited.
+	for _, p := range got.Pairs() {
+		if p.Key == "line" {
+			t.Errorf("line entered the identity: %+v", got.Pairs())
+		}
+	}
+}
+
+// The fingerprint is derived from the same selection, so the two can never
+// disagree about what identifies a finding.
+func TestFingerprint_IsDerivedFromTheSelection(t *testing.T) {
+	f := identity.Finding{
+		Code: "ISSUE-701", File: "ci.yml", Job: "build",
+		Message: "prose that is about to be reworded",
+		Data:    map[string]any{"uses": "owner/act@v1"},
+	}
+	reworded := f
+	reworded.Message = "reworded in a later release"
+	if identity.Fingerprint(f) != identity.Fingerprint(reworded) {
+		t.Errorf("fingerprint moved on a message rewording while the selection did not")
+	}
+	if identity.Fingerprint(identity.Finding{Message: "x"}) != "" {
+		t.Errorf("codeless finding got a fingerprint; want empty")
+	}
+}
+
+// Golden values from the recipe as shipped. Moving the package must not move a
+// single fingerprint in the wild: a change here re-keys every finding that used
+// it, which downstream reads as one issue disappearing and another appearing.
+func TestFingerprint_MatchesTheShippedValues(t *testing.T) {
+	cases := []struct {
+		name string
+		in   identity.Finding
+		want string
+	}{
+		{
+			name: "structured subject",
+			in: identity.Finding{
+				Code: "ISSUE-701", File: "ci.yml", Job: "build",
+				Data: map[string]any{"uses": "owner/act@v1"},
+			},
+			want: "16dd795c6db9b1a5",
+		},
+		{
+			name: "structured subject with a resolved step",
+			in: identity.Finding{
+				Code: "ISSUE-713", File: ".github/workflows/ci.yml", Job: "coverage",
+				Data: map[string]any{"uses": "owner/act@v1", "step": "Post PR comment"},
+			},
+			want: "b59e02be3cb9dc5f",
+		},
+		{
+			name: "message fallback",
+			in: identity.Finding{
+				Code: "ISSUE-801", File: "ci.yml", Job: "build",
+				Message: "no structured subject here",
+			},
+			want: "e9c1e3ed67a9960b",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := identity.Fingerprint(tc.in); got != tc.want {
+				t.Errorf("Fingerprint = %q, want %q (the recipe changed: bump identity.RecipeVersion deliberately)", got, tc.want)
+			}
+		})
+	}
+}
+
+// The subject-key priority list is part of the published recipe: the platform
+// reads it to know which key it is looking at.
+func TestSubjectKeys_ArePublishedInPriorityOrder(t *testing.T) {
+	keys := identity.SubjectKeys()
+	if len(keys) == 0 {
+		t.Fatalf("SubjectKeys is empty")
+	}
+	if keys[0] != "uses" {
+		t.Errorf("SubjectKeys()[0] = %q, want uses", keys[0])
+	}
+	if slices.Contains(keys, "message") {
+		t.Errorf("message is the fallback, not a subject key: %v", keys)
+	}
+	// The caller gets a copy: a consumer that sorts the slice must not silently
+	// re-key every finding the process computes afterwards.
+	keys[0] = "mutated"
+	if identity.SubjectKeys()[0] != "uses" {
+		t.Errorf("SubjectKeys returned the package's own slice; a caller can mutate the recipe")
+	}
+}
+
+// Every control that names what it is about must have its key in the list, or
+// its findings ride on reformulable prose.
+func TestSubjectKeys_CoverTheStructuredControls(t *testing.T) {
+	keys := identity.SubjectKeys()
+	for _, want := range []string{
+		"uses", "branchName", "includePath", "templatePath", "componentPath",
+		"requiredAction", "hardcodedJob",
+	} {
+		if !slices.Contains(keys, want) {
+			t.Errorf("subject key %q missing from the recipe: %v", want, keys)
+		}
+	}
+}
+
+// componentName is payload, not identity. ISSUE-402 and ISSUE-403 emit it as an
+// empty string for any include that is not a component, and it holds a bare
+// name where includePath holds the full source. Two components named "deploy"
+// in different groups would collide on the bare name.
+func TestSubjectKeys_ExcludesComponentName(t *testing.T) {
+	if slices.Contains(identity.SubjectKeys(), "componentName") {
+		t.Errorf("componentName is payload, not a subject key: %v", identity.SubjectKeys())
+	}
+}
+
+// A finding carrying both keys must identify on the full source.
+func TestOf_IncludePathOutranksComponentName(t *testing.T) {
+	f := identity.Finding{
+		Code: "ISSUE-403", File: ".gitlab-ci.yml",
+		Data: map[string]any{
+			"componentName": "deploy",
+			"includePath":   "gitlab.example.com/components/deploy/deploy",
+		},
+	}
+
+	got, _ := identity.Of(f)
+
+	if got.Subject.Key != "includePath" {
+		t.Errorf("subject = %+v, want the includePath key", got.Subject)
+	}
+}
+
+// A version consumers can store next to a grouped finding, so a later change to
+// the selection is detectable and migratable instead of silent.
+func TestRecipeVersion_IsExported(t *testing.T) {
+	if identity.RecipeVersion < 1 {
+		t.Errorf("RecipeVersion = %d, want a positive version", identity.RecipeVersion)
+	}
+}

--- a/internal/engine/opa/engine.go
+++ b/internal/engine/opa/engine.go
@@ -11,8 +11,6 @@ import (
 	"bytes"
 	"cmp"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -22,6 +20,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/rego"
 
+	"github.com/getplumber/plumber/finding/identity"
 	"github.com/getplumber/plumber/internal/ir"
 )
 
@@ -92,58 +91,36 @@ func (f Finding) MarshalJSON() ([]byte, error) {
 	return json.Marshal(out)
 }
 
-// computeFingerprint derives a stable, line-independent identifier from a
-// finding's identity: its code, file, context (job), and message. The message
-// carries the concrete subject the rule flagged (the action ref, image,
-// variable, ...), so the fingerprint distinguishes different findings of the
-// same code in the same file/job. Line and URL are deliberately excluded
-// because they move when unrelated code above the finding is edited, so the
-// fingerprint survives that drift and lets a consumer follow the same finding
-// across runs. Codeless findings get no fingerprint.
-// fingerprintSubjectKeys lists the structured payload keys that say what a
-// finding is ABOUT, in priority order; the first one present wins. Preferring
-// these over the prose message is what makes the fingerprint survive a message
-// rewording: the subject (an action ref, a branch, an image, a variable, a
-// script line) is the thing the rule actually flagged.
+// Identity returns the finding's identity field set: the fields the shared
+// recipe selects as identifying this one finding instance across runs, as data.
+// ok is false for a codeless finding, which has no identity.
 //
-// Volatile payload is deliberately excluded, because it changes for reasons
-// unrelated to the finding and would make it look new: advisories grows as CVEs
-// are published, latestVersion moves whenever upstream releases, metadata is
-// refetched every run, and reasons/status track current settings rather than
-// identity.
-var fingerprintSubjectKeys = []string{
-	"uses", "branchName", "componentName", "image", "serviceImage",
-	"link", "tag", "variableName", "scriptLine", "detail",
+// The selection lives in finding/identity because Plumber is not its only
+// consumer: a platform grouping findings into long-lived issues needs the same
+// answer, and a second list maintained alongside this one would drift.
+func (f Finding) Identity() (identity.Fields, bool) {
+	return identity.Of(f.identityInput())
 }
 
-// fingerprintSubject returns the finding's structured subject, falling back to
-// the message for rules that emit none. The key name is included so two
-// different keys holding the same value cannot collide.
-func fingerprintSubject(f Finding) string {
-	for _, k := range fingerprintSubjectKeys {
-		if v, ok := f.Data[k].(string); ok && v != "" {
-			return k + "=" + v
-		}
+// identityInput projects a finding onto the view the recipe reads. Line and URL
+// are not passed on: they move whenever unrelated code above the finding is
+// edited, and the whole point of the fingerprint is to survive that drift.
+func (f Finding) identityInput() identity.Finding {
+	return identity.Finding{
+		Code:    f.Code,
+		File:    f.File,
+		Job:     f.Job,
+		Message: f.Message,
+		Data:    f.Data,
 	}
-	return f.Message
 }
 
+// computeFingerprint hashes the identity field set above into the short, stable
+// identifier every output format carries. It is the same selection, so the
+// fingerprint and the platform's grouping key can never disagree about which
+// findings are the same finding. Codeless findings get no fingerprint.
 func computeFingerprint(f Finding) string {
-	if f.Code == "" {
-		return ""
-	}
-	id := f.Code + "\n" + f.File + "\n" + f.Job + "\n" + fingerprintSubject(f)
-	// A step name, when the workflow provides one, is appended as the final
-	// discriminator: two steps in the same job that reference the same action
-	// produce an identical code/file/job/message and would otherwise collide
-	// (observed on grafana/grafana, where one action appears twice in a job).
-	// Appended only when known, so findings without a step keep their
-	// identifier unchanged.
-	if step, ok := f.Data["step"].(string); ok && step != "" {
-		id += "\n" + step
-	}
-	sum := sha256.Sum256([]byte(id))
-	return hex.EncodeToString(sum[:])[:16]
+	return identity.Fingerprint(f.identityInput())
 }
 
 // StampFingerprints sets Fingerprint on every finding in place. Call it once,

--- a/internal/engine/opa/fingerprint_test.go
+++ b/internal/engine/opa/fingerprint_test.go
@@ -1,6 +1,61 @@
 package opa
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/getplumber/plumber/finding/identity"
+)
+
+// A consumer outside this module reads findings from Plumber's serialized
+// output, not from the Go type, and must arrive at the same identity. That only
+// holds if every input the recipe reads is flattened into the JSON object, so
+// the round trip is pinned here rather than assumed.
+func TestFingerprint_SurvivesTheJSONRoundTrip(t *testing.T) {
+	findings := []Finding{{
+		Code: "ISSUE-701", File: ".github/workflows/ci.yml", Job: "build",
+		Message: "prose", Line: 12, URL: "https://example.com/ci.yml#L12",
+		Data: map[string]any{"uses": "owner/act@v1", "step": "Check out", "advisories": "GHSA-1"},
+	}, {
+		Code: "ISSUE-803", File: "ci.yml", Job: "build", Message: "no structured subject here",
+	}, {
+		Code: "ISSUE-405", File: ".gitlab-ci.yml", Job: "templates/go/go",
+		Message: "required template is missing",
+		Data:    map[string]any{"templatePath": "templates/go/go"},
+	}}
+	StampFingerprints(findings)
+	for _, f := range findings {
+		b, err := json.Marshal(f)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", f.Code, err)
+		}
+		var serialized map[string]any
+		if err := json.Unmarshal(b, &serialized); err != nil {
+			t.Fatalf("unmarshal %s: %v", f.Code, err)
+		}
+		if got := identity.Fingerprint(identity.FromMap(serialized)); got != f.Fingerprint {
+			t.Errorf("%s: fingerprint from serialized finding = %q, stamped = %q", f.Code, got, f.Fingerprint)
+		}
+	}
+}
+
+// The engine must not keep a second copy of the selection: it computes the
+// fingerprint through the public recipe, so a key added there is honoured here
+// without an edit. A finding using a subject key the engine never knew about is
+// the check that the two are one implementation and not two lists.
+func TestFingerprint_ComesFromTheSharedRecipe(t *testing.T) {
+	f := Finding{
+		Code: "ISSUE-405", File: ".gitlab-ci.yml", Job: "templates/go/go",
+		Message: `required template "templates/go/go" is missing from the pipeline (group 0)`,
+		Data:    map[string]any{"templatePath": "templates/go/go"},
+	}
+	want := identity.Fingerprint(identity.Finding{
+		Code: f.Code, File: f.File, Job: f.Job, Message: f.Message, Data: f.Data,
+	})
+	if got := computeFingerprint(f); got != want {
+		t.Errorf("computeFingerprint = %q, identity.Fingerprint = %q; the engine is using its own selection", got, want)
+	}
+}
 
 // The fingerprint must survive line drift: the same finding whose line moved
 // (because unrelated code above it was edited) keeps the same identifier, so a

--- a/policies/branch_non_compliant.rego
+++ b/policies/branch_non_compliant.rego
@@ -36,10 +36,11 @@ deny contains finding if {
 	reasons := [r | r := _non_compliant_reasons[branch.name][_]]
 	count(reasons) > 0
 	finding := {
-		"code":                          "ISSUE-505",
-		"severity":                      "high",
-		"message":                       sprintf("Branch '%s' has non-compliant protection settings", [branch.name]),
-		"job":                           branch.name,
+		"code":     "ISSUE-505",
+		"severity": "high",
+		"message":  sprintf("Branch '%s' has non-compliant protection settings", [branch.name]),
+		# No "job": a branch is not a job. branchName names what this finding is
+		# about and is what the identity recipe selects (finding/identity).
 		"type":                          "non_compliant",
 		"branchName":                    branch.name,
 		"reasons":                       reasons,

--- a/policies/branch_unprotected.rego
+++ b/policies/branch_unprotected.rego
@@ -13,10 +13,11 @@ deny contains finding if {
 	branch.protected == false
 	_branch_must_be_protected(branch.name)
 	finding := {
-		"code":       "ISSUE-501",
-		"severity":   "critical",
-		"message":    sprintf("branch %q must be protected", [branch.name]),
-		"job":        branch.name,
+		"code":     "ISSUE-501",
+		"severity": "critical",
+		"message":  sprintf("branch %q must be protected", [branch.name]),
+		# No "job": a branch is not a job. branchName names what this finding is
+		# about and is what the identity recipe selects (finding/identity).
 		"type":       "unprotected",
 		"branchName": branch.name,
 	}

--- a/policies/component_missing.rego
+++ b/policies/component_missing.rego
@@ -22,7 +22,11 @@ deny contains finding if {
 		"code":     "ISSUE-408",
 		"severity": "high",
 		"message":  sprintf("required component %q is missing from the pipeline (group %d)", [required, i]),
-		"job":      required,
+		# No "job": a missing component is not a job. componentPath names what
+		# this finding is about and is what the identity recipe selects
+		# (finding/identity). The group index stays out: it moves whenever the
+		# user reorders requiredGroups, which is not a new finding.
+		"componentPath": required,
 	}
 }
 

--- a/policies/component_overridden.rego
+++ b/policies/component_overridden.rego
@@ -24,7 +24,10 @@ deny contains finding if {
 		"code":     "ISSUE-409",
 		"severity": "high",
 		"message":  sprintf("required component %q is imported but %d of its job(s) are overridden locally", [required, count(inc.overriddenJobs)]),
-		"job":      required,
+		# No "job": an overridden component is not a job. componentPath names
+		# what this finding is about, so its identity does not depend on the
+		# message above, whose override count moves as jobs are added.
+		"componentPath": required,
 	}
 }
 

--- a/policies/hardcoded_jobs.rego
+++ b/policies/hardcoded_jobs.rego
@@ -16,5 +16,10 @@ deny contains finding if {
 		"severity": "medium",
 		"message":  sprintf("job %q is hardcoded (not sourced from include/component/template)", [job.name]),
 		"job":      job.name,
+		# hardcodedJob names what this finding is about, so its identity is the
+		# job rather than the wording of the message above (finding/identity).
+		# Not "jobName": that was a v0.2.x output alias for `job`, retired on
+		# purpose, and reviving the key would confuse JSON consumers.
+		"hardcodedJob": job.name,
 	}
 }

--- a/policies/includes_forbidden_version.rego
+++ b/policies/includes_forbidden_version.rego
@@ -24,7 +24,11 @@ deny contains finding if {
 		"code":     "ISSUE-404",
 		"severity": "medium",
 		"message":  sprintf("%s uses forbidden version '%s'", [inc.source, inc.ref]),
-		"job":      inc.source,
+		# No "job": an include is not a job. includePath names what this finding
+		# is about and is what the identity recipe selects (finding/identity).
+		# The ref stays out: the same include drifting from one forbidden
+		# version to another is the same unresolved problem.
+		"includePath": inc.source,
 	}
 }
 

--- a/policies/includes_outdated.rego
+++ b/policies/includes_outdated.rego
@@ -21,7 +21,10 @@ deny contains finding if {
 		"code":                  "ISSUE-403",
 		"severity":              "medium",
 		"message":               sprintf("%s uses version '%s' (latest: %s)", [inc.source, inc.ref, inc.current]),
-		"job":                   inc.source,
+		# No "job": an include is not a job. includePath names what this finding
+		# is about (finding/identity). componentName stays as payload: it is a
+		# bare name, empty for any include that is not a component.
+		"includePath":           inc.source,
 		"file":                  object.get(inc, "originFile", ""),
 		"line":                  object.get(inc, "originLine", 0),
 		"version":               inc.ref,

--- a/policies/ref_confusion.rego
+++ b/policies/ref_confusion.rego
@@ -42,7 +42,9 @@ deny contains finding if {
 		"code":                  "ISSUE-402",
 		"severity":              "medium",
 		"message":               sprintf("%s pins ref '%s' — it resolves as both a tag AND a branch in the source project, so which revision runs is ambiguous; pin to a commit SHA to disambiguate", [inc.source, inc.ref]),
-		"job":                   inc.source,
+		# No "job": an include is not a job. includePath names what this finding
+		# is about (finding/identity). componentName stays as payload.
+		"includePath":           inc.source,
 		"file":                  object.get(inc, "originFile", ""),
 		"line":                  object.get(inc, "originLine", 0),
 		"version":               inc.ref,

--- a/policies/required_actions.rego
+++ b/policies/required_actions.rego
@@ -50,9 +50,13 @@ deny contains finding if {
 		"code":     "ISSUE-417",
 		"severity": "high",
 		"message":  sprintf("required action or reusable workflow %q is not referenced by any workflow (group %d)", [required, i]),
-		"job":      required,
-		"required": required,
-		"groupIndex": i,
+		# No "job": a missing required action is not a job. requiredAction names
+		# what this finding is about and is what the identity recipe selects
+		# (finding/identity). groupIndex stays as payload: it moves whenever the
+		# user reorders requiredGroups, which is not a new finding.
+		"requiredAction": required,
+		"required":       required,
+		"groupIndex":     i,
 	}
 }
 

--- a/policies/rules_test.go
+++ b/policies/rules_test.go
@@ -6,12 +6,14 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/getplumber/plumber/finding/identity"
 	githubpkg "github.com/getplumber/plumber/github"
 	opaengine "github.com/getplumber/plumber/internal/engine/opa"
 	"github.com/getplumber/plumber/internal/ir"
@@ -1178,20 +1180,21 @@ func TestIssue505_BranchNonCompliant(t *testing.T) {
 		t.Fatalf("evaluate: %v", err)
 	}
 	hits := map[string]bool{}
-	issue505ByJob := map[string]opaengine.Finding{}
+	issue505ByBranch := map[string]opaengine.Finding{}
 	for _, f := range findings {
 		if f.Code == "ISSUE-505" {
-			if issue505ByJob[f.Job].Code != "" {
-				t.Fatalf("expected at most one ISSUE-505 per branch, got duplicate for %q", f.Job)
+			branch, _ := f.Data["branchName"].(string)
+			if issue505ByBranch[branch].Code != "" {
+				t.Fatalf("expected at most one ISSUE-505 per branch, got duplicate for %q", branch)
 			}
-			issue505ByJob[f.Job] = f
-			hits[f.Job] = true
+			issue505ByBranch[branch] = f
+			hits[branch] = true
 		}
 	}
 	if !hits["main"] || !hits["low-push"] {
 		t.Fatalf("expected main and low-push flagged, got %v", hits)
 	}
-	mainF := issue505ByJob["main"]
+	mainF := issue505ByBranch["main"]
 	if !strings.Contains(mainF.Message, "main") || !strings.Contains(mainF.Message, "non-compliant") {
 		t.Fatalf("unexpected ISSUE-505 message for main: %q", mainF.Message)
 	}
@@ -1202,6 +1205,8 @@ func TestIssue505_BranchNonCompliant(t *testing.T) {
 	if hits["compliant"] || hits["unprotected"] {
 		t.Fatalf("unexpected flag on compliant/unprotected: %v", hits)
 	}
+	assertSubjectKey(t, findings, "ISSUE-505", "branchName", []string{"main", "low-push"})
+	assertNoJob(t, findings, "ISSUE-505")
 }
 
 // TestIssue505_AccessLevelStrictestPolicy: GitLab access level 0 = "No one".
@@ -1346,8 +1351,8 @@ func TestIssue505_DetailUnknownAbstainsButIssue501StillFires(t *testing.T) {
 	for _, f := range findings {
 		switch f.Code {
 		case "ISSUE-501":
-			if f.Job != "feature" {
-				t.Fatalf("ISSUE-501 should target the unprotected branch, got %q", f.Job)
+			if name, _ := f.Data["branchName"].(string); name != "feature" {
+				t.Fatalf("ISSUE-501 should target the unprotected branch, got %q", name)
 			}
 			saw501++
 		case "ISSUE-505":
@@ -1360,6 +1365,8 @@ func TestIssue505_DetailUnknownAbstainsButIssue501StillFires(t *testing.T) {
 	if saw505 != 0 {
 		t.Errorf("expected 0 ISSUE-505 when ProtectionDetailsKnown=false, got %d", saw505)
 	}
+	assertSubjectKey(t, findings, "ISSUE-501", "branchName", []string{"feature"})
+	assertNoJob(t, findings, "ISSUE-501")
 }
 
 // TestIssue505_NotInPolicyScope ensures ISSUE-501 scope matches ISSUE-505:
@@ -1431,6 +1438,11 @@ func TestIssue404_IncludesForbiddenVersion(t *testing.T) {
 	if hits != 2 {
 		t.Fatalf("expected 2 ISSUE-404 findings, got %d", hits)
 	}
+	// The include path is what the finding is about. Without it the finding's
+	// identity falls back to the prose message, and a copy-edit to that message
+	// re-keys every ISSUE-404 in the wild.
+	assertSubjectKey(t, findings, "ISSUE-404", "includePath", []string{"plumber/a", "plumber/b"})
+	assertNoJob(t, findings, "ISSUE-404")
 }
 
 // TestIssue204_UnsafeVariableExpansion flags scripts re-parsing
@@ -1476,6 +1488,71 @@ func TestIssue401_HardcodedJobs(t *testing.T) {
 	}
 	if len(hits) != 1 || hits[0] != "build" {
 		t.Fatalf("expected only [build], got %v", hits)
+	}
+	assertSubjectKey(t, findings, "ISSUE-401", "hardcodedJob", []string{"build"})
+}
+
+// assertSubjectKey pins the structured key a control emits to say what its
+// finding is about. That key is what the finding-identity recipe selects
+// (finding/identity.SubjectKeys); a control emitting none of them falls back to
+// its prose message, so rewording the rule re-keys every finding it ever
+// emitted. Pinning the key here is what keeps that from happening silently.
+//
+// This is also the tripwire the recipe's own tests cannot be: they run on fixed
+// identity.Finding values, so they guard the algorithm and stay green when a
+// control changes what it emits, even though that moves real fingerprints just
+// as much. If one of these assertions fails because a rule's payload changed on
+// purpose, bump identity.RecipeVersion in the same change.
+func assertSubjectKey(t *testing.T, findings []opaengine.Finding, code, key string, wantValues []string) {
+	t.Helper()
+	if !slices.Contains(identity.SubjectKeys(), key) {
+		t.Fatalf("%s: key %q is not part of the identity recipe: %v", code, key, identity.SubjectKeys())
+	}
+	got := []string{}
+	for _, f := range findings {
+		if f.Code != code {
+			continue
+		}
+		fields, ok := f.Identity()
+		if !ok {
+			t.Fatalf("%s: finding has no identity: %+v", code, f)
+		}
+		if fields.Subject.Key != key {
+			t.Errorf("%s: identity subject is %q=%q, want the structured key %q", code, fields.Subject.Key, fields.Subject.Value, key)
+			continue
+		}
+		got = append(got, fields.Subject.Value)
+	}
+	slices.Sort(got)
+	want := slices.Clone(wantValues)
+	slices.Sort(want)
+	if !slices.Equal(got, want) {
+		t.Errorf("%s: %s values = %v, want %v", code, key, got, want)
+	}
+}
+
+// assertNoJob pins that a control leaves Finding.Job empty. The field is a CI
+// job name and a hashed identity input; a control that puts a branch, an
+// include source or a required path there both mislabels its output and makes
+// identity depend on the mislabelling.
+//
+// It also requires that the code produced at least one finding: a pin that
+// silently passes because the control emitted zero findings is not a
+// regression guard, it is a no-op.
+func assertNoJob(t *testing.T, findings []opaengine.Finding, code string) {
+	t.Helper()
+	count := 0
+	for _, f := range findings {
+		if f.Code != code {
+			continue
+		}
+		count++
+		if f.Job != "" {
+			t.Errorf("%s: job = %q, want empty: this finding is not about a job", code, f.Job)
+		}
+	}
+	if count == 0 {
+		t.Fatalf("%s: no findings with this code, assertNoJob passes vacuously", code)
 	}
 }
 
@@ -1732,12 +1809,14 @@ func TestIssue404_WildcardForbiddenVersion(t *testing.T) {
 	hits := []string{}
 	for _, f := range findings {
 		if f.Code == "ISSUE-404" {
-			hits = append(hits, f.Job)
+			path, _ := f.Data["includePath"].(string)
+			hits = append(hits, path)
 		}
 	}
 	if len(hits) != 1 || hits[0] != "plumber/a" {
 		t.Fatalf("expected only [plumber/a] flagged via wildcard, got %v", hits)
 	}
+	assertNoJob(t, findings, "ISSUE-404")
 }
 
 // TestIssue204_SourceAndDotSourcing covers the two patterns that were
@@ -2214,7 +2293,8 @@ func TestIssue408_ComponentMissing(t *testing.T) {
 	hits := map[string]bool{}
 	for _, f := range findings {
 		if f.Code == "ISSUE-408" {
-			hits[f.Job] = true
+			name, _ := f.Data["componentPath"].(string)
+			hits[name] = true
 		}
 	}
 	if !hits["components/secret-detection/secret-detection"] {
@@ -2226,6 +2306,9 @@ func TestIssue408_ComponentMissing(t *testing.T) {
 	if hits["components/sast/sast"] {
 		t.Fatalf("unexpected flag on present component: %v", hits)
 	}
+	assertSubjectKey(t, findings, "ISSUE-408", "componentPath",
+		[]string{"components/secret-detection/secret-detection", "your-org/full-security/full-security"})
+	assertNoJob(t, findings, "ISSUE-408")
 }
 
 // TestIssue409_ComponentOverridden flags required components whose
@@ -2268,6 +2351,8 @@ func TestIssue409_ComponentOverridden(t *testing.T) {
 	if hits != 1 {
 		t.Fatalf("expected 1 ISSUE-409 finding, got %d", hits)
 	}
+	assertSubjectKey(t, findings, "ISSUE-409", "componentPath", []string{"components/sast/sast"})
+	assertNoJob(t, findings, "ISSUE-409")
 }
 
 // TestIssue405_TemplateMissing flags DNF groups whose required
@@ -2301,7 +2386,8 @@ func TestIssue405_TemplateMissing(t *testing.T) {
 	hits := map[string]bool{}
 	for _, f := range findings {
 		if f.Code == "ISSUE-405" {
-			hits[f.Job] = true
+			path, _ := f.Data["templatePath"].(string)
+			hits[path] = true
 		}
 	}
 	if !hits["templates/trivy/trivy"] {
@@ -2310,6 +2396,8 @@ func TestIssue405_TemplateMissing(t *testing.T) {
 	if hits["templates/go/go"] {
 		t.Fatalf("unexpected flag on present template: %v", hits)
 	}
+	assertSubjectKey(t, findings, "ISSUE-405", "templatePath", []string{"templates/trivy/trivy"})
+	assertNoJob(t, findings, "ISSUE-405")
 }
 
 // TestIssue406_TemplateOverridden flags required templates whose
@@ -2353,6 +2441,8 @@ func TestIssue406_TemplateOverridden(t *testing.T) {
 	if hits != 1 {
 		t.Fatalf("expected 1 ISSUE-406 finding, got %d", hits)
 	}
+	assertSubjectKey(t, findings, "ISSUE-406", "templatePath", []string{"templates/go/go"})
+	assertNoJob(t, findings, "ISSUE-406")
 }
 
 // parseGitHubStepsUses extracts `steps[].uses` entries from a workflow
@@ -4767,7 +4857,8 @@ func TestIssue416_RequiredActionMissing(t *testing.T) {
 		hits := map[string]bool{}
 		for _, f := range findings {
 			if f.Code == "ISSUE-417" {
-				hits[f.Job] = true
+				requiredAction, _ := f.Data["requiredAction"].(string)
+				hits[requiredAction] = true
 			}
 		}
 		for _, want := range []string{"myorg/sast-scan", "myorg/policy/.github/workflows/policy.yml", "myorg/full-security"} {
@@ -4775,6 +4866,12 @@ func TestIssue416_RequiredActionMissing(t *testing.T) {
 				t.Errorf("expected ISSUE-417 finding for %q; got hits=%v", want, hits)
 			}
 		}
+		assertSubjectKey(t, findings, "ISSUE-417", "requiredAction", []string{
+			"myorg/sast-scan",
+			"myorg/policy/.github/workflows/policy.yml",
+			"myorg/full-security",
+		})
+		assertNoJob(t, findings, "ISSUE-417")
 	})
 
 	t.Run("step-level uses with pinned SHA satisfies ref-agnostic match", func(t *testing.T) {
@@ -4849,7 +4946,7 @@ func TestIssue416_RequiredActionMissing(t *testing.T) {
 		}
 		matched := false
 		for _, f := range findings {
-			if f.Code == "ISSUE-417" && f.Job == "myorg/sast-scan" {
+			if f.Code == "ISSUE-417" && f.Data["requiredAction"] == "myorg/sast-scan" {
 				matched = true
 			}
 		}
@@ -5071,4 +5168,49 @@ func TestIssue323_FindingsCarryStructuredEvidence(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ISSUE-403 is about an include, not a job. Its identity used to be the include
+// source smuggled through the job field, with componentName (a bare name, empty
+// for non-component includes) as the only structured key.
+func TestIssue403_OutdatedIncludeIdentifiesOnTheIncludePath(t *testing.T) {
+	engine := opaengine.New()
+	if err := engine.LoadFromFSFiltered(policies.FS, nil); err != nil {
+		t.Fatalf("load embedded policies: %v", err)
+	}
+	pipeline := &ir.NormalizedPipeline{
+		Provider: ir.ProviderGitLab,
+		Includes: []ir.Include{
+			{Kind: "component", Source: "gitlab.example.com/components/sast/sast", Ref: "1.0.0", Current: "1.1.0"},
+		},
+	}
+	findings, err := engine.Evaluate(context.Background(), pipeline, nil)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	assertSubjectKey(t, findings, "ISSUE-403", "includePath",
+		[]string{"gitlab.example.com/components/sast/sast"})
+	assertNoJob(t, findings, "ISSUE-403")
+}
+
+// ISSUE-402's GitLab block is about an include. Its GitHub block, which flags an
+// ambiguous action ref inside a job, keeps its job name and its uses subject.
+func TestIssue402_AmbiguousIncludeIdentifiesOnTheIncludePath(t *testing.T) {
+	engine := opaengine.New()
+	if err := engine.LoadFromFSFiltered(policies.FS, nil); err != nil {
+		t.Fatalf("load embedded policies: %v", err)
+	}
+	pipeline := &ir.NormalizedPipeline{
+		Provider: ir.ProviderGitLab,
+		Includes: []ir.Include{
+			{Kind: "component", Source: "gitlab.example.com/components/sast/sast", Ref: "v1", RefIsAmbiguous: true},
+		},
+	}
+	findings, err := engine.Evaluate(context.Background(), pipeline, nil)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	assertSubjectKey(t, findings, "ISSUE-402", "includePath",
+		[]string{"gitlab.example.com/components/sast/sast"})
+	assertNoJob(t, findings, "ISSUE-402")
 }

--- a/policies/template_missing.rego
+++ b/policies/template_missing.rego
@@ -22,7 +22,11 @@ deny contains finding if {
 		"code":     "ISSUE-405",
 		"severity": "high",
 		"message":  sprintf("required template %q is missing from the pipeline (group %d)", [required, i]),
-		"job":      required,
+		# No "job": a missing template is not a job. templatePath names what
+		# this finding is about and is what the identity recipe selects
+		# (finding/identity). The group index stays out: it moves whenever the
+		# user reorders requiredGroups, which is not a new finding.
+		"templatePath": required,
 	}
 }
 

--- a/policies/template_overridden.rego
+++ b/policies/template_overridden.rego
@@ -23,7 +23,10 @@ deny contains finding if {
 		"code":     "ISSUE-406",
 		"severity": "high",
 		"message":  sprintf("required template %q is imported but %d of its job(s) are overridden locally", [required, count(inc.overriddenJobs)]),
-		"job":      required,
+		# No "job": an overridden template is not a job. templatePath names what
+		# this finding is about, so its identity does not depend on the message
+		# above, whose override count moves as jobs are added.
+		"templatePath": required,
 	}
 }
 


### PR DESCRIPTION
Closes #403

## Why

The fingerprint already answered a question the platform also needs answered: **which fields identify one finding instance across runs**. That selection lived in `internal/engine/opa`, so nothing outside this module could import it, and the platform would have had to maintain a second, parallel list that drifts and costs a change per new control.

Two things were wrong with the selection itself:

- A third of the controls had no structured key, so their identity was their **prose message**. A copy-edit to a Rego string re-keyed every finding that control ever produced.
- Ten finding blocks put something that is **not a job** into `Finding.Job` (a branch name, an include source, a required path). That field is the third hashed segment of the identity, so identity depended on a mislabelled field, and the field could not be corrected later without a second re-key.

## The public package

`finding/identity` holds the selection once, and both sides read it:

| API | Returns |
| --- | --- |
| `identity.Of(f)` | the identity **field set** as data (`Fields`, with `Pairs()` for the ordered key/value pairs) |
| `identity.Fingerprint(f)` | the short hash of exactly what `Of` selected |
| `identity.SubjectKeys()` | the subject-key priority list (a copy, so a caller cannot re-key findings by sorting it) |
| `identity.FromMap(m)` | a finding read back from serialized JSON |
| `identity.RecipeVersion` | the version of the selection |

`Fingerprint` is built on `Of`, so the CLI's hash and the platform's grouping key cannot disagree about which findings are the same finding. `internal/engine/opa` reads it through `Finding.Identity()`; `StampFingerprints` and every export path behave as before.

## RecipeVersion ships at 2

The version tracks identity **outcomes**, not just the algorithm. This change re-keys findings without touching the selection code, so a version that only moved with the algorithm would have stayed at 1 while real fingerprints moved, and a consumer holding only the hash (SARIF, OCSF, CSV) would have had no signal at all.

The recipe's golden tests run on fixed inputs and stay green through a control changing what it emits. The per-control pins in `policies/rules_test.go` are the tripwire for that case, and a failure in one is the prompt to bump.

## What moved

Eleven finding blocks changed. Nine identified on prose and now name what they are about; ten stopped putting a non-job value in `job`.

| Block | was in `job` | now identifies on |
| --- | --- | --- |
| ISSUE-401 hardcoded-jobs | a real job name, kept | `hardcodedJob` |
| ISSUE-402 (GitLab block), ISSUE-403, ISSUE-404 | include source | `includePath` |
| ISSUE-405, ISSUE-406 | required template path | `templatePath` |
| ISSUE-408, ISSUE-409 | required component path | `componentPath` |
| ISSUE-417 | required action path | `requiredAction` |
| ISSUE-501, ISSUE-505 | branch name | `branchName`, which they already had |

ISSUE-402's GitHub block is untouched: its `job` is a job. `componentName` leaves the priority list, since it is payload and empty for any include that is not a component.

ISSUE-402, ISSUE-403 and ISSUE-417 had **no** working structured subject at all before this. That is the defect #403 exists to remove; they were simply missing from the issue's list.

## The identity block in JSON

The recipe alone turned out to be unusable from outside: no shipped output carries the fields it reads. `projectFinding` strips `message`, `file` and `line` from each issue entry, so a consumer could not re-derive identity from the report (0 of 125 GitHub findings agreed with their own stamped fingerprint), and `--ocsf` keeps `message` and `file` but drops the structured payload.

Each issue entry now carries the selection itself:

```json
"identity": {
  "version": 2,
  "subjectFromMessage": false,
  "fields": [
    { "key": "code", "value": "ISSUE-701" },
    { "key": "file", "value": ".github/workflows/build_debian.yaml" },
    { "key": "job",  "value": "build_debian/build" },
    { "key": "uses", "value": "element-hq/packages.element.io@master" }
  ]
}
```

The platform stores what the CLI selected instead of recomputing it, so the two cannot drift even in principle. `subjectFromMessage` marks the findings a copy-edit would still re-key. Additive: the trimmed legacy issue shape is otherwise unchanged, and rule payload cannot forge the block.

## Deliberate identity collapses

Four inputs leave identity because each moves for reasons that are not a new finding, and all four are documented in `docs/FINGERPRINT.md`:

- the **DNF group index** (ISSUE-405/408/417), which shifts whenever a user reorders `requiredGroups`;
- the **forbidden ref** (ISSUE-404), since the same include drifting between two forbidden versions is one unresolved problem;
- the **include ref** (ISSUE-402 GitLab, ISSUE-403), same reasoning;
- the **overridden-job count** (ISSUE-406/409), which moves as jobs are added.

The consequence a consumer needs: one report can contain two entries sharing a fingerprint. Group by it, do not assume one row per value.

## Verification

- **Six real GitHub repositories, 181 findings**: not one fingerprint moved, per-code counts identical, all five export formats byte-identical apart from per-run timestamps.
- **A real GitLab instance**: only the intended controls moved, each carrying its new key, none still carrying a `job`.
- **An external Go module** importing `finding/identity` rebuilds the stamped fingerprint from the identity block alone for 44/44 GitHub and 21/21 GitLab findings.

One regression was caught this way and fixed: `enrichForbiddenVersion404IssueMaps` read the **serialized issue's** `"job"` key as an include source, so emptying the field silently dropped the whole ISSUE-404 enrichment payload. A grep of `Finding.Job` could not see it. A test now drives the OPA engine through `buildForbiddenVersionsBlock` so the producer and the consumer are joined by something other than review.

`assertNoJob` fails on zero findings, so the guard for this change cannot pass vacuously.

## One thing to flag

`finding/identity` is exempt from the `deadcode` check in the Makefile and CI: it publishes an API for consumers outside this module, so reachability from our own `main` says nothing about whether it is used. The analyzer runs on its own line and only its output is filtered, so the exemption cannot swallow a broken analyzer run and report it as clean.

## Follow-ups, deliberately not here

- `policies/action_mutable_remote_exec.rego` seeds `"job": ""` into its signals, so ISSUE-713/714/715 can emit an empty job key. Pre-existing and inert (the engine deletes the key), but it breaks the rule this PR establishes.
- `finding/identity` has no `Fields.Fingerprint()`, so a consumer holding a stored field set must rebuild a synthetic finding to re-derive the hash.
- `output-example.json` at the repo root predates fingerprints and is referenced by nothing.
