### PR TITLE
feat(ci): Add --platform feature to integrate pushing of results per …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         # Exact patch versions: floating specs (stable/oldstable) resolve
         # to a different toolchain over time without any workflow change.
-        go-version: ['1.26.5', '1.25.12']
+        go-version: ['1.26.6', '1.25.13']
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       # Build from what git actually tracks. Every other job builds the
       # working tree, which can contain generated or git-ignored files that
@@ -69,7 +69,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Run tests
         run: go test ./... -race -coverprofile=coverage.out -covermode=atomic
@@ -91,7 +91,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       # Run golangci-lint via `go install` instead of the third-party
       # golangci-lint-action wrapper — no external action is trusted, and
@@ -137,7 +137,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install and run govulncheck
         # setup-go pins GOTOOLCHAIN=local, which makes `go` ignore the

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # Build stage
-# golang:1.26-alpine — pinned to a digest shipping Go 1.26.5 (fixes stdlib
-# advisory GO-2026-4970, High). Bump this digest when go.mod's `toolchain`
-# is raised so the bundled compiler carries stdlib security fixes.
-FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS builder
+# golang:1.26-alpine — pinned to a digest shipping Go 1.26.6 (fixes stdlib
+# advisories GO-2026-5026, GO-2026-5972, GO-2026-6089, GO-2026-6090, all High).
+# Bump this digest when go.mod's `toolchain` is raised so the bundled compiler
+# carries stdlib security fixes.
+FROM golang:1.26-alpine@sha256:70b46548e42db77e0966aaf3619fd068734dc6c77584d526b91126504fd95816 AS builder
 
 # Set working directory
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -213,6 +213,13 @@ Display it with a badge in your README (swap in your platform/owner/repo):
 > name public**. Only the default branch's score is displayed. See [score
 > docs](https://getplumber.io/docs/plumber-score).
 
+## Common `analyze` flags
+
+| Flag | Purpose |
+|---|---|
+| `--score-endpoint` | Score service base URL (default `https://score.getplumber.io`). Override only for a self-hosted score service. |
+| `--platform` | Plumber platform base URL. Setting it pushes this run's full results there over CI OIDC, and takes precedence over `--score-push`. Requires an id-token grant: `permissions: id-token: write` on GitHub, the component's `id_tokens:` block on GitLab. A platform that is down or unreachable warns and never changes the run's outcome. |
+
 ## Configuration
 
 Plumber reads `.plumber.yaml`.

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,9 @@ inputs:
   score-endpoint:
     description: "Score service base URL. Override only for a self-hosted score service; the minted OIDC audience follows this value so it always matches the target."
     default: "https://score.getplumber.io"
+  platform:
+    description: "Plumber platform base URL. Setting it pushes this run's full results there over CI OIDC, and takes precedence over score-push. The calling workflow MUST grant 'permissions: id-token: write'."
+    default: ""
   fail-warnings:
     description: "Fail the run on warnings: unknown configuration keys (exit 2) and 'could not verify' checks such as a skipped known-CVE lookup when an action version cannot be resolved (exit 3). soft-fail does not mask exit 3."
     default: "false"
@@ -173,6 +176,7 @@ runs:
         IN_SCORE: ${{ inputs.score }}
         IN_SCORE_PUSH: ${{ inputs.score-push }}
         IN_SCORE_ENDPOINT: ${{ inputs.score-endpoint }}
+        IN_PLATFORM: ${{ inputs.platform }}
         IN_FAIL_WARNINGS: ${{ inputs.fail-warnings }}
         IN_OUTPUT: ${{ inputs.output }}
         IN_PBOM: ${{ inputs.pbom }}
@@ -208,6 +212,7 @@ runs:
         [ "$IN_SCORE" = "true" ]    && args+=(--score-point)
         [ "$IN_SCORE_PUSH" = "true" ] && args+=(--score-push)
         [ -n "$IN_SCORE_ENDPOINT" ] && args+=(--score-endpoint "$IN_SCORE_ENDPOINT")
+        [ -n "$IN_PLATFORM" ] && args+=(--platform "$IN_PLATFORM")
         [ "$IN_FAIL_WARNINGS" = "true" ] && args+=(--fail-warnings)
         [ -n "$IN_OUTPUT" ]         && args+=(--output "$IN_OUTPUT")
         [ -n "$IN_PBOM" ]           && args+=(--pbom "$IN_PBOM")

--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -63,6 +63,7 @@ var (
 	showScorePoint    bool
 	pushScore         bool
 	scoreEndpoint     string
+	platformURL       string
 	controlsFilter    string
 	skipControls      string
 	ciConfigPath      string
@@ -183,6 +184,7 @@ func init() {
 	analyzeCmd.Flags().BoolVar(&showScorePoint, "score-point", false, "Like --score plus full points breakdown in stdout and MR comment; overrides --score when both are set")
 	analyzeCmd.Flags().BoolVar(&pushScore, "score-push", false, "Publish this repo's Plumber Score to the hosted badge service (CI only; needs a CI OIDC id-token, so a local run is a no-op)")
 	analyzeCmd.Flags().StringVar(&scoreEndpoint, "score-endpoint", "", "Score service base URL (default https://score.getplumber.io); override only for a self-hosted score service")
+	analyzeCmd.Flags().StringVar(&platformURL, "platform", "", "Plumber platform base URL; setting it pushes this run's full results there over CI OIDC (implies the push, and takes precedence over --score-push)")
 	analyzeCmd.Flags().StringVar(&controlsFilter, "controls", "", "Run only listed controls (comma-separated)")
 	analyzeCmd.Flags().StringVar(&skipControls, "skip-controls", "", "Skip listed controls (comma-separated)")
 	analyzeCmd.Flags().BoolVar(&failWarnings, "fail-warnings", false, "Treat configuration warnings as errors (exit 2)")
@@ -515,6 +517,7 @@ var envKeys = map[string]string{
 	"score-point":    "PLUMBER_ANALYZE_SCORE_POINT",
 	"score-push":     "PLUMBER_ANALYZE_SCORE_PUSH",
 	"score-endpoint": "PLUMBER_ANALYZE_SCORE_ENDPOINT",
+	"platform":       "PLUMBER_ANALYZE_PLATFORM",
 	"controls":       "PLUMBER_ANALYZE_CONTROLS",
 	"skip-controls":  "PLUMBER_ANALYZE_SKIP_CONTROLS",
 	"fail-warnings":  "PLUMBER_ANALYZE_FAIL_WARNINGS",
@@ -632,6 +635,7 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 		func() error {
 			return envStringFallback(cmd, "score-endpoint", envKeys["score-endpoint"], &scoreEndpoint)
 		},
+		func() error { return envStringFallback(cmd, "platform", envKeys["platform"], &platformURL) },
 		func() error { return envStringFallback(cmd, "controls", envKeys["controls"], &controlsFilter) },
 		func() error { return envStringFallback(cmd, "skip-controls", envKeys["skip-controls"], &skipControls) },
 		func() error {

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -34,7 +34,7 @@ func runWithProvider(p provider.Provider, cmd *cobra.Command, conf *configuratio
 	}
 
 	newLocationLinker(conf, result, p.Name()).Annotate(result.Findings)
-	opaengine.StampFingerprints(result.Findings)
+	opaengine.StampFingerprints(result.Findings, conf.GitRepoRoot)
 
 	summary := buildComplianceSummary(p, result, conf)
 
@@ -48,7 +48,9 @@ func runWithProvider(p provider.Provider, cmd *cobra.Command, conf *configuratio
 		return err
 	}
 
-	handleScorePublishing(p, conf, result, summary)
+	jsonPayload := buildPublishPayload(p, conf, result, summary)
+	handleScorePublishing(p, conf, result, summary, jsonPayload)
+	platformErr := maybePushPlatform(p, conf, result, jsonPayload)
 
 	pas := provider.PostActionSummary{
 		Passed:     summary.passed(),
@@ -61,7 +63,7 @@ func runWithProvider(p provider.Provider, cmd *cobra.Command, conf *configuratio
 		return err
 	}
 
-	return finalizeRun(result, summary)
+	return finalizeRun(result, summary, platformErr)
 }
 
 // buildComplianceSummary assembles the gate inputs for a run: the Plumber
@@ -234,7 +236,7 @@ func writeOutputsWithProvider(p provider.Provider, result *control.AnalysisResul
 // pipeline.
 func presentResultWithProvider(p provider.Provider, cmd *cobra.Command, result *control.AnalysisResult, conf *configuration.Configuration) error {
 	newLocationLinker(conf, result, p.Name()).Annotate(result.Findings)
-	opaengine.StampFingerprints(result.Findings)
+	opaengine.StampFingerprints(result.Findings, conf.GitRepoRoot)
 	summary := buildComplianceSummary(p, result, conf)
 	if printOutput {
 		if err := outputTextWithProvider(p, result, conf, summary, conf.ControlsFilter, conf.SkipControlsFilter); err != nil {
@@ -244,7 +246,9 @@ func presentResultWithProvider(p provider.Provider, cmd *cobra.Command, result *
 	if err := writeOutputsWithProvider(p, result, conf, summary); err != nil {
 		return err
 	}
-	handleScorePublishing(p, conf, result, summary)
+	jsonPayload := buildPublishPayload(p, conf, result, summary)
+	handleScorePublishing(p, conf, result, summary, jsonPayload)
+	platformErr := maybePushPlatform(p, conf, result, jsonPayload)
 	pas := provider.PostActionSummary{
 		Passed:     summary.passed(),
 		GateLine:   summary.gateLine(),
@@ -257,7 +261,7 @@ func presentResultWithProvider(p provider.Provider, cmd *cobra.Command, result *
 			return err
 		}
 	}
-	return finalizeRun(result, summary)
+	return finalizeRun(result, summary, platformErr)
 }
 
 func joinStrings(ss []string) string {
@@ -309,16 +313,49 @@ func computeScoreResult(result *control.AnalysisResult, scoreMode bool) *control
 	return &s
 }
 
+// buildPublishPayload builds the analysis JSON payload shared by the score
+// badge and the platform push, so the two destinations can never diverge on
+// what "the report" contains — both send the exact bytes buildAnalysisJSONReport
+// produced. Built once here (rather than separately inside each consumer) and
+// skipped (nil) when neither push is configured, so a plain local run pays no
+// marshal/hash cost for a payload nobody sends.
+func buildPublishPayload(p provider.Provider, conf *configuration.Configuration, result *control.AnalysisResult, summary complianceSummary) []byte {
+	scorePush, _ := effectiveScorePush()
+	platformPush, _ := effectivePlatformPush()
+	if !scorePush && !platformPush {
+		return nil
+	}
+	var pc *configuration.PlumberConfig
+	var includeOnly, skip []string
+	if conf != nil {
+		pc = conf.PlumberConfig
+		includeOnly, skip = conf.ControlsFilter, conf.SkipControlsFilter
+	}
+	payload, err := buildAnalysisJSONReport(result, pc, summary, jsonOutputParams{
+		provider: p.Name(), includeOnly: includeOnly, skip: skip,
+	})
+	if err != nil {
+		scoreWarn(fmt.Sprintf("could not build the publish payload: %v", err))
+		return nil
+	}
+	return payload
+}
+
 // finalizeRun applies the exit-code gates in priority order: a degraded run
 // (incomplete data) fails at exit 3 regardless of the gate (#220); then
-// --fail-warnings fails at exit 3 when "could not verify" warnings exist;
-// otherwise the score gate (or the deprecated --threshold gate) governs.
-func finalizeRun(result *control.AnalysisResult, s complianceSummary) error {
+// --fail-warnings fails at exit 3 when "could not verify" warnings exist; then
+// the score gate (or the deprecated --threshold gate). A platform token failure
+// is evaluated LAST so a broken id-token grant can never mask a security
+// finding the scan just made.
+func finalizeRun(result *control.AnalysisResult, s complianceSummary, platformErr error) error {
 	if result.DataCollectionDegraded {
 		return &IncompleteDataError{Reasons: result.DegradedReasons}
 	}
 	if failWarnings && len(result.Warnings) > 0 {
 		return &DegradedError{Count: len(result.Warnings)}
 	}
-	return s.gateErr()
+	if err := s.gateErr(); err != nil {
+		return err
+	}
+	return platformErr
 }

--- a/cmd/gate_test.go
+++ b/cmd/gate_test.go
@@ -500,3 +500,61 @@ func TestBuildAnalysisJSONReport_GateContract(t *testing.T) {
 		assertAbsent(t, m, "minPoints", "minScore", "compliance")
 	})
 }
+
+// ---------------------------------------------------------------------------
+// finalizeRun — exit-code gate priority order
+// ---------------------------------------------------------------------------
+
+// TestFinalizeRun_OrderingPriority pins the priority order the platform push
+// depends on: a degraded run fails regardless of anything else (#220); then
+// --fail-warnings; then the score gate; and the platform token error is
+// evaluated LAST, so a broken id-token grant can never mask (by pre-empting)
+// a real degraded/warnings/gate failure the scan already found.
+func TestFinalizeRun_OrderingPriority(t *testing.T) {
+	platformErr := &PlatformTokenError{Reason: "no CI OIDC id-token available"}
+	passingGate := complianceSummary{minPoints: 100, score: scoreWithPoints(100), controlCount: 1}
+	failingGate := complianceSummary{minPoints: 100, score: scoreWithPoints(0), controlCount: 1}
+
+	t.Run("degraded wins over everything, including a platform error", func(t *testing.T) {
+		result := &control.AnalysisResult{DataCollectionDegraded: true, DegradedReasons: []string{"x"}}
+		err := finalizeRun(result, passingGate, platformErr)
+		var want *IncompleteDataError
+		if !errors.As(err, &want) {
+			t.Fatalf("finalizeRun = %v (%T), want *IncompleteDataError", err, err)
+		}
+	})
+
+	t.Run("--fail-warnings wins over the gate and a platform error", func(t *testing.T) {
+		defer func(v bool) { failWarnings = v }(failWarnings)
+		failWarnings = true
+		result := &control.AnalysisResult{Warnings: []string{"could not verify something"}}
+		err := finalizeRun(result, passingGate, platformErr)
+		var want *DegradedError
+		if !errors.As(err, &want) {
+			t.Fatalf("finalizeRun = %v (%T), want *DegradedError", err, err)
+		}
+	})
+
+	t.Run("the score gate wins over a platform error", func(t *testing.T) {
+		result := &control.AnalysisResult{}
+		err := finalizeRun(result, failingGate, platformErr)
+		var want *ScoreGateError
+		if !errors.As(err, &want) {
+			t.Fatalf("finalizeRun = %v (%T), want *ScoreGateError", err, err)
+		}
+	})
+
+	t.Run("a platform error surfaces only once nothing else failed", func(t *testing.T) {
+		result := &control.AnalysisResult{}
+		if err := finalizeRun(result, passingGate, platformErr); err != platformErr {
+			t.Fatalf("finalizeRun = %v, want the platform error itself", err)
+		}
+	})
+
+	t.Run("a clean run with no platform error passes", func(t *testing.T) {
+		result := &control.AnalysisResult{}
+		if err := finalizeRun(result, passingGate, nil); err != nil {
+			t.Fatalf("finalizeRun = %v, want nil", err)
+		}
+	})
+}

--- a/cmd/platform_push.go
+++ b/cmd/platform_push.go
@@ -1,0 +1,246 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/control"
+	providerPkg "github.com/getplumber/plumber/provider"
+)
+
+// platformSentinelURL is the GitLab CI component's default for its `platform`
+// input. GitLab requires the `id_tokens:` block's `aud` to be non-empty, so
+// the input (which doubles as both the audience and PLUMBER_ANALYZE_PLATFORM)
+// cannot default to "". ".invalid" is reserved by RFC 2606 and can never
+// resolve to a real host, so it is a safe value to mint a token against and
+// wire through as the env var on every run without turning the push on for
+// everyone. effectivePlatformPush treats this exact value as "not configured".
+const platformSentinelURL = "https://platform.invalid"
+
+// effectivePlatformPush resolves whether to push to the platform and the base
+// URL to push to. Unlike the badge, there is no separate opt-in: supplying the
+// URL is the opt-in, because a platform URL has no other meaning. Resolved only
+// from operator-controlled sources (the flag / PLUMBER_ANALYZE_PLATFORM), never
+// from the analyzed repository's config file. platformSentinelURL is the one
+// value that does NOT opt in — see its doc comment.
+func effectivePlatformPush() (push bool, endpoint string) {
+	endpoint = strings.TrimRight(strings.TrimSpace(platformURL), "/")
+	if endpoint == platformSentinelURL {
+		return false, ""
+	}
+	return endpoint != "", endpoint
+}
+
+// platformEnvelope is the body POSTed to the platform. It exists so the
+// analysis document can be pushed unchanged: everything the platform needs to
+// know that the document does not carry lives here, not in the report.
+//
+// results is an array from the first release even though local policy
+// resolution yields exactly one entry, because #368 makes it one entry per
+// policy. Growing it must not change the shape of anything else.
+type platformEnvelope struct {
+	SchemaVersion int              `json:"schemaVersion"`
+	Results       []platformResult `json:"results"`
+}
+
+// platformResult is one policy's verdict on this project.
+//
+// Degraded and DegradedReasons sit here rather than in the report because the
+// analysis JSON document carries no degradation signal at all: the flag reaches
+// SARIF (as invocations) and GitLab SAST (as scan.messages) and stops there.
+// Without them the platform would receive a partial scan and render it as a
+// complete one, with a score computed from missing data.
+type platformResult struct {
+	Policy          platformPolicy  `json:"policy"`
+	Degraded        bool            `json:"degraded"`
+	DegradedReasons []string        `json:"degradedReasons"`
+	Report          json.RawMessage `json:"report"`
+}
+
+// platformPolicy identifies which policy produced the sibling report. Today
+// Source is either "local" (Ref names the .plumber.yaml file that was
+// actually read from disk) or "embedded" (the run used the config compiled
+// into the binary — a zero-config run, Ref empty, because no file was read
+// and claiming one would name a path that may not exist). Under #368 Source
+// also becomes "platform", with Name and Ref carrying what the platform
+// returned. A backend written against this keeps working across that change.
+type platformPolicy struct {
+	Name   string `json:"name"`
+	Source string `json:"source"`
+	Ref    string `json:"ref"`
+}
+
+// platformPolicySourceLocal marks a policy descriptor whose Ref names a
+// .plumber.yaml file that was actually read from disk.
+const platformPolicySourceLocal = "local"
+
+// platformPolicySourceEmbedded marks a policy descriptor for a run that used
+// the config embedded in the binary (no .plumber.yaml on disk, no --config
+// pointing at a real file). Ref is empty in this case: the flag default
+// (".plumber.yaml") names no file that was actually read, and asserting it
+// as the descriptor's Ref would claim a local file that may not exist.
+const platformPolicySourceEmbedded = "embedded"
+
+// policyNameFor derives a stable, human-meaningful policy name from the config
+// path: ".plumber.yaml" is the unnamed default, and any leading qualifier
+// ("team.plumber.yml", ".plumber.strict.yaml") names the policy. Under #368 the
+// platform supplies the name instead and this is not consulted.
+func policyNameFor(configPath string) string {
+	base := filepath.Base(strings.TrimSpace(configPath))
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		return "default"
+	}
+	base = strings.TrimSuffix(strings.TrimSuffix(base, ".yaml"), ".yml")
+	base = strings.TrimPrefix(base, ".")
+	switch {
+	case base == "" || base == "plumber":
+		return "default"
+	case strings.HasPrefix(base, "plumber."):
+		return strings.TrimPrefix(base, "plumber.")
+	case strings.HasSuffix(base, ".plumber"):
+		return strings.TrimSuffix(base, ".plumber")
+	default:
+		return base
+	}
+}
+
+// buildPlatformEnvelope wraps the analysis document for the platform. report
+// is embedded as json.RawMessage from the SAME buildAnalysisJSONReport call
+// that produced the --output file, so the two can never carry different DATA.
+// The bytes on the wire are not byte-identical to the --output file, though:
+// json.Marshal on the envelope re-serializes report compactly (as one field
+// nested inside a larger document) and HTML-escapes '<', '>', '&' in any
+// string values. That is intentional and left as-is — whitespace carries no
+// semantic meaning, and no real report contains those characters — but callers
+// must not assume the transmitted copy is a byte-for-byte match of the file.
+func buildPlatformEnvelope(report []byte, configPath string, degraded bool, reasons []string) ([]byte, error) {
+	if len(report) == 0 {
+		return nil, fmt.Errorf("empty analysis report")
+	}
+	if reasons == nil {
+		reasons = []string{}
+	}
+	env := platformEnvelope{
+		SchemaVersion: 1,
+		Results: []platformResult{{
+			Policy:          platformPolicyFor(configPath),
+			Degraded:        degraded,
+			DegradedReasons: reasons,
+			Report:          json.RawMessage(report),
+		}},
+	}
+	body, err := json.Marshal(env)
+	if err != nil {
+		return nil, fmt.Errorf("marshal platform envelope: %w", err)
+	}
+	return body, nil
+}
+
+// platformPolicyFor derives the policy descriptor from the resolved config
+// path (the *configuration.Configuration's ConfigFilePath, see
+// maybePushPlatform). configPath is empty or equal to
+// builtinDefaultConfigSource ("built-in default", set by
+// loadEmbeddedDefaultConfig) exactly when the run never read a local
+// .plumber.yaml — the --config flag's own default is ".plumber.yaml"
+// regardless of whether that file exists, so it cannot be trusted to tell
+// the two cases apart. Only when a real file was read does the descriptor
+// claim "local" and carry its path; otherwise it claims "embedded" with no
+// Ref, so the descriptor never names a file that may not exist on disk.
+func platformPolicyFor(configPath string) platformPolicy {
+	ref := strings.TrimSpace(configPath)
+	if ref == "" || ref == builtinDefaultConfigSource {
+		return platformPolicy{Name: policyNameFor(""), Source: platformPolicySourceEmbedded, Ref: ""}
+	}
+	return platformPolicy{Name: policyNameFor(ref), Source: platformPolicySourceLocal, Ref: ref}
+}
+
+// PlatformTokenError reports that the run could not obtain the CI OIDC
+// id-token the platform push requires. It is the ONLY platform-push condition
+// that fails a run: the grant is missing from the pipeline's own configuration,
+// the user can fix it, and a silently skipped push would hide that from them.
+// Everything remote — unreachable, 4xx, 5xx, oversized — is a warning.
+type PlatformTokenError struct{ Reason string }
+
+func (e *PlatformTokenError) Error() string {
+	return "platform push: " + e.Reason
+}
+
+// platformTokenFailure reports a token failure on stderr AND returns it.
+//
+// Printing here rather than relying on the returned error is what makes the
+// message reliable. finalizeRun evaluates this error last, deliberately, so a
+// broken id-token grant can never mask a security finding the scan just made.
+// The consequence is that on a run which also fails its gate the error is
+// discarded, and without this line the user would be told nothing at all: no
+// push, no warning, no clue why. That is the failure mode the whole feature
+// exists to prevent, so the diagnosis is emitted at the point of failure and
+// the error still propagates to decide the exit code when nothing outranks it.
+func platformTokenFailure(reason string) error {
+	fmt.Fprintf(os.Stderr, "⚠️  platform push: %s\n", reason)
+	return &PlatformTokenError{Reason: reason}
+}
+
+// maybePushPlatform pushes the analysis result to the configured platform.
+// It returns non-nil ONLY for a token failure; see PlatformTokenError. conf's
+// only use here is resolving which config file (if any) produced this run's
+// policy — for the platform record's policy descriptor — via
+// conf.ConfigFilePath, the RESOLVED path set once at load time (falling back
+// to the --config flag when conf is nil or the field is empty, e.g. in tests
+// that construct the payload directly). Project identity for the platform
+// record is a separate matter and still comes from the verified OIDC claims
+// server-side, never from operator-supplied config.
+func maybePushPlatform(p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult, payload []byte) error {
+	push, endpoint := effectivePlatformPush()
+	if !push || len(payload) == 0 {
+		return nil
+	}
+
+	// Every failure to obtain the token fails the run, INCLUDING a transport
+	// error such as a timeout, DNS failure or refused connection while talking
+	// to the CI's own token service. That is deliberate and is not an oversight
+	// to be "fixed" into a warning later: minting happens inside the pipeline,
+	// against the CI provider's own infrastructure, so a failure there is an
+	// ordinary pipeline failure like any other step being unable to reach its
+	// dependencies. The never-block rule protects the pipeline from ONE thing
+	// only: the platform receiving the data being down. That is a third party
+	// the pipeline should not be coupled to; the CI's token endpoint is not.
+	token, err := scoreOIDCToken(p, endpoint)
+	if err != nil {
+		return platformTokenFailure(fmt.Sprintf("could not mint the CI OIDC id-token for %s: %v", endpoint, err))
+	}
+	if token == "" {
+		switch {
+		case p.Name() == "github":
+			return platformTokenFailure("the workflow must grant `permissions: id-token: write` to push to the platform")
+		default:
+			return platformTokenFailure("no CI OIDC id-token available for the platform push; the pipeline must declare the component's `id_tokens:` block (" + gitlabPlatformTokenEnv + ")")
+		}
+	}
+
+	configPath := strings.TrimSpace(configFile)
+	if conf != nil {
+		if resolved := strings.TrimSpace(conf.ConfigFilePath); resolved != "" {
+			configPath = resolved
+		}
+	}
+	body, err := buildPlatformEnvelope(payload, configPath, result.DataCollectionDegraded, result.DegradedReasons)
+	if err != nil {
+		scoreWarn(fmt.Sprintf("platform push skipped: %v", err))
+		return nil
+	}
+
+	// Every remote condition lands here, including 413 for an oversized body:
+	// the server is the authority on its own limit, so the CLI enforces none.
+	// The push is skipped whole rather than truncated, because the platform
+	// renders the record as the complete picture.
+	if err := postScoreReport(endpoint+"/api/v1/results", token, body); err != nil {
+		scoreWarn(fmt.Sprintf("platform push failed: %v", err))
+		return nil
+	}
+	fmt.Fprintf(os.Stderr, "✓ Results pushed to the platform: %s\n", endpoint)
+	return nil
+}

--- a/cmd/platform_push_test.go
+++ b/cmd/platform_push_test.go
@@ -1,0 +1,580 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/control"
+	providerPkg "github.com/getplumber/plumber/provider"
+)
+
+// --platform implies the push; there is no separate switch.
+func TestEffectivePlatformPush_SetImpliesPush(t *testing.T) {
+	orig := platformURL
+	defer func() { platformURL = orig }()
+
+	platformURL = "  https://app.example.com/  "
+	push, endpoint := effectivePlatformPush()
+	if !push {
+		t.Error("push = false, want true: setting --platform implies pushing")
+	}
+	if endpoint != "https://app.example.com" {
+		t.Errorf("endpoint = %q, want the trimmed URL without a trailing slash", endpoint)
+	}
+}
+
+func TestEffectivePlatformPush_UnsetDoesNotPush(t *testing.T) {
+	orig := platformURL
+	defer func() { platformURL = orig }()
+
+	platformURL = ""
+	if push, _ := effectivePlatformPush(); push {
+		t.Error("push = true with no --platform, want false")
+	}
+}
+
+// The GitLab component defaults its `platform` input to platformSentinelURL
+// because id_tokens requires a non-empty audience. That default reaches the
+// CLI as PLUMBER_ANALYZE_PLATFORM on every run, so seeing it alone must not
+// enable a push — only an operator-supplied, non-sentinel URL does.
+func TestEffectivePlatformPush_SentinelDoesNotPush(t *testing.T) {
+	orig := platformURL
+	defer func() { platformURL = orig }()
+
+	for _, v := range []string{
+		platformSentinelURL,
+		platformSentinelURL + "/",
+		"  " + platformSentinelURL + "  ",
+	} {
+		platformURL = v
+		if push, endpoint := effectivePlatformPush(); push || endpoint != "" {
+			t.Errorf("platformURL = %q: push = %v, endpoint = %q, want false, \"\" for the template's sentinel default", v, push, endpoint)
+		}
+	}
+
+	platformURL = "https://platform.example.com"
+	if push, endpoint := effectivePlatformPush(); !push || endpoint != "https://platform.example.com" {
+		t.Errorf("an ordinary URL: push = %v, endpoint = %q, want true, %q", push, endpoint, "https://platform.example.com")
+	}
+}
+
+// The badge push yields, so a run never publishes to both. Silence would make a
+// dropped push a mystery, which is the failure mode this feature exists to fix.
+func TestEffectiveScorePush_YieldsToPlatform(t *testing.T) {
+	origP, origS := platformURL, pushScore
+	defer func() { platformURL, pushScore = origP, origS }()
+
+	platformURL, pushScore = "https://app.example.com", true
+	if push, _ := effectiveScorePush(); push {
+		t.Error("badge push = true while --platform is set, want false")
+	}
+
+	platformURL = ""
+	if push, _ := effectiveScorePush(); !push {
+		t.Error("badge push = false with --platform unset, want true")
+	}
+}
+
+// buildPublishPayload is the single gate deciding whether a payload exists for
+// BOTH publish paths — every maybePushPlatform/handleScorePublishing test
+// injects a payload directly, so only this test would catch a narrowed gate
+// (e.g. dropping the platformPush term): a --platform-only run would then get
+// nil and maybePushPlatform would silently do nothing, with the suite green.
+// Also pins that the bytes ARE buildAnalysisJSONReport's output, the
+// no-divergence promise in the doc comment.
+func TestBuildPublishPayload_GateAndBytes(t *testing.T) {
+	origP, origS := platformURL, pushScore
+	defer func() { platformURL, pushScore = origP, origS }()
+
+	prov := &providerPkg.GitLabProvider{}
+	result := &control.AnalysisResult{CiValid: true}
+	conf := configuration.NewDefaultConfiguration()
+	conf.PlumberConfig = &configuration.PlumberConfig{}
+	summary := complianceSummary{minPoints: 100, score: scoreWithPoints(100), scoreMode: true, controlCount: 1}
+
+	t.Run("platform-only run gets the exact report bytes", func(t *testing.T) {
+		platformURL, pushScore = "https://app.example.com", false
+		payload := buildPublishPayload(prov, conf, result, summary)
+		if payload == nil {
+			t.Fatal("payload = nil for a --platform-only run: the platform push would silently never happen")
+		}
+		want, err := buildAnalysisJSONReport(result, conf.PlumberConfig, summary, jsonOutputParams{
+			provider: prov.Name(), includeOnly: conf.ControlsFilter, skip: conf.SkipControlsFilter,
+		})
+		if err != nil {
+			t.Fatalf("buildAnalysisJSONReport: %v", err)
+		}
+		if !bytes.Equal(payload, want) {
+			t.Errorf("payload diverges from buildAnalysisJSONReport:\ngot:  %s\nwant: %s", payload, want)
+		}
+	})
+
+	t.Run("badge-only run gets a payload", func(t *testing.T) {
+		platformURL, pushScore = "", true
+		if buildPublishPayload(prov, conf, result, summary) == nil {
+			t.Fatal("payload = nil for a --score-push-only run: the badge push would silently never happen")
+		}
+	})
+
+	t.Run("neither push configured skips the marshal", func(t *testing.T) {
+		platformURL, pushScore = "", false
+		if payload := buildPublishPayload(prov, conf, result, summary); payload != nil {
+			t.Errorf("payload = %d bytes with no push configured, want nil (a plain run must not pay the marshal cost)", len(payload))
+		}
+	})
+
+	t.Run("the component's sentinel default does not opt in", func(t *testing.T) {
+		platformURL, pushScore = platformSentinelURL, false
+		if payload := buildPublishPayload(prov, conf, result, summary); payload != nil {
+			t.Errorf("payload = %d bytes for the sentinel platform URL, want nil: the GitLab component sets it on every run", len(payload))
+		}
+	})
+}
+
+// The report is embedded with the same DATA the file on disk gets: one
+// builder (buildAnalysisJSONReport) feeds both, so the two cannot drift.
+// json.Marshal on the envelope re-serializes report compactly (it is nested
+// inside a larger document) and would HTML-escape '<', '>', '&' — that is
+// accepted and intentional (see buildPlatformEnvelope's doc comment), so this
+// deliberately asserts semantic equality, not byte equality. The fixture is
+// indented, multi-line, and carries a unicode character so a naive compact-ASCII
+// fixture couldn't have masked a real mutation.
+func TestBuildPlatformEnvelope_EmbedsTheReportUnchanged(t *testing.T) {
+	report := []byte(`{
+  "projectPath": "org/repo",
+  "plumberScore": {
+    "score": "B"
+  },
+  "note": "café — pipeline ok"
+}`)
+
+	body, err := buildPlatformEnvelope(report, ".plumber.yaml", false, nil)
+	if err != nil {
+		t.Fatalf("buildPlatformEnvelope: %v", err)
+	}
+	var env platformEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("envelope does not round-trip: %v", err)
+	}
+	if env.SchemaVersion != 1 {
+		t.Errorf("schemaVersion = %d, want 1", env.SchemaVersion)
+	}
+	if len(env.Results) != 1 {
+		t.Fatalf("results = %d, want exactly 1 while policy resolution is local", len(env.Results))
+	}
+
+	var want, got any
+	if err := json.Unmarshal(report, &want); err != nil {
+		t.Fatalf("fixture does not parse as JSON: %v", err)
+	}
+	if err := json.Unmarshal(env.Results[0].Report, &got); err != nil {
+		t.Fatalf("embedded report does not parse as JSON: %v", err)
+	}
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("embedded report is not semantically equal to the input:\n got %#v\nwant %#v", got, want)
+	}
+}
+
+// The descriptor is per entry, not envelope-level, so #368 grows the array
+// without changing the shape.
+func TestBuildPlatformEnvelope_CarriesThePolicyDescriptor(t *testing.T) {
+	body, err := buildPlatformEnvelope([]byte(`{}`), "config/.plumber.strict.yaml", false, nil)
+	if err != nil {
+		t.Fatalf("buildPlatformEnvelope: %v", err)
+	}
+	var env platformEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatal(err)
+	}
+	p := env.Results[0].Policy
+	if p.Source != "local" {
+		t.Errorf("policy.source = %q, want %q while the policy is a local file", p.Source, "local")
+	}
+	if p.Ref != "config/.plumber.strict.yaml" {
+		t.Errorf("policy.ref = %q, want the config path as given", p.Ref)
+	}
+	if p.Name != "strict" {
+		t.Errorf("policy.name = %q, want %q", p.Name, "strict")
+	}
+}
+
+// The bug this guards: a zero-config run never reads a .plumber.yaml file —
+// it loads the config embedded in the binary (loadEmbeddedDefaultConfig) —
+// but the --config flag still carries its own default (".plumber.yaml"),
+// which names no file that was actually read and may not even exist on
+// disk. builtinDefaultConfigSource is what conf.ConfigFilePath holds in that
+// case; the descriptor must not claim "local" for it. An empty configPath
+// (no resolved path known at all) gets the same treatment: safer to say
+// "not a local file" than to guess ".plumber.yaml".
+func TestBuildPlatformEnvelope_EmbeddedDefaultDoesNotClaimALocalFile(t *testing.T) {
+	for _, configPath := range []string{builtinDefaultConfigSource, "", "   "} {
+		body, err := buildPlatformEnvelope([]byte(`{}`), configPath, false, nil)
+		if err != nil {
+			t.Fatalf("buildPlatformEnvelope(%q): %v", configPath, err)
+		}
+		var env platformEnvelope
+		if err := json.Unmarshal(body, &env); err != nil {
+			t.Fatal(err)
+		}
+		p := env.Results[0].Policy
+		if p.Source != platformPolicySourceEmbedded {
+			t.Errorf("configPath=%q: policy.source = %q, want %q", configPath, p.Source, platformPolicySourceEmbedded)
+		}
+		if p.Ref != "" {
+			t.Errorf("configPath=%q: policy.ref = %q, want empty — no local file was read", configPath, p.Ref)
+		}
+		if p.Name != "default" {
+			t.Errorf("configPath=%q: policy.name = %q, want %q", configPath, p.Name, "default")
+		}
+	}
+}
+
+// maybePushPlatform must describe the config that was ACTUALLY loaded —
+// conf.ConfigFilePath, resolved once at load time (cmd/analyze_gitlab.go,
+// cmd/analyze_github.go) — not the raw --config flag value: the flag
+// defaults to ".plumber.yaml" whether or not that file exists, so using it
+// directly (the pre-fix behavior) claimed a local file even on a zero-config
+// run that read the embedded default instead.
+func TestMaybePushPlatform_DescriptorUsesResolvedConfigPathFromConf(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	// The --config flag still carries its unrelated default; conf.ConfigFilePath
+	// is what the run actually resolved, and must win.
+	origConfigFile := configFile
+	configFile = ".plumber.yaml"
+	defer func() { configFile = origConfigFile }()
+
+	conf := &configuration.Configuration{ConfigFilePath: builtinDefaultConfigSource}
+	if err := maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, []byte(`{}`)); err != nil {
+		t.Fatalf("maybePushPlatform: %v", err)
+	}
+	var env platformEnvelope
+	if err := json.Unmarshal(gotBody, &env); err != nil {
+		t.Fatal(err)
+	}
+	p := env.Results[0].Policy
+	if p.Source != platformPolicySourceEmbedded || p.Ref != "" {
+		t.Errorf("policy = %+v, want the embedded-default descriptor (source=%q, ref=\"\") even though --config defaults to %q", p, platformPolicySourceEmbedded, configFile)
+	}
+}
+
+// When conf carries no resolved path (nil conf, or an empty
+// ConfigFilePath, as in tests that build the payload directly), the
+// --config flag is still consulted as a fallback so the descriptor is never
+// simply blank for a run that DID read a real file.
+func TestMaybePushPlatform_FallsBackToConfigFlagWhenConfHasNoPath(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	origConfigFile := configFile
+	configFile = "config/.plumber.strict.yaml"
+	defer func() { configFile = origConfigFile }()
+
+	if err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, []byte(`{}`)); err != nil {
+		t.Fatalf("maybePushPlatform: %v", err)
+	}
+	var env platformEnvelope
+	if err := json.Unmarshal(gotBody, &env); err != nil {
+		t.Fatal(err)
+	}
+	p := env.Results[0].Policy
+	if p.Source != platformPolicySourceLocal || p.Ref != "config/.plumber.strict.yaml" {
+		t.Errorf("policy = %+v, want source=%q ref=%q from the --config flag fallback", p, platformPolicySourceLocal, "config/.plumber.strict.yaml")
+	}
+}
+
+// The analysis document has no degradation signal at all, so without these the
+// platform would render a partial scan as complete.
+func TestBuildPlatformEnvelope_MarksADegradedRun(t *testing.T) {
+	reasons := []string{"branch protection could not be fetched (network or timeout)"}
+	body, err := buildPlatformEnvelope([]byte(`{}`), ".plumber.yaml", true, reasons)
+	if err != nil {
+		t.Fatalf("buildPlatformEnvelope: %v", err)
+	}
+	var env platformEnvelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatal(err)
+	}
+	if !env.Results[0].Degraded {
+		t.Error("degraded = false, want true")
+	}
+	if len(env.Results[0].DegradedReasons) != 1 || env.Results[0].DegradedReasons[0] != reasons[0] {
+		t.Errorf("degradedReasons = %v, want %v", env.Results[0].DegradedReasons, reasons)
+	}
+}
+
+func TestPolicyNameFor(t *testing.T) {
+	for _, tc := range []struct{ path, want string }{
+		{".plumber.yaml", "default"},
+		{"/abs/path/.plumber.yaml", "default"},
+		{".plumber.strict.yaml", "strict"},
+		{"config/team.plumber.yml", "team"},
+		{"", "default"},
+	} {
+		if got := policyNameFor(tc.path); got != tc.want {
+			t.Errorf("policyNameFor(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+// The happy path: the push is a POST to {platform}/api/v1/results carrying the
+// bearer token and the envelope.
+func TestMaybePushPlatform_PostsTheEnvelope(t *testing.T) {
+	var gotPath, gotAuth, gotType string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotAuth, gotType = r.URL.Path, r.Header.Get("Authorization"), r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, []byte(`{"projectPath":"org/repo"}`))
+	if err != nil {
+		t.Fatalf("maybePushPlatform returned %v, want nil on a 202", err)
+	}
+	if gotPath != "/api/v1/results" {
+		t.Errorf("path = %q, want /api/v1/results", gotPath)
+	}
+	if gotAuth != "Bearer tok-123" {
+		t.Errorf("Authorization = %q, want the bearer id-token", gotAuth)
+	}
+	if gotType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotType)
+	}
+	var env platformEnvelope
+	if err := json.Unmarshal(gotBody, &env); err != nil {
+		t.Fatalf("body is not an envelope: %v", err)
+	}
+	if len(env.Results) != 1 || len(env.Results[0].Report) == 0 {
+		t.Errorf("body did not carry exactly one complete result: %s", gotBody)
+	}
+}
+
+// Every remote condition warns and leaves the exit code alone: the platform
+// being unhappy must never gate somebody's pipeline.
+func TestMaybePushPlatform_RemoteFailuresOnlyWarn(t *testing.T) {
+	for _, status := range []int{
+		http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden,
+		http.StatusNotFound, http.StatusRequestEntityTooLarge, http.StatusInternalServerError,
+	} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+			}))
+			defer srv.Close()
+			restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+			defer restore()
+
+			if err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, []byte(`{}`)); err != nil {
+				t.Errorf("status %d returned %v, want nil: a remote condition must not fail the run", status, err)
+			}
+		})
+	}
+}
+
+func TestMaybePushPlatform_UnreachableOnlyWarns(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close() // nothing is listening now
+
+	restore := withPlatformTestEnv(t, url, "tok-123")
+	defer restore()
+
+	if err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, []byte(`{}`)); err != nil {
+		t.Errorf("unreachable platform returned %v, want nil", err)
+	}
+}
+
+// The one failing case: no id-token. It is a pipeline defect the user must fix
+// and would otherwise never notice.
+func TestMaybePushPlatform_MissingTokenFailsWithActionableMessage(t *testing.T) {
+	restore := withPlatformTestEnv(t, "https://app.example.com", "")
+	defer restore()
+
+	err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, []byte(`{}`))
+	if err == nil {
+		t.Fatal("missing id-token returned nil, want an error: a silently skipped push is the failure mode this prevents")
+	}
+	if !strings.Contains(err.Error(), "id-token") {
+		t.Errorf("error %q does not name the missing grant", err)
+	}
+}
+
+// The GitHub side of the one failing case: a workflow that never granted
+// `permissions: id-token: write` has no ACTIONS_ID_TOKEN_REQUEST_URL /
+// ACTIONS_ID_TOKEN_REQUEST_TOKEN at all, so scoreOIDCToken returns ("", nil)
+// (not a token-granting context) rather than an error — maybePushPlatform
+// must still fail the run and name the exact permission to add, mirroring the
+// GitLab id_tokens: case above. Only the GitLab token branch was covered
+// before this test; the GitHub branch is the same run-failing path and needs
+// the same guarantee.
+func TestMaybePushPlatform_GitHubMissingGrantFailsWithActionableMessage(t *testing.T) {
+	p, ok := providerPkg.Get("github")
+	if !ok {
+		t.Skip("github provider not registered")
+	}
+
+	orig := platformURL
+	defer func() { platformURL = orig }()
+	platformURL = "https://app.example.com"
+
+	// Absent, not merely empty: a workflow without `permissions: id-token:
+	// write` never has these set in the runner environment at all.
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "")
+
+	err := maybePushPlatform(p, nil, &control.AnalysisResult{}, []byte(`{}`))
+	if err == nil {
+		t.Fatal("missing GitHub id-token grant returned nil, want an error: a silently skipped push is the failure mode this prevents")
+	}
+	var tokenErr *PlatformTokenError
+	if !errors.As(err, &tokenErr) {
+		t.Fatalf("error %v is not a *PlatformTokenError", err)
+	}
+	if !strings.Contains(err.Error(), "permissions: id-token: write") {
+		t.Errorf("error %q does not name the missing grant (`permissions: id-token: write`)", err)
+	}
+}
+
+// A 500 from the token-MINTING endpoint (the GitHub Actions runtime that
+// issues the id-token, not the platform the report is pushed to) means the
+// run never obtained a token to push with. That is still the one failing
+// condition — a *PlatformTokenError, not a remote-push warning — and is
+// distinct from the missing-grant case above, where the request is never
+// attempted at all.
+func TestMaybePushPlatform_GitHubTokenMintFailureReturnsPlatformTokenError(t *testing.T) {
+	p, ok := providerPkg.Get("github")
+	if !ok {
+		t.Skip("github provider not registered")
+	}
+
+	mint := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer mint.Close()
+
+	orig := platformURL
+	defer func() { platformURL = orig }()
+	platformURL = "https://app.example.com"
+
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", mint.URL)
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "req-token")
+
+	err := maybePushPlatform(p, nil, &control.AnalysisResult{}, []byte(`{}`))
+	if err == nil {
+		t.Fatal("a failed token mint returned nil, want a *PlatformTokenError: the run must not proceed as if the push were merely skipped")
+	}
+	var tokenErr *PlatformTokenError
+	if !errors.As(err, &tokenErr) {
+		t.Fatalf("error %v is not a *PlatformTokenError", err)
+	}
+}
+
+// The degraded markers must reach the wire, since that is what makes pushing a
+// degraded run safe rather than misleading.
+func TestMaybePushPlatform_SendsDegradedMarkers(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	result := &control.AnalysisResult{
+		DataCollectionDegraded: true,
+		DegradedReasons:        []string{"pipeline configuration could not be fetched (network or timeout)"},
+	}
+	if err := maybePushPlatform(testProvider(t), nil, result, []byte(`{}`)); err != nil {
+		t.Fatalf("maybePushPlatform: %v", err)
+	}
+	var env platformEnvelope
+	if err := json.Unmarshal(gotBody, &env); err != nil {
+		t.Fatal(err)
+	}
+	if !env.Results[0].Degraded || len(env.Results[0].DegradedReasons) != 1 {
+		t.Errorf("degraded markers did not reach the wire: %s", gotBody)
+	}
+}
+
+// testProvider returns the GitLab provider, whose scoreOIDCToken path reads
+// the id-token env var directly (no HTTP round trip to mint), which is what
+// makes these tests exercisable with httptest alone.
+func testProvider(t *testing.T) providerPkg.Provider {
+	t.Helper()
+	p, ok := providerPkg.Get("gitlab")
+	if !ok {
+		t.Skip("gitlab provider not registered")
+	}
+	return p
+}
+
+// withPlatformTestEnv points the CLI at a stand-in platform and supplies (or
+// withholds) the GitLab-style id-token, which is the path that needs no HTTP
+// round trip to mint. Returns a restore func.
+func withPlatformTestEnv(t *testing.T, url, token string) func() {
+	t.Helper()
+	origURL, origTok := platformURL, os.Getenv(gitlabPlatformTokenEnv)
+	platformURL = url
+	if token == "" {
+		_ = os.Unsetenv(gitlabPlatformTokenEnv)
+	} else {
+		t.Setenv(gitlabPlatformTokenEnv, token)
+	}
+	return func() {
+		platformURL = origURL
+		if origTok != "" {
+			_ = os.Setenv(gitlabPlatformTokenEnv, origTok)
+		}
+	}
+}
+
+// A token failure must announce itself on stderr, not only through the
+// returned error. finalizeRun evaluates the platform error LAST so it cannot
+// mask a security finding, which means a run that also fails its gate discards
+// it. Found in real use: a GitLab scan scoring C pushed nothing and said
+// nothing, because the gate error won and the token error vanished with it.
+func TestMaybePushPlatform_TokenFailureIsAnnouncedNotOnlyReturned(t *testing.T) {
+	restore := withPlatformTestEnv(t, "https://app.example.com", "")
+	defer restore()
+
+	var err error
+	out := captureStderr(t, func() {
+		err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, []byte(`{}`))
+	})
+
+	if err == nil {
+		t.Fatal("no error returned for a missing id-token")
+	}
+	if !strings.Contains(out, "id_tokens") && !strings.Contains(out, "id-token") {
+		t.Errorf("stderr = %q, want the actionable diagnosis printed at the point of failure; "+
+			"without it a run that also fails its gate reports nothing at all", out)
+	}
+}

--- a/cmd/score_push.go
+++ b/cmd/score_push.go
@@ -27,6 +27,12 @@ const scorePushHTTPTimeout = 15 * time.Second
 // mints the token itself there.)
 const gitlabScoreTokenEnv = "PLUMBER_ANALYZE_SCORE_TOKEN"
 
+// gitlabPlatformTokenEnv is the env var the GitLab CI component's `id_tokens:`
+// block writes the PLATFORM OIDC id-token to. It is separate from the score
+// token because the audience must equal the destination, and the two
+// destinations differ.
+const gitlabPlatformTokenEnv = "PLUMBER_ANALYZE_PLATFORM_TOKEN"
+
 // effectiveScorePush resolves whether to publish and the score service
 // endpoint. Publishing has a single opt-in: the `--score-push` flag /
 // PLUMBER_ANALYZE_SCORE_PUSH env, which the CI integration input (the
@@ -36,6 +42,12 @@ const gitlabScoreTokenEnv = "PLUMBER_ANALYZE_SCORE_TOKEN"
 // sources, never from the analyzed repository's config file.
 func effectiveScorePush() (push bool, endpoint string) {
 	push = pushScore
+	// A run publishes to one destination. The platform supersedes the public
+	// badge when both are configured; maybePushScore prints the note so the
+	// skip is never silent.
+	if platformPush, _ := effectivePlatformPush(); platformPush {
+		push = false
+	}
 	endpoint = strings.TrimRight(strings.TrimSpace(scoreEndpoint), "/")
 	if endpoint == "" {
 		endpoint = configuration.DefaultScoreEndpoint
@@ -49,6 +61,13 @@ func effectiveScorePush() (push bool, endpoint string) {
 // publish; an explicit --score-push then prints a one-line note instead of
 // skipping silently, so the requested push is never a mystery.
 func maybePushScore(p providerPkg.Provider, conf *configuration.Configuration, payload []byte, defaultBranch string) {
+	// The --platform-preempts-badge skip note lives in handleScorePublishingOnce
+	// (printScorePushSkippedForPlatform), the only production caller: it decides
+	// push/no-push BEFORE building the payload, so by the time maybePushScore
+	// runs, push is already true. Do not duplicate that note here — a prior
+	// version did, and it went uncovered by any production call path because
+	// this function is only ever invoked after the caller already confirmed
+	// push == true.
 	push, endpoint := effectiveScorePush()
 	if !push || len(payload) == 0 {
 		return
@@ -63,7 +82,7 @@ func maybePushScore(p providerPkg.Provider, conf *configuration.Configuration, p
 		return
 	}
 
-	platform, projectPath, ok := resolveScoreTarget(p, conf)
+	forgeHost, projectPath, ok := resolveScoreTarget(p, conf)
 	if !ok {
 		scoreWarn("could not resolve the project path for the score push; skipped")
 		return
@@ -89,7 +108,7 @@ func maybePushScore(p providerPkg.Provider, conf *configuration.Configuration, p
 		return
 	}
 
-	target := fmt.Sprintf("%s/%s/%s", endpoint, platform, projectPath)
+	target := fmt.Sprintf("%s/%s/%s", endpoint, forgeHost, projectPath)
 	if err := postScoreReport(target, token, payload); err != nil {
 		scoreWarn(fmt.Sprintf("score push failed: %v", err))
 		return
@@ -101,7 +120,7 @@ func maybePushScore(p providerPkg.Provider, conf *configuration.Configuration, p
 	if branch := ciRunBranch(p); branch != "" && defaultBranch != "" && branch != defaultBranch {
 		note = fmt.Sprintf(" (but not displayed on the public badge: %q is not the default branch)", branch)
 	}
-	fmt.Fprintf(os.Stderr, "✓ Plumber Score published: %s/%s/%s%s\n", endpoint, platform, projectPath, note)
+	fmt.Fprintf(os.Stderr, "✓ Plumber Score published: %s/%s/%s%s\n", endpoint, forgeHost, projectPath, note)
 }
 
 // ciRunBranch returns the branch this CI run executes on, or "" when unknown
@@ -138,10 +157,10 @@ func ciScoreTargetMismatch(p providerPkg.Provider, conf *configuration.Configura
 	return ciRepo, scanned, !strings.EqualFold(ciRepo, scanned)
 }
 
-// resolveScoreTarget returns the {platform host} and {namespace/repo} project
+// resolveScoreTarget returns the {forge host} and {namespace/repo} project
 // path the badge is keyed by. The CI env (authoritative inside a pipeline)
 // wins over config. ok is false when no project path can be determined.
-func resolveScoreTarget(p providerPkg.Provider, conf *configuration.Configuration) (platform, projectPath string, ok bool) {
+func resolveScoreTarget(p providerPkg.Provider, conf *configuration.Configuration) (forgeHost, projectPath string, ok bool) {
 	env := p.CIEnvVars()
 
 	projectPath = strings.Trim(strings.TrimSpace(os.Getenv(env.RepoPath)), "/")
@@ -157,16 +176,16 @@ func resolveScoreTarget(p providerPkg.Provider, conf *configuration.Configuratio
 			serverURL = conf.GitlabURL
 		}
 	}
-	platform = hostOf(serverURL)
-	if platform == "" {
+	forgeHost = hostOf(serverURL)
+	if forgeHost == "" {
 		if p.Name() == "github" {
-			platform = "github.com"
+			forgeHost = "github.com"
 		} else {
-			platform = "gitlab.com"
+			forgeHost = "gitlab.com"
 		}
 	}
 
-	return platform, projectPath, projectPath != ""
+	return forgeHost, projectPath, projectPath != ""
 }
 
 // scoreOIDCToken returns the CI-native OIDC id-token minted for the score
@@ -182,8 +201,12 @@ func scoreOIDCToken(p providerPkg.Provider, endpoint string) (string, error) {
 		}
 		return fetchGitHubActionsIDToken(reqURL, reqTok, endpoint)
 	}
-	// GitLab (and others): the pipeline's id_tokens: block writes the token
-	// to the env; the CLI just reads it. Audience is pinned in the template.
+	// GitLab (and others): the pipeline's id_tokens: block writes the token to
+	// the env; the CLI just reads it. Audience is pinned in the template, so
+	// the destination decides which of the two tokens to read.
+	if platformPush, platformEndpoint := effectivePlatformPush(); platformPush && endpoint == platformEndpoint {
+		return strings.TrimSpace(os.Getenv(gitlabPlatformTokenEnv)), nil
+	}
 	return strings.TrimSpace(os.Getenv(gitlabScoreTokenEnv)), nil
 }
 
@@ -272,6 +295,15 @@ func scoreWarn(msg string) {
 	fmt.Fprintf(os.Stderr, "⚠️  %s (the run is not failed)\n", msg)
 }
 
+// printScorePushSkippedForPlatform tells the operator that their explicit
+// --score-push was preempted by --platform, so an explicitly requested badge
+// push is never dropped without a trace. Unlike maybeScoreNudge, this is NOT
+// gated by --print/--silent: the global "the skip is never silent" rule for
+// --platform vs --score-push is a hard requirement, not a cosmetic one.
+func printScorePushSkippedForPlatform(target string) {
+	fmt.Fprintf(os.Stderr, "ℹ️  --score-push skipped: results are being pushed to the platform at %s instead.\n", target)
+}
+
 // scorePublishOnce guards handleScorePublishing so a run publishes at most
 // once. The two entry points — runWithProvider (GitLab) and
 // presentResultWithProvider (GitHub) — are mutually exclusive today, but a
@@ -280,16 +312,28 @@ func scoreWarn(msg string) {
 var scorePublishOnce sync.Once
 
 // handleScorePublishing publishes the score when push is enabled, otherwise
-// nudges the user (interactive local runs only) to wire it into CI. It builds
-// the push payload from the same builder the JSON output uses, so the badge
+// nudges the user (interactive local runs only) to wire it into CI. payload is
+// the same analysis JSON bytes buildAnalysisJSONReport produced for --output,
+// built once by the caller and shared with the platform push, so the badge
 // record and the file on disk never diverge. Never fails the run, and runs at
 // most once per process (scorePublishOnce).
-func handleScorePublishing(p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult, summary complianceSummary) {
-	scorePublishOnce.Do(func() { handleScorePublishingOnce(p, conf, result, summary) })
+func handleScorePublishing(p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult, summary complianceSummary, payload []byte) {
+	scorePublishOnce.Do(func() { handleScorePublishingOnce(p, conf, result, summary, payload) })
 }
 
-func handleScorePublishingOnce(p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult, summary complianceSummary) {
+func handleScorePublishingOnce(p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult, summary complianceSummary, payload []byte) {
 	if push, _ := effectiveScorePush(); !push {
+		// A push was explicitly requested (--score-push) but --platform preempted
+		// it: say so instead of falling through to the "you should turn on
+		// score-push" nudge, which would be both wrong (it's already on) and,
+		// under --silent, would print nothing at all — silently dropping an
+		// explicit request.
+		if pushScore {
+			if platformPush, target := effectivePlatformPush(); platformPush {
+				printScorePushSkippedForPlatform(target)
+				return
+			}
+		}
 		maybeScoreNudge()
 		return
 	}
@@ -303,17 +347,8 @@ func handleScorePublishingOnce(p providerPkg.Provider, conf *configuration.Confi
 		scoreWarn("data collection was incomplete; score not published (avoids overwriting the last good badge)")
 		return
 	}
-	var pc *configuration.PlumberConfig
-	var includeOnly, skip []string
-	if conf != nil {
-		pc = conf.PlumberConfig
-		includeOnly, skip = conf.ControlsFilter, conf.SkipControlsFilter
-	}
-	payload, err := buildAnalysisJSONReport(result, pc, summary, jsonOutputParams{
-		provider: p.Name(), includeOnly: includeOnly, skip: skip,
-	})
-	if err != nil {
-		scoreWarn(fmt.Sprintf("could not build the score report payload: %v", err))
+	if len(payload) == 0 {
+		scoreWarn("could not build the score report payload; skipped")
 		return
 	}
 	maybePushScore(p, conf, payload, result.DefaultBranch)

--- a/cmd/score_push_optin_check_test.go
+++ b/cmd/score_push_optin_check_test.go
@@ -48,7 +48,7 @@ func TestHandleScorePublishing_DisabledNeverSends(t *testing.T) {
 	conf := &configuration.Configuration{PlumberConfig: &configuration.PlumberConfig{}}
 	result := &control.AnalysisResult{ProjectPath: "group/repo", DefaultBranch: "main"}
 
-	handleScorePublishing(p, conf, result, complianceSummary{})
+	handleScorePublishing(p, conf, result, complianceSummary{}, []byte(`{"plumberScore":{"score":"A"}}`))
 
 	if got := posts.Load(); got != 0 {
 		t.Fatalf("score-push disabled but the service was contacted %d time(s); want 0", got)

--- a/cmd/score_push_target_test.go
+++ b/cmd/score_push_target_test.go
@@ -47,7 +47,7 @@ func TestHandleScorePublishing_SkipsForeignProject(t *testing.T) {
 	}
 	result := &control.AnalysisResult{ProjectPath: "owner/other-repo", DefaultBranch: "main"}
 
-	handleScorePublishing(p, conf, result, complianceSummary{})
+	handleScorePublishing(p, conf, result, complianceSummary{}, []byte(`{"plumberScore":{"score":"A"}}`))
 
 	if got := posts.Load(); got != 0 {
 		t.Fatalf("foreign-project scan POSTed %d time(s); want 0 (push must be skipped)", got)

--- a/cmd/score_push_test.go
+++ b/cmd/score_push_test.go
@@ -466,7 +466,7 @@ func TestHandleScorePublishing_NonDefaultBranchStillPublishes(t *testing.T) {
 	conf := &configuration.Configuration{PlumberConfig: &configuration.PlumberConfig{}}
 	result := &control.AnalysisResult{ProjectPath: "group/subgroup/repo", DefaultBranch: "main"}
 
-	handleScorePublishing(p, conf, result, complianceSummary{})
+	handleScorePublishing(p, conf, result, complianceSummary{}, []byte(`{"plumberScore":{"score":"A"}}`))
 
 	if got := posts.Load(); got != 1 {
 		t.Fatalf("MR-pipeline run POSTed %d times, want exactly 1", got)
@@ -508,7 +508,7 @@ func TestHandleScorePublishing_SkipsDegraded(t *testing.T) {
 	conf := &configuration.Configuration{PlumberConfig: &configuration.PlumberConfig{}}
 	result := &control.AnalysisResult{ProjectPath: "group/repo", DefaultBranch: "main", DataCollectionDegraded: true}
 
-	handleScorePublishing(p, conf, result, complianceSummary{})
+	handleScorePublishing(p, conf, result, complianceSummary{}, []byte(`{"plumberScore":{"score":"A"}}`))
 
 	if got := posts.Load(); got != 0 {
 		t.Fatalf("degraded run POSTed %d times, want 0", got)
@@ -552,10 +552,84 @@ func TestHandleScorePublishing_PublishesOnce(t *testing.T) {
 	conf := &configuration.Configuration{PlumberConfig: &configuration.PlumberConfig{}}
 	result := &control.AnalysisResult{ProjectPath: "octo/repo", DefaultBranch: "main"}
 
-	handleScorePublishing(p, conf, result, complianceSummary{})
-	handleScorePublishing(p, conf, result, complianceSummary{})
+	handleScorePublishing(p, conf, result, complianceSummary{}, []byte(`{"plumberScore":{"score":"A"}}`))
+	handleScorePublishing(p, conf, result, complianceSummary{}, []byte(`{"plumberScore":{"score":"A"}}`))
 
 	if got := posts.Load(); got != 1 {
 		t.Fatalf("score POSTed %d times, want exactly 1", got)
 	}
+}
+
+// TestHandleScorePublishing_PlatformPreemptsScorePush drives the real
+// production entry point (handleScorePublishing, not a direct
+// effectiveScorePush/maybePushScore call) with both --score-push and
+// --platform set. This is the path a code-review round found broken:
+// handleScorePublishingOnce checked effectiveScorePush() (false, since
+// --platform preempts it), then unconditionally called maybeScoreNudge(),
+// which both printed the wrong ("turn on score-push") message and, under
+// --silent (printOutput == false), printed nothing at all — silently
+// dropping an explicit --score-push. That violates the global "the skip is
+// never silent" rule. This test pins the fix: the platform skip note prints,
+// the nudge does not, the badge endpoint is never hit, and the note survives
+// even with printOutput off.
+func TestHandleScorePublishing_PlatformPreemptsScorePush(t *testing.T) {
+	p, ok := providerPkg.Get("gitlab")
+	if !ok {
+		t.Skip("gitlab provider not registered")
+	}
+
+	var posts atomic.Int32
+	score := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		posts.Add(1)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer score.Close()
+
+	defer func(pp bool, e, pf string, po bool) {
+		pushScore, scoreEndpoint, platformURL, printOutput = pp, e, pf, po
+	}(pushScore, scoreEndpoint, platformURL, printOutput)
+
+	t.Setenv("CI", "true")
+	t.Setenv("GITLAB_CI", "true")
+	t.Setenv("CI_PROJECT_PATH", "group/repo")
+	t.Setenv("CI_SERVER_URL", "https://gitlab.com")
+	t.Setenv(gitlabScoreTokenEnv, "tok")
+
+	conf := &configuration.Configuration{PlumberConfig: &configuration.PlumberConfig{}}
+	result := &control.AnalysisResult{ProjectPath: "group/repo", DefaultBranch: "main"}
+
+	t.Run("printOutput on: note prints, nudge does not, badge not hit", func(t *testing.T) {
+		pushScore, scoreEndpoint, platformURL, printOutput = true, score.URL, "https://platform.example.com/", true
+		scorePublishOnce = sync.Once{}
+
+		out := captureStderr(t, func() {
+			handleScorePublishing(p, conf, result, complianceSummary{}, []byte(`{"plumberScore":{"score":"A"}}`))
+		})
+
+		if !strings.Contains(out, "--score-push skipped") || !strings.Contains(out, "https://platform.example.com") {
+			t.Fatalf("expected the platform skip note naming the trimmed platform URL, got: %q", out)
+		}
+		if strings.Contains(out, "turn on score-push") {
+			t.Fatalf("the nudge must not print once --score-push is already on, got: %q", out)
+		}
+		if got := posts.Load(); got != 0 {
+			t.Fatalf("badge endpoint hit %d times, want 0: --platform must preempt the badge POST", got)
+		}
+	})
+
+	t.Run("printOutput off (--silent): note still prints, not silently dropped", func(t *testing.T) {
+		pushScore, scoreEndpoint, platformURL, printOutput = true, score.URL, "https://platform.example.com/", false
+		scorePublishOnce = sync.Once{}
+
+		out := captureStderr(t, func() {
+			handleScorePublishing(p, conf, result, complianceSummary{}, []byte(`{"plumberScore":{"score":"A"}}`))
+		})
+
+		if !strings.Contains(out, "--score-push skipped") {
+			t.Fatalf("the skip note must survive --silent (never silent is a hard rule), got: %q", out)
+		}
+		if got := posts.Load(); got != 0 {
+			t.Fatalf("badge endpoint hit %d times, want 0", got)
+		}
+	})
 }

--- a/control/scoring.go
+++ b/control/scoring.go
@@ -49,6 +49,11 @@ type PlumberScoreResult struct {
 
 	// RawPoints is 100 minus summed capped per-code losses (before Critical malus).
 	RawPoints float64 `json:"rawPoints"`
+	// RawPointsUnclamped is RawPoints before the floor at zero. RawPoints is
+	// what the gate and the badge are defined on, so it stays clamped; this
+	// carries the true signed deficit for consumers that store history and
+	// want to distinguish "barely failing" from "catastrophic".
+	RawPointsUnclamped float64 `json:"rawPointsUnclamped"`
 	// FinalPoints applies Critical category malus (max points in E band when any Critical exists).
 	FinalPoints float64 `json:"finalPoints"`
 	// Score is the letter A–E from final points (what people mean by "how did we score?").
@@ -252,6 +257,7 @@ func ComputePlumberScore(codeCounts map[ErrorCode]int) PlumberScoreResult {
 	}
 
 	raw := 100.0 - totalLoss
+	out.RawPointsUnclamped = raw
 	if raw < 0 {
 		raw = 0
 	}

--- a/control/scoring_test.go
+++ b/control/scoring_test.go
@@ -155,3 +155,30 @@ func TestScoreLetterFromPoints_boundaries(t *testing.T) {
 		}
 	}
 }
+
+// A project whose losses exceed 100 reports a floored rawPoints, because the
+// gate and the badge are defined on a 0-100 scale. The unclamped value is kept
+// alongside it so a consumer that wants the true depth of the deficit (the
+// platform) can read it without changing what the gate sees.
+func TestComputePlumberScore_KeepsUnclampedRawPoints(t *testing.T) {
+	counts := map[ErrorCode]int{}
+	// Enough critical findings to drive the summed capped loss well past 100.
+	// Use multiple distinct critical codes so losses stack.
+	counts[CodeDebugTraceEnabled] = 50
+	counts[CodeImpostorCommit] = 50
+	got := ComputePlumberScore(counts)
+
+	if got.RawPoints != 0 {
+		t.Errorf("RawPoints = %v, want 0 (clamped; the gate and badge must not change)", got.RawPoints)
+	}
+	if got.RawPointsUnclamped >= 0 {
+		t.Errorf("RawPointsUnclamped = %v, want a negative value carrying the true deficit", got.RawPointsUnclamped)
+	}
+	var summed float64
+	for _, cl := range got.CodeLosses {
+		summed += cl.CappedLoss
+	}
+	if want := 100.0 - summed; got.RawPointsUnclamped != want {
+		t.Errorf("RawPointsUnclamped = %v, want %v (100 minus summed capped losses)", got.RawPointsUnclamped, want)
+	}
+}

--- a/docs/FINGERPRINT.md
+++ b/docs/FINGERPRINT.md
@@ -34,7 +34,7 @@ The two sides never have to agree on a hash, only on the selection.
 
 ### The recipe version
 
-`identity.RecipeVersion` is currently **2**. Store it next to anything you key
+`identity.RecipeVersion` is currently **3**. Store it next to anything you key
 off the selection.
 
 It tracks identity **outcomes**, not just the code in the package, so it moves
@@ -60,6 +60,7 @@ signal.
 | --- | --- |
 | 1 | The recipe as first shipped. |
 | 2 | Eleven finding blocks that had no structured key, or that smuggled their subject through the `job` field, now name what they are about: ISSUE-401 (`hardcodedJob`), ISSUE-402 GitLab / ISSUE-403 / ISSUE-404 (`includePath`), ISSUE-405 / ISSUE-406 (`templatePath`), ISSUE-408 / ISSUE-409 (`componentPath`), ISSUE-417 (`requiredAction`), and ISSUE-501 / ISSUE-505 keep `branchName` while dropping `job`. Ten of the eleven also dropped `job`; ISSUE-401's `job` is a real job name and was kept. The algorithm is unchanged; their fingerprints are not. |
+| 3 | `file` is normalized to a repository-relative path before hashing. It was previously the collector's absolute path, so the same finding carried a different identity depending on whether it was scanned on a laptop or on a runner. Every finding whose file was recorded absolutely is re-keyed once. |
 
 The SARIF `partialFingerprints["plumber/v1"]` key is the name of that SARIF
 entry, not the recipe version. It stays at `v1` across bumps, because renaming

--- a/finding/identity/identity.go
+++ b/finding/identity/identity.go
@@ -72,7 +72,11 @@ import (
 //	       job, for the same reason: job held the branch name, not a job.
 //	   Ten of the eleven blocks lost job; only ISSUE-401 kept it. The
 //	   algorithm is unchanged; their fingerprints are not.
-const RecipeVersion = 2
+//	3  (2026-08-10): Finding.File is normalized to a repository-relative path
+//	   before hashing. It was the collector's absolute path, so the same finding
+//	   carried a different identity depending on whether it was scanned locally or
+//	   on a runner. Re-keys every finding whose file was recorded absolutely.
+const RecipeVersion = 3
 
 // fingerprintLength is how many hex characters of the digest the short
 // fingerprint keeps. 16 hex chars (64 bits) is short enough to read in a CSV

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/getplumber/plumber
 
 go 1.25.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/internal/engine/opa/engine.go
+++ b/internal/engine/opa/engine.go
@@ -14,6 +14,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"os"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -123,10 +125,55 @@ func computeFingerprint(f Finding) string {
 	return identity.Fingerprint(f.identityInput())
 }
 
-// StampFingerprints sets Fingerprint on every finding in place. Call it once,
-// after findings are finalized, so all output writers read the same value.
-func StampFingerprints(findings []Finding) {
+// repoRelative rewrites an absolute path recorded by a collector into a
+// repository-relative, forward-slashed one, relative to root. The GitHub
+// collector stores absolute paths rooted at the repository (not the
+// process's working directory — see StampFingerprints), and Finding.File is
+// one of the hashed identity segments, so leaving it raw makes the same
+// finding hash differently on a laptop and on a runner. Paths already
+// relative pass through unchanged. A path outside root (or an empty root) is
+// left alone: there is no correct relative form for it, and an unstable
+// identity is still better than a wrong path.
+func repoRelative(file, root string) string {
+	file = strings.TrimPrefix(file, "./")
+	if file == "" || !filepath.IsAbs(file) {
+		return filepath.ToSlash(file)
+	}
+	if root == "" {
+		return filepath.ToSlash(file)
+	}
+	rel, err := filepath.Rel(root, file)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return filepath.ToSlash(file)
+	}
+	return filepath.ToSlash(rel)
+}
+
+// StampFingerprints sets Fingerprint on every finding in place. Along the
+// way it also rewrites File in place to a repository-relative path (see
+// repoRelative), because the fingerprint is computed from the (possibly
+// just-rewritten) File — so both mutations are part of this call's contract,
+// not just the one named in the function's own name. Call it once, after
+// findings are finalized, so all output writers read the same File and
+// Fingerprint values.
+//
+// root is the repository root absolute File paths should be relativized
+// against. Pass the collector's own root (e.g. conf.GitRepoRoot) rather than
+// the process's current working directory: a collector that walks a
+// configured repo root (the GitHub collector walks conf.GitRepoRoot) keeps
+// recording paths relative to that root regardless of which subdirectory
+// Plumber was invoked from, and relativizing against os.Getwd() instead would
+// make the fingerprint depend on the invocation directory again — reopening
+// the machine-dependence problem this function exists to close. When root is
+// unknown, pass "" and StampFingerprints falls back to os.Getwd().
+func StampFingerprints(findings []Finding, root string) {
+	if root == "" {
+		if wd, err := os.Getwd(); err == nil {
+			root = wd
+		}
+	}
 	for i := range findings {
+		findings[i].File = repoRelative(findings[i].File, root)
 		findings[i].Fingerprint = computeFingerprint(findings[i])
 	}
 }

--- a/internal/engine/opa/fingerprint_test.go
+++ b/internal/engine/opa/fingerprint_test.go
@@ -2,6 +2,8 @@ package opa
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/getplumber/plumber/finding/identity"
@@ -23,7 +25,7 @@ func TestFingerprint_SurvivesTheJSONRoundTrip(t *testing.T) {
 		Message: "required template is missing",
 		Data:    map[string]any{"templatePath": "templates/go/go"},
 	}}
-	StampFingerprints(findings)
+	StampFingerprints(findings, "")
 	for _, f := range findings {
 		b, err := json.Marshal(f)
 		if err != nil {
@@ -176,12 +178,39 @@ func TestFingerprint_CodelessIsEmpty(t *testing.T) {
 	}
 }
 
+// A relative path whose first segment merely STARTS WITH ".." (e.g.
+// "..foo/bar.yml") is a legitimate in-repo path, not an escape above root. A
+// bare strings.HasPrefix(rel, "..") check misclassifies it as an escape and
+// leaves File (wrongly) absolute; the fix checks the ".." path SEGMENT
+// specifically.
+func TestRepoRelative_DoesNotMisclassifyDotDotPrefixedSegment(t *testing.T) {
+	root := filepath.FromSlash("/repo")
+	file := filepath.Join(root, "..foo", "bar.yml")
+
+	got := repoRelative(file, root)
+	if got != "..foo/bar.yml" {
+		t.Errorf("repoRelative(%q, %q) = %q, want %q (a legitimate in-repo path, not an escape)", file, root, got, "..foo/bar.yml")
+	}
+}
+
+// A genuine escape above root (the ".." segment itself, or a path continuing
+// through it) must still be rejected and left absolute.
+func TestRepoRelative_RejectsGenuineEscape(t *testing.T) {
+	root := filepath.FromSlash("/repo/sub")
+	file := filepath.FromSlash("/repo/outside.yml")
+
+	got := repoRelative(file, root)
+	if got != filepath.ToSlash(file) {
+		t.Errorf("repoRelative(%q, %q) = %q, want the original absolute path unchanged (genuine escape)", file, root, got)
+	}
+}
+
 func TestStampFingerprints_SetsFieldInPlace(t *testing.T) {
 	fs := []Finding{
 		{Code: "ISSUE-701", File: "ci.yml", Job: "build", Message: "x"},
 		{Code: "", Message: "codeless"},
 	}
-	StampFingerprints(fs)
+	StampFingerprints(fs, "")
 	if fs[0].Fingerprint == "" {
 		t.Errorf("StampFingerprints did not set a fingerprint on a coded finding")
 	}
@@ -190,5 +219,88 @@ func TestStampFingerprints_SetsFieldInPlace(t *testing.T) {
 	}
 	if fs[0].Fingerprint != computeFingerprint(fs[0]) {
 		t.Errorf("stamped fingerprint != computeFingerprint")
+	}
+}
+
+// The GitHub collector records absolute paths, and the path is one of the four
+// hashed identity segments. Left raw, the same finding fingerprints differently
+// on a laptop and on a runner, which makes it unusable as a database key.
+func TestStampFingerprints_NormalizesFileToRepoRelative(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings := []Finding{{
+		Code: "ISSUE-701",
+		File: filepath.Join(wd, ".github", "workflows", "ci.yml"),
+		Job:  "ci/build",
+		Data: map[string]any{"uses": "actions/checkout@v4"},
+	}}
+	StampFingerprints(findings, wd)
+
+	if got := findings[0].File; got != ".github/workflows/ci.yml" {
+		t.Errorf("File = %q, want the repo-relative path", got)
+	}
+}
+
+// Two runs of the same finding from different absolute roots must agree.
+func TestStampFingerprints_FingerprintIsRootIndependent(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mk := func(file, root string) string {
+		f := []Finding{{
+			Code: "ISSUE-701", File: file, Job: "ci/build",
+			Data: map[string]any{"uses": "actions/checkout@v4"},
+		}}
+		StampFingerprints(f, root)
+		return f[0].Fingerprint
+	}
+	inside := mk(filepath.Join(wd, ".github", "workflows", "ci.yml"), wd)
+	relative := mk(".github/workflows/ci.yml", wd)
+	if inside != relative {
+		t.Errorf("fingerprint depends on the absolute root: %q vs %q", inside, relative)
+	}
+}
+
+// The regression this guards: the previous implementation relativized every
+// File against os.Getwd() with no way to override it, but the GitHub
+// collector's absolute paths are rooted at conf.GitRepoRoot, not the
+// process's working directory. Running Plumber from a subdirectory of the
+// repo made filepath.Rel return a "../…" path, the escape guard rejected it,
+// and File (and therefore the fingerprint) stayed absolute and
+// machine-dependent — the exact defect RecipeVersion 3 claims to have fixed.
+// StampFingerprints now takes the repo root explicitly, so the SAME root
+// (not the caller's cwd) decides the relative path and the fingerprint no
+// longer depends on which directory Plumber was invoked from.
+func TestStampFingerprints_FingerprintStableFromSubdirectoryOfRepoRoot(t *testing.T) {
+	repoRoot := t.TempDir()
+	subDir := filepath.Join(repoRoot, "sub", "dir")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(repoRoot, ".github", "workflows", "ci.yml")
+
+	mk := func() string {
+		f := []Finding{{
+			Code: "ISSUE-701", File: file, Job: "ci/build",
+			Data: map[string]any{"uses": "actions/checkout@v4"},
+		}}
+		StampFingerprints(f, repoRoot)
+		if f[0].File != ".github/workflows/ci.yml" {
+			t.Errorf("File = %q, want the repo-relative path regardless of cwd", f[0].File)
+		}
+		return f[0].Fingerprint
+	}
+
+	t.Chdir(repoRoot)
+	atRoot := mk()
+
+	t.Chdir(subDir)
+	fromSubdir := mk()
+
+	if atRoot != fromSubdir {
+		t.Errorf("fingerprint depends on the working directory: %q (at repo root) vs %q (from a subdirectory)", atRoot, fromSubdir)
 	}
 }

--- a/internal/engine/opa/step_resolution_test.go
+++ b/internal/engine/opa/step_resolution_test.go
@@ -41,7 +41,7 @@ func TestEnrichFindingsWithJobLocation_ResolvesStepName(t *testing.T) {
 	}
 
 	// The point of resolving it: the two findings must not collide.
-	StampFingerprints(findings)
+	StampFingerprints(findings, "")
 	if findings[0].Fingerprint == findings[1].Fingerprint {
 		t.Errorf("both findings share fingerprint %q; step resolution failed to discriminate", findings[0].Fingerprint)
 	}

--- a/templates/plumber.yml
+++ b/templates/plumber.yml
@@ -98,6 +98,9 @@ spec:
     score_endpoint:
       description: "Score service base URL. Override only for a self-hosted score service; the OIDC audience follows this value so it always matches the target."
       default: "https://score.getplumber.io"
+    platform:
+      description: "Plumber platform base URL. Setting it pushes this run's full results there over CI OIDC, and takes precedence over score_push. The default is a placeholder (RFC 2606 .invalid) that never enables a push — GitLab requires the id_tokens audience to be non-empty, so this input cannot default to empty."
+      default: "https://platform.invalid"
     controls:
       description: Run only listed controls (comma-separated control names). Cannot be used with skip_controls.
       default: ""
@@ -162,6 +165,14 @@ spec:
     # push is a one-line change; the CLI only uses it when push is on.
     PLUMBER_ANALYZE_SCORE_TOKEN:
       aud: $[[ inputs.score_endpoint ]]
+    # OIDC id-token for the platform push. Audience MUST equal the platform
+    # URL (the platform validates `aud`), so it follows the platform input.
+    # Minted on every run, matching the score token above, using the same
+    # `platform` input that also carries the sentinel default — the CLI
+    # decides whether to push, not this block. The CLI treats the literal
+    # value "https://platform.invalid" as "not configured" and skips the push.
+    PLUMBER_ANALYZE_PLATFORM_TOKEN:
+      aud: $[[ inputs.platform ]]
   variables:
     # Use intermediate variable to avoid self-reference when default is $GITLAB_TOKEN
     # GITLAB_TOKEN is exported in script (not here) to avoid a circular variable
@@ -186,6 +197,11 @@ spec:
     PLUMBER_ANALYZE_SCORE_POINT: $[[ inputs.score_point ]]
     PLUMBER_ANALYZE_SCORE_PUSH: $[[ inputs.score_push ]]
     PLUMBER_ANALYZE_SCORE_ENDPOINT: $[[ inputs.score_endpoint ]]
+    # Non-empty (the sentinel default) on every run; the CLI is the one that
+    # decides whether that constitutes "configured" (see platformSentinelURL
+    # in cmd/platform_push.go), so this passthrough alone never turns the push
+    # on for everyone.
+    PLUMBER_ANALYZE_PLATFORM: $[[ inputs.platform ]]
     PLUMBER_ANALYZE_CONTROLS: $[[ inputs.controls ]]
     PLUMBER_ANALYZE_SKIP_CONTROLS: $[[ inputs.skip_controls ]]
     PLUMBER_ANALYZE_FAIL_WARNINGS: $[[ inputs.fail_warnings ]]


### PR DESCRIPTION
…policy

Closes #367 


> [!IMPORTANT]
> **Breaking: this PR bumps the finding-identity recipe (RecipeVersion 2 → 3) and re-keys findings.**
>
> Finding file paths are now normalized to repository-relative before the
> fingerprint is hashed (`repoRelative` in `internal/engine/opa/engine.go`), so
> the same finding no longer hashes differently on a laptop vs a CI runner.
> Consequence: **every finding recorded with an absolute path (all GitHub
> findings) gets a new fingerprint.** The platform stores fingerprints as issue
> identity, so this needs a **coordinated platform-side pin bump** — otherwise
> ingestion reads the re-keyed findings as old issues closing and new ones
> opening.
>
> Heads-up for planning: #411 bumps the recipe again (v3 → v4, per-code identity
> declarations), a second coordinated re-key. Same drill, one PR later.
