### PR TITLE
feat(ci): platform push restored to contract + policy_id keying + the gate block

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,24 @@ Display it with a badge in your README (swap in your platform/owner/repo):
 | Flag | Purpose |
 |---|---|
 | `--score-endpoint` | Score service base URL (default `https://score.getplumber.io`). Override only for a self-hosted score service. |
-| `--platform` | Plumber platform base URL. Setting it pushes this run's full results there over CI OIDC, and takes precedence over `--score-push`. Requires an id-token grant: `permissions: id-token: write` on GitHub, the component's `id_tokens:` block on GitLab. A platform that is down or unreachable warns and never changes the run's outcome. |
+| `--platform` | Plumber platform base URL. Setting it pushes this run's full results there over CI OIDC, and takes precedence over `--score-push`. Requires an id-token grant: `permissions: id-token: write` on GitHub, the component's `id_tokens:` block on GitLab. Results are automatically keyed to the platform's own policies (fetched via `/context`) when the local policy name matches one exactly; no match, and the push still succeeds by name alone. |
+
+The platform can gate the run: if it returns a blocking decision for this
+push, the job exits `1` with a line naming every blocking policy. A platform
+that is down, slow, or erroring **never blocks**: the gate only ever fails
+open, and the two sentences below are exact so you can alert on them:
+
+- `gate unavailable, letting through`: the platform itself is unreachable
+  (timeout, connection error, 5xx). The run proceeds.
+- `gate NOT RUN: authentication/configuration failed`: the request reached
+  the platform but was rejected (expired/invalid token, misconfigured
+  project). The run proceeds.
+
+A third, informational line is deliberately distinct from both, so alerts on
+the sentences above stay precise: `platform returned no gate verdict,
+letting through` means the push was accepted (2xx) but the response carried
+no usable gate decision - typically a platform version that predates the
+gate. Routine during a platform rollout; the run proceeds.
 
 ## Configuration
 

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -50,7 +50,7 @@ func runWithProvider(p provider.Provider, cmd *cobra.Command, conf *configuratio
 
 	jsonPayload := buildPublishPayload(p, conf, result, summary)
 	handleScorePublishing(p, conf, result, summary, jsonPayload)
-	platformErr := maybePushPlatform(p, conf, result, jsonPayload)
+	platformErr := maybePushPlatform(p, conf, result, summary.score)
 
 	pas := provider.PostActionSummary{
 		Passed:     summary.passed(),
@@ -248,7 +248,7 @@ func presentResultWithProvider(p provider.Provider, cmd *cobra.Command, result *
 	}
 	jsonPayload := buildPublishPayload(p, conf, result, summary)
 	handleScorePublishing(p, conf, result, summary, jsonPayload)
-	platformErr := maybePushPlatform(p, conf, result, jsonPayload)
+	platformErr := maybePushPlatform(p, conf, result, summary.score)
 	pas := provider.PostActionSummary{
 		Passed:     summary.passed(),
 		GateLine:   summary.gateLine(),
@@ -313,16 +313,17 @@ func computeScoreResult(result *control.AnalysisResult, scoreMode bool) *control
 	return &s
 }
 
-// buildPublishPayload builds the analysis JSON payload shared by the score
-// badge and the platform push, so the two destinations can never diverge on
-// what "the report" contains — both send the exact bytes buildAnalysisJSONReport
-// produced. Built once here (rather than separately inside each consumer) and
-// skipped (nil) when neither push is configured, so a plain local run pays no
+// buildPublishPayload builds the analysis JSON payload for the score badge
+// push (handleScorePublishing): the exact bytes buildAnalysisJSONReport
+// produced for --output, so the badge record and the file on disk can never
+// diverge. The platform push does NOT consume this payload — maybePushPlatform
+// builds its own structured envelope directly from result/conf/score — so the
+// gate below is scorePush alone; skipped (nil) when the badge push is not
+// configured, so a plain local run (or a --platform-only run) pays no
 // marshal/hash cost for a payload nobody sends.
 func buildPublishPayload(p provider.Provider, conf *configuration.Configuration, result *control.AnalysisResult, summary complianceSummary) []byte {
 	scorePush, _ := effectiveScorePush()
-	platformPush, _ := effectivePlatformPush()
-	if !scorePush && !platformPush {
+	if !scorePush {
 		return nil
 	}
 	var pc *configuration.PlumberConfig

--- a/cmd/gate_test.go
+++ b/cmd/gate_test.go
@@ -501,6 +501,41 @@ func TestBuildAnalysisJSONReport_GateContract(t *testing.T) {
 	})
 }
 
+// rawPointsUnclamped exists ONLY to be read out of the pushed report (the
+// platform stores score history and wants the true signed deficit), so its
+// presence in the serialized JSON is the contract — the struct field alone
+// proves nothing if a projection or an omitempty tag ever drops it from the
+// document. A negative fixture value also pins that the emitted number is the
+// unclamped one, not a copy of the floored rawPoints sitting next to it.
+func TestBuildAnalysisJSONReport_EmitsRawPointsUnclamped(t *testing.T) {
+	score := &control.PlumberScoreResult{RawPoints: 0, RawPointsUnclamped: -37.5, Score: "E"}
+	s := complianceSummary{minPoints: 100, score: score, scoreMode: true, controlCount: 1}
+
+	payload, err := buildAnalysisJSONReport(&control.AnalysisResult{CiValid: true}, confWithDebugTrace().PlumberConfig, s, jsonOutputParams{provider: "gitlab"})
+	if err != nil {
+		t.Fatalf("buildAnalysisJSONReport: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(payload, &m); err != nil {
+		t.Fatalf("report is not valid JSON: %v", err)
+	}
+
+	ps, ok := m["plumberScore"].(map[string]any)
+	if !ok {
+		t.Fatalf("plumberScore block missing from the report, got keys %v", m)
+	}
+	got, ok := ps["rawPointsUnclamped"]
+	if !ok {
+		t.Fatalf("rawPointsUnclamped missing from plumberScore: the platform's deficit-depth signal is gone, got %v", ps)
+	}
+	if got != -37.5 {
+		t.Errorf("rawPointsUnclamped = %v, want -37.5 (the unclamped value, not the floored rawPoints)", got)
+	}
+	if ps["rawPoints"] != 0.0 {
+		t.Errorf("rawPoints = %v, want 0: the clamped value next to it must stay floored", ps["rawPoints"])
+	}
+}
+
 // ---------------------------------------------------------------------------
 // finalizeRun — exit-code gate priority order
 // ---------------------------------------------------------------------------

--- a/cmd/platform_context.go
+++ b/cmd/platform_context.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/getplumber/plumber/configuration"
+	providerPkg "github.com/getplumber/plumber/provider"
+)
+
+// platformContextPolicy is one entry of the platform's /context resolved
+// policy set. Only id and name are consulted here (the exact-name match that
+// stamps policy_id); enforcement and every other field the platform may add
+// are left undecoded on purpose - /context is forward tolerant, and the CLI
+// has no use for the rest of the shape yet.
+type platformContextPolicy struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// platformContext is the platform's GET .../context response. snapshot
+// (data-collection info for control evaluation) is deliberately not decoded
+// here - this call site only needs the resolved policy set - so an unknown
+// or newer snapshot shape never breaks parsing.
+type platformContext struct {
+	Policies []platformContextPolicy `json:"policies"`
+}
+
+// fetchPlatformContext calls the platform's self-only /context endpoint for
+// this project (Bearer = the same OIDC token the push itself uses) and
+// returns its resolved policy set. Any non-2xx status or a body that does
+// not parse as JSON is returned as an error. Every caller treats every error
+// identically: no policy_id is stamped, one warning line is printed, and the
+// push proceeds name-only - /context is best-effort keying, never a
+// condition the run can fail on.
+//
+// projectPath is percent-escaped as a single path segment (url.PathEscape)
+// because it contains "/" (e.g. "org/repo") and the platform's route is
+// /projects/:project_path/context: an unescaped path would be split across
+// route segments by the platform's router instead of reaching the
+// project_path param whole.
+func fetchPlatformContext(endpoint, token, projectPath string) (*platformContext, error) {
+	target := endpoint + "/api/v1/projects/" + url.PathEscape(projectPath) + "/context"
+	req, err := http.NewRequest(http.MethodGet, target, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := (&http.Client{Timeout: scorePushHTTPTimeout}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("%s", resp.Status)
+	}
+	var ctx platformContext
+	if err := json.NewDecoder(resp.Body).Decode(&ctx); err != nil {
+		return nil, fmt.Errorf("decode /context response: %w", err)
+	}
+	return &ctx, nil
+}
+
+// matchPlatformContextPolicyID resolves the /context policy id for the
+// locally-derived policy name (platformPolicyNameFor). Matching is EXACT
+// name equality, case-sensitive: this mirrors the same key the platform's
+// own one-version name tolerance resolves on server-side, moved client-side
+// now that /context provides the authoritative list. Exactly one match is
+// required to stamp an id - zero or multiple matches return ok=false, and
+// the caller falls back to a name-only push (the platform's tolerance
+// covers it); guessing at an ambiguous match would risk mis-keying the push
+// to the wrong policy.
+func matchPlatformContextPolicyID(name string, policies []platformContextPolicy) (id string, ok bool) {
+	for _, p := range policies {
+		if p.Name != name {
+			continue
+		}
+		if ok {
+			return "", false // a second match: ambiguous, no id
+		}
+		id, ok = p.ID, true
+	}
+	return id, ok
+}
+
+// resolvePlatformPolicyID makes the run's (at most one) /context call and
+// returns the policy id to stamp, or "" when none was resolved. It never
+// returns an error: every failure mode (no resolvable project path,
+// transport error, non-2xx, unparseable body, no/ambiguous name match) is
+// handled here with a single informative line on stderr, and the push
+// always proceeds - /context is additive keying, not a gate.
+func resolvePlatformPolicyID(p providerPkg.Provider, conf *configuration.Configuration, endpoint, token, configPath string) string {
+	_, projectPath, ok := resolveScoreTarget(p, conf)
+	if !ok {
+		scoreWarn("could not resolve the project path for the platform /context lookup; pushing without a policy id")
+		return ""
+	}
+
+	ctx, err := fetchPlatformContext(endpoint, token, projectPath)
+	if err != nil {
+		scoreWarn(fmt.Sprintf("could not fetch the platform's policy set (%v); pushing without a policy id", err))
+		return ""
+	}
+
+	name := platformPolicyNameFor(configPath)
+	id, matched := matchPlatformContextPolicyID(name, ctx.Policies)
+	if !matched {
+		fmt.Fprintf(os.Stderr, "ℹ️  platform push: no single /context policy named %q; pushing without a policy id\n", name)
+		return ""
+	}
+	return id
+}

--- a/cmd/platform_context_test.go
+++ b/cmd/platform_context_test.go
@@ -1,0 +1,309 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/control"
+)
+
+// withPlatformContextTestEnv extends withPlatformTestEnv with CI_PROJECT_PATH
+// (GitLab's RepoPath env, read by resolveScoreTarget) and a pinned configFile,
+// so the derived policy name is deterministic ("default") and a /context call
+// has a project path to fetch for. Returns a restore func.
+func withPlatformContextTestEnv(t *testing.T, url, token, projectPath string) func() {
+	t.Helper()
+	restorePlatform := withPlatformTestEnv(t, url, token)
+	t.Setenv("CI_PROJECT_PATH", projectPath)
+	origConfigFile := configFile
+	configFile = ".plumber.yaml"
+	return func() {
+		configFile = origConfigFile
+		restorePlatform()
+	}
+}
+
+// platformTestServer serves both the push (POST /api/v1/pushes) and the
+// context (GET .../context) routes from one httptest.Server, matching the
+// single-server, two-endpoint shape a real platform push exercises in one
+// run. contextHandler may be nil to leave /context unhandled (a caller that
+// closes the server or wants a transport error typically does that instead).
+func platformTestServer(t *testing.T, contextHandler func(w http.ResponseWriter, r *http.Request), pushBody *[]byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.EscapedPath(), "/context") {
+			if contextHandler != nil {
+				contextHandler(w, r)
+				return
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		*pushBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+}
+
+// The happy path: /context returns a policy whose name matches the locally
+// derived name ("default", from the pinned .plumber.yaml), so the push body
+// carries results[].policy_id alongside the existing name-only policy string.
+func TestMaybePushPlatform_StampsPolicyIDOnExactNameMatch(t *testing.T) {
+	var gotPushBody []byte
+	var gotContextPath string
+	srv := platformTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotContextPath = r.URL.EscapedPath()
+		if auth := r.Header.Get("Authorization"); auth != "Bearer tok-123" {
+			t.Errorf("context request Authorization = %q, want the same bearer token as the push", auth)
+		}
+		_, _ = w.Write([]byte(`{"policies":[{"id":"11111111-2222-3333-4444-555555555555","name":"default","enforcement":"block"}],"snapshot":{}}`))
+	}, &gotPushBody)
+	defer srv.Close()
+
+	restore := withPlatformContextTestEnv(t, srv.URL, "tok-123", "org/repo")
+	defer restore()
+
+	conf := &configuration.Configuration{ConfigFilePath: ".plumber.yaml", PlumberConfig: testDefaultPlumberConfig(t)}
+	score := &control.PlumberScoreResult{Score: "B", RawPointsUnclamped: 82.5}
+	if err := maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, score); err != nil {
+		t.Fatalf("maybePushPlatform: %v", err)
+	}
+	if !strings.HasSuffix(gotContextPath, "/api/v1/projects/org%2Frepo/context") {
+		t.Errorf("context request path = %q, want the project path percent-escaped as a single segment", gotContextPath)
+	}
+
+	var push platformPush
+	if err := json.Unmarshal(gotPushBody, &push); err != nil {
+		t.Fatalf("push body does not decode as a platformPush: %v", err)
+	}
+	if len(push.Results) != 1 {
+		t.Fatalf("results = %d, want exactly 1: %s", len(push.Results), gotPushBody)
+	}
+	entry := push.Results[0]
+	if entry.PolicyID != "11111111-2222-3333-4444-555555555555" {
+		t.Errorf("policy_id = %q, want the /context uuid", entry.PolicyID)
+	}
+	if entry.Policy != "default" {
+		t.Errorf("policy = %q, want %q (unchanged by stamping)", entry.Policy, "default")
+	}
+
+	// The raw wire body must actually carry the key: a struct-level assertion
+	// alone would not catch a broken json tag.
+	if !strings.Contains(string(gotPushBody), `"policy_id":"11111111-2222-3333-4444-555555555555"`) {
+		t.Errorf("raw push body does not contain the policy_id key: %s", gotPushBody)
+	}
+}
+
+// No /context entry names the local policy ("default"): the key is omitted
+// from the wire entirely, not sent empty or zero.
+func TestMaybePushPlatform_NoMatchOmitsPolicyIDKey(t *testing.T) {
+	var gotPushBody []byte
+	srv := platformTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"policies":[{"id":"11111111-2222-3333-4444-555555555555","name":"strict","enforcement":"report"}]}`))
+	}, &gotPushBody)
+	defer srv.Close()
+
+	conf := &configuration.Configuration{ConfigFilePath: ".plumber.yaml", PlumberConfig: testDefaultPlumberConfig(t)}
+	score := &control.PlumberScoreResult{Score: "B", RawPointsUnclamped: 82.5}
+
+	out := captureStderr(t, func() {
+		restore := withPlatformContextTestEnv(t, srv.URL, "tok-123", "org/repo")
+		defer restore()
+
+		if err := maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, score); err != nil {
+			t.Fatalf("maybePushPlatform: %v", err)
+		}
+	})
+
+	if strings.Contains(string(gotPushBody), "policy_id") {
+		t.Errorf("push body contains policy_id with no /context match: %s", gotPushBody)
+	}
+	var push platformPush
+	if err := json.Unmarshal(gotPushBody, &push); err != nil {
+		t.Fatalf("push body does not decode as a platformPush: %v", err)
+	}
+	if push.Results[0].Policy != "default" {
+		t.Errorf("policy = %q, want %q: a no-match push stays name-only, never dropped", push.Results[0].Policy, "default")
+	}
+	if !strings.Contains(out, "default") {
+		t.Errorf("stderr = %q, want an informative line naming the unmatched policy", out)
+	}
+}
+
+// Ambiguous /context response (two entries with the same name): also no id,
+// same as zero matches - the platform's tolerance covers the name-only push,
+// guessing at ambiguity is worse than omitting.
+func TestMaybePushPlatform_AmbiguousMatchOmitsPolicyIDKey(t *testing.T) {
+	var gotPushBody []byte
+	srv := platformTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"policies":[
+			{"id":"11111111-2222-3333-4444-555555555555","name":"default","enforcement":"block"},
+			{"id":"66666666-7777-8888-9999-000000000000","name":"default","enforcement":"report"}
+		]}`))
+	}, &gotPushBody)
+	defer srv.Close()
+
+	restore := withPlatformContextTestEnv(t, srv.URL, "tok-123", "org/repo")
+	defer restore()
+
+	conf := &configuration.Configuration{ConfigFilePath: ".plumber.yaml", PlumberConfig: testDefaultPlumberConfig(t)}
+	score := &control.PlumberScoreResult{Score: "B", RawPointsUnclamped: 82.5}
+	if err := maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, score); err != nil {
+		t.Fatalf("maybePushPlatform: %v", err)
+	}
+	if strings.Contains(string(gotPushBody), "policy_id") {
+		t.Errorf("push body contains policy_id for an ambiguous /context match: %s", gotPushBody)
+	}
+}
+
+// Every failure mode of the /context call itself (5xx, transport/timeout,
+// 403, unparseable body) must never affect the run or the push: no id, one
+// warning, the push still succeeds name-only.
+func TestMaybePushPlatform_ContextFetchFailureFallsBackToNameOnly(t *testing.T) {
+	conf := &configuration.Configuration{ConfigFilePath: ".plumber.yaml", PlumberConfig: testDefaultPlumberConfig(t)}
+	score := &control.PlumberScoreResult{Score: "B", RawPointsUnclamped: 82.5}
+
+	t.Run("500", func(t *testing.T) {
+		var gotPushBody []byte
+		srv := platformTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}, &gotPushBody)
+		defer srv.Close()
+
+		var err error
+		out := captureStderr(t, func() {
+			restore := withPlatformContextTestEnv(t, srv.URL, "tok-123", "org/repo")
+			defer restore()
+			err = maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, score)
+		})
+		if err != nil {
+			t.Fatalf("maybePushPlatform: %v, want nil: a /context 500 must never fail the run", err)
+		}
+		if strings.Contains(string(gotPushBody), "policy_id") {
+			t.Errorf("push body contains policy_id despite a /context 500: %s", gotPushBody)
+		}
+		if len(gotPushBody) == 0 {
+			t.Error("push body is empty: the push must still proceed name-only after a /context failure")
+		}
+		if !strings.Contains(out, "⚠️") {
+			t.Errorf("stderr = %q, want a scoreWarn-style warning line", out)
+		}
+	})
+
+	t.Run("403", func(t *testing.T) {
+		var gotPushBody []byte
+		srv := platformTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}, &gotPushBody)
+		defer srv.Close()
+
+		var err error
+		out := captureStderr(t, func() {
+			restore := withPlatformContextTestEnv(t, srv.URL, "tok-123", "org/repo")
+			defer restore()
+			err = maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, score)
+		})
+		if err != nil {
+			t.Fatalf("maybePushPlatform: %v, want nil: a /context 403 must never fail the run", err)
+		}
+		if strings.Contains(string(gotPushBody), "policy_id") {
+			t.Errorf("push body contains policy_id despite a /context 403: %s", gotPushBody)
+		}
+		if len(gotPushBody) == 0 {
+			t.Error("push body is empty: the push must still proceed name-only after a /context 403")
+		}
+		if !strings.Contains(out, "⚠️") {
+			t.Errorf("stderr = %q, want a scoreWarn-style warning line", out)
+		}
+	})
+
+	t.Run("unreachable (transport error)", func(t *testing.T) {
+		// Start a server, learn its URL, then close it: nothing is listening,
+		// so any request (context GET or push POST) is a transport error.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		url := srv.URL
+		srv.Close()
+
+		var err error
+		out := captureStderr(t, func() {
+			restore := withPlatformContextTestEnv(t, url, "tok-123", "org/repo")
+			defer restore()
+			err = maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, score)
+		})
+		if err != nil {
+			t.Fatalf("maybePushPlatform: %v, want nil: an unreachable /context must never fail the run", err)
+		}
+		if !strings.Contains(out, "⚠️") {
+			t.Errorf("stderr = %q, want a scoreWarn-style warning line", out)
+		}
+	})
+
+	t.Run("unparseable body", func(t *testing.T) {
+		var gotPushBody []byte
+		srv := platformTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`not json`))
+		}, &gotPushBody)
+		defer srv.Close()
+
+		var err error
+		out := captureStderr(t, func() {
+			restore := withPlatformContextTestEnv(t, srv.URL, "tok-123", "org/repo")
+			defer restore()
+			err = maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, score)
+		})
+		if err != nil {
+			t.Fatalf("maybePushPlatform: %v, want nil: an unparseable /context body must never fail the run", err)
+		}
+		if strings.Contains(string(gotPushBody), "policy_id") {
+			t.Errorf("push body contains policy_id despite an unparseable /context body: %s", gotPushBody)
+		}
+		if !strings.Contains(out, "⚠️") {
+			t.Errorf("stderr = %q, want a scoreWarn-style warning line", out)
+		}
+	})
+}
+
+// The zero-uuid rule, pinned directly at the wire-shape level: a
+// platformPolicyResult with no resolved id must never serialize the literal
+// all-zero uuid, and must omit the key rather than emit it empty. This is
+// what makes "no match" and "no id resolved" structurally the same thing as
+// "policy_id was never set" - there is no code path that can fall back to a
+// zero-value uuid string.
+func TestPlatformPolicyResult_ZeroPolicyIDNeverEmitsAllZeroUUID(t *testing.T) {
+	body, err := json.Marshal(platformPolicyResult{Policy: "default"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(body), "00000000") {
+		t.Errorf("zero-value policy result carries an all-zero uuid on the wire: %s", body)
+	}
+	if strings.Contains(string(body), "policy_id") {
+		t.Errorf("zero-value policy result carries the policy_id key at all, want it omitted: %s", body)
+	}
+}
+
+// matchPlatformContextPolicyID is the matching primitive on its own, isolated
+// from the HTTP/env plumbing above.
+func TestMatchPlatformContextPolicyID(t *testing.T) {
+	policies := []platformContextPolicy{
+		{ID: "aaa", Name: "default"},
+		{ID: "bbb", Name: "strict"},
+	}
+	if id, ok := matchPlatformContextPolicyID("default", policies); !ok || id != "aaa" {
+		t.Errorf("exact match: id=%q ok=%v, want aaa/true", id, ok)
+	}
+	if _, ok := matchPlatformContextPolicyID("nonexistent", policies); ok {
+		t.Error("zero matches: ok=true, want false")
+	}
+	dup := []platformContextPolicy{{ID: "aaa", Name: "default"}, {ID: "bbb", Name: "default"}}
+	if _, ok := matchPlatformContextPolicyID("default", dup); ok {
+		t.Error("duplicate names: ok=true, want false (ambiguous)")
+	}
+	if _, ok := matchPlatformContextPolicyID("Default", policies); ok {
+		t.Error("case-insensitive match: ok=true, want false (exact match only)")
+	}
+}

--- a/cmd/platform_gate.go
+++ b/cmd/platform_gate.go
@@ -1,0 +1,211 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// platformGatePolicy is one policy's gate verdict, from the push response's
+// gate.policies array. All five fields are consulted: ID/Name/Enforcement
+// identify the policy, Blocking selects which entries name the run's
+// failure, LiveFailCount is what the job-log line reports for each one.
+type platformGatePolicy struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Enforcement   string `json:"enforcement"`
+	Blocking      bool   `json:"blocking"`
+	LiveFailCount int    `json:"live_fail_count"`
+}
+
+// platformGate is the push response's "gate" block: the platform's
+// post-push gate evaluation for this run. Evaluated false means the
+// platform deliberately did not render a verdict (e.g. nothing configured
+// to gate this project yet) - Reason then explains why, and the run
+// proceeds exactly like every other fail-open case.
+type platformGate struct {
+	Evaluated bool                 `json:"evaluated"`
+	Blocking  bool                 `json:"blocking"`
+	Reason    string               `json:"reason"`
+	Policies  []platformGatePolicy `json:"policies"`
+}
+
+// platformPushResponse is the shape decoded from a 2xx push response body.
+// Gate is a pointer so a response with no "gate" key at all (an old
+// platform that predates gate evaluation) is distinguishable from one that
+// evaluated the gate - see evaluatePlatformGate.
+type platformPushResponse struct {
+	Gate *platformGate `json:"gate"`
+}
+
+// PlatformGateError reports that the platform's post-push gate evaluation
+// blocked this run: one or more policies has live-monitoring failures the
+// operator configured as blocking. It is a verdict on the project, exactly
+// like ScoreGateError, not a program error - classifyExecError maps it to
+// the same exit code (1). Policies is already filtered to the blocking
+// subset of gate.policies.
+type PlatformGateError struct {
+	Reason   string
+	Policies []platformGatePolicy
+}
+
+func (e *PlatformGateError) Error() string {
+	// The same never-a-bare-colon guarantee as the job-log line (the shared
+	// platformGateDetail fallback chain): on a run that passes locally but is
+	// blocked by the platform, this string is the ONLY human-readable reason
+	// the operator sees (classifyExecError emits it at process exit while the
+	// terminal report still says PASSED), so it must always carry something.
+	msg := "platform gate blocked the run: " + platformGateDetail(e.Policies, e.Reason)
+	if len(e.Policies) > 0 && e.Reason != "" {
+		msg += " (" + e.Reason + ")"
+	}
+	return msg
+}
+
+// platformGateDetail is the shared fallback chain both output paths of a
+// gate block use (the job-log line in evaluatePlatformGate and
+// PlatformGateError.Error()): the blocking policies' descriptions, else the
+// gate's own reason, else an honest placeholder - never empty, so neither
+// path can ever end in a bare colon (the PR-review findings, both rounds).
+func platformGateDetail(policies []platformGatePolicy, reason string) string {
+	detail := strings.Join(platformGatePolicyDescriptions(policies), ", ")
+	if detail == "" {
+		detail = reason
+	}
+	if detail == "" {
+		detail = "the platform provided no policy detail"
+	}
+	return detail
+}
+
+// platformGatePolicyDescriptions renders "name (N live failures)" per
+// policy - the shared text both PlatformGateError.Error() and the job-log
+// line use, so the two can never drift apart.
+func platformGatePolicyDescriptions(policies []platformGatePolicy) []string {
+	out := make([]string, 0, len(policies))
+	for _, p := range policies {
+		out = append(out, fmt.Sprintf("%s (%d live failures)", p.Name, p.LiveFailCount))
+	}
+	return out
+}
+
+// evaluatePlatformGate parses a successful push response's gate block and
+// decides the platform-gate outcome for this run. Every fail-open path
+// prints exactly one line and returns nil - never an error - matching the
+// same "unavailable-class" sentence the transport/non-2xx failures use
+// (platformGateFailOpenLine), so an old platform that has never heard of
+// gates behaves identically to one that is temporarily down:
+//
+//   - a body that does not parse as JSON, or one that parses but carries no
+//     "gate" key at all: an old platform. Fail open with the unavailable
+//     line.
+//   - evaluated:false: the platform's own explicit fail-open (nothing
+//     configured to gate this project, a snapshot not yet collected,
+//     etc). Fail open, logging the platform's own reason.
+//   - blocking:false: nothing to do, the run proceeds.
+//   - blocking:true: a *PlatformGateError naming every blocking policy
+//     (gate.policies filtered to Blocking==true) is returned, and the
+//     same detail is printed to stderr here - the job-log line - so it
+//     reaches the operator regardless of what finalizeRun's precedence
+//     ultimately does with the returned error (a local score-gate failure
+//     outranks it and discards it as the *returned* error, but the line
+//     already reached the log).
+func evaluatePlatformGate(body []byte) error {
+	var resp platformPushResponse
+	if err := json.Unmarshal(body, &resp); err != nil || resp.Gate == nil {
+		// A 2xx-accepted push whose body carries no usable gate verdict: an
+		// older platform that predates the gate, or a mangled body. The
+		// platform is UP and the push LANDED, so this is the no-verdict
+		// line, never the alertable "unavailable" sentence (see the
+		// constants' doc comment below).
+		scoreWarn(platformGateNoVerdictLine)
+		return nil
+	}
+	gate := resp.Gate
+
+	if !gate.Evaluated {
+		msg := "platform gate not evaluated"
+		if gate.Reason != "" {
+			msg += ": " + gate.Reason
+		}
+		scoreWarn(msg)
+		return nil
+	}
+
+	if !gate.Blocking {
+		return nil
+	}
+
+	blocking := make([]platformGatePolicy, 0, len(gate.Policies))
+	for _, p := range gate.Policies {
+		if p.Blocking {
+			blocking = append(blocking, p)
+		}
+	}
+	// The job-log line names every blocking policy - but the top-level
+	// Blocking flag is the platform's decision and does not structurally
+	// guarantee a non-empty per-policy subset. When no entry is marked
+	// blocking (a future platform blocking for a run-level reason, or a
+	// shape this CLI predates), the line must still carry WHY:
+	// platformGateDetail falls back to gate.reason, then to an honest
+	// placeholder - never a bare "BLOCKED: " with nothing after the colon
+	// (PR-review finding).
+	fmt.Fprintf(os.Stderr, "✗ platform gate BLOCKED: %s\n", platformGateDetail(blocking, gate.Reason))
+	return &PlatformGateError{Reason: gate.Reason, Policies: blocking}
+}
+
+// The two EXACT fail-open sentences the spec requires (see
+// platformGateFailOpenLine's doc comment for the class boundary), plus the
+// informational no-verdict line. All three wordings are load-bearing - tests
+// assert these literal strings, and the README tells operators the first two
+// are stable enough to alert on - so they are named constants rather than
+// inlined at each call site.
+//
+// platformGateNoVerdictLine is deliberately NOT either alertable sentence: a
+// reachable platform that accepted the push (2xx) but returned no usable
+// gate verdict (an older platform that predates the gate, an unparseable
+// body, or a body that could not be read) is a routine rollout state, not an
+// outage and not a misconfiguration. Emitting the "unavailable" sentence
+// there would false-positive every alert built on it during a platform
+// upgrade window (the PR-review finding this constant exists to fix).
+const (
+	platformGateUnavailableLine = "gate unavailable, letting through"
+	platformGateNotRunLine      = "gate NOT RUN: authentication/configuration failed"
+	platformGateNoVerdictLine   = "platform returned no gate verdict, letting through"
+)
+
+// platformGateFailOpenLine classifies a failed push (non-2xx, transport, or
+// a 2xx whose body could not even be read) into its fail-open sentence, by
+// HTTP status code. statusCode is 0 for a transport-level failure (timeout,
+// DNS, connection refused) - no response was ever received, so the platform
+// is the thing that's unreachable, the same class as a 5xx.
+//
+//   - 0 (transport) or 5xx: the platform itself is unavailable - the CLI
+//     cannot know whether the run would have passed, so it lets through
+//     with the alertable "unavailable" sentence.
+//   - 2xx: the push was ACCEPTED and the token was fine; only the gate
+//     verdict is missing (the body could not be read). The platform is
+//     neither down nor misconfigured, so this is the informational
+//     no-verdict line - the same one evaluatePlatformGate emits for a
+//     2xx body without a gate key - keeping both alertable sentences
+//     precise (the PR-review finding).
+//   - 401/403/422: the request reached the platform but was rejected on
+//     authentication or configuration grounds (bad/expired token, project
+//     not recognized) - not a "the platform is down" condition, so it gets
+//     the NOT-RUN class instead.
+//   - any other 4xx (400 malformed request, 404 unknown route, 429 rate
+//     limited, ...): no dedicated bucket exists for these. The closest
+//     honest fit is still NOT-RUN - the request as sent was rejected, which
+//     reads closer to "misconfigured" than "platform is down" - flagged for
+//     Thomas in the PR body per the plan's global constraints rather than
+//     silently decided.
+func platformGateFailOpenLine(statusCode int) string {
+	if statusCode >= 200 && statusCode < 300 {
+		return platformGateNoVerdictLine
+	}
+	if statusCode == 0 || statusCode >= 500 {
+		return platformGateUnavailableLine
+	}
+	return platformGateNotRunLine
+}

--- a/cmd/platform_gate_test.go
+++ b/cmd/platform_gate_test.go
@@ -1,0 +1,410 @@
+package cmd
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/control"
+)
+
+// gatePushServer starts a server that answers every request (the push POST;
+// no /context call happens because these tests leave CI_PROJECT_PATH unset,
+// same as the existing platform_push_test.go fixtures) with the given status
+// and body.
+func gatePushServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		if body != "" {
+			_, _ = w.Write([]byte(body))
+		}
+	}))
+}
+
+func gateConf(t *testing.T) *configuration.Configuration {
+	t.Helper()
+	return &configuration.Configuration{ConfigFilePath: ".plumber.yaml", PlumberConfig: testDefaultPlumberConfig(t)}
+}
+
+// blocking:true must fail the run: a *PlatformGateError naming every
+// blocking policy, and the job-log line on stderr must name each blocking
+// policy together with its live_fail_count - the operator's only signal for
+// why the run was blocked.
+func TestMaybePushPlatform_GateBlockingFailsWithPolicyDetail(t *testing.T) {
+	srv := gatePushServer(t, http.StatusAccepted, `{"gate":{"evaluated":true,"blocking":true,"reason":"live failures exceed policy threshold","policies":[
+		{"id":"p1","name":"team-baseline","enforcement":"block","blocking":true,"live_fail_count":3},
+		{"id":"p2","name":"prod-images","enforcement":"block","blocking":true,"live_fail_count":1},
+		{"id":"p3","name":"advisory-only","enforcement":"report","blocking":false,"live_fail_count":9}
+	]}}`)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	var err error
+	out := captureStderr(t, func() {
+		err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+	})
+
+	var gateErr *PlatformGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("maybePushPlatform = %v (%T), want a *PlatformGateError", err, err)
+	}
+	if len(gateErr.Policies) != 2 {
+		t.Fatalf("PlatformGateError.Policies = %d entries, want exactly the 2 blocking ones: %+v", len(gateErr.Policies), gateErr.Policies)
+	}
+	for _, want := range []string{"team-baseline", "3", "prod-images", "1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stderr = %q, want it to name every blocking policy and its live_fail_count (missing %q)", out, want)
+		}
+	}
+	if strings.Contains(out, "advisory-only") {
+		t.Errorf("stderr = %q, want only the blocking policies named, not the report-only one", out)
+	}
+}
+
+// blocking:true with NO per-policy blocking entry (a future platform
+// blocking for a run-level reason, or an empty policies array): the run must
+// still exit 1 via a *PlatformGateError, and the job-log line must carry the
+// gate's reason - never a bare "BLOCKED: " with nothing after the colon
+// (the PR-review test-coverage finding: the top-level flag and the
+// per-policy subset are computed independently and can disagree).
+func TestMaybePushPlatform_GateBlockingWithoutPolicyDetailStillNamesTheReason(t *testing.T) {
+	srv := gatePushServer(t, http.StatusAccepted, `{"gate":{"evaluated":true,"blocking":true,"reason":"snapshot too stale to evaluate","policies":[
+		{"id":"p1","name":"team-baseline","enforcement":"block","blocking":false,"live_fail_count":0}
+	]}}`)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	var err error
+	out := captureStderr(t, func() {
+		err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+	})
+
+	var gateErr *PlatformGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("maybePushPlatform = %v (%T), want a *PlatformGateError: the top-level blocking flag decides", err, err)
+	}
+	if !strings.Contains(out, "platform gate BLOCKED: snapshot too stale to evaluate") {
+		t.Errorf("stderr = %q, want the gate's reason on the BLOCKED line when no policy is individually marked blocking", out)
+	}
+	if strings.Contains(out, "BLOCKED: \n") {
+		t.Errorf("stderr = %q, want never a bare BLOCKED line with nothing after the colon", out)
+	}
+}
+
+// PlatformGateError.Error() is the ONLY human-readable reason the operator
+// sees when the run passes locally but the platform blocks (Execute prints
+// it at process exit; the terminal report still says PASSED) - so it is
+// pinned directly, on both the detail path and the no-detail fallback
+// (the PR-review test-coverage finding, second round).
+func TestPlatformGateError_Error_NamesBlockingPolicies(t *testing.T) {
+	err := &PlatformGateError{
+		Reason: "live failures exceed threshold",
+		Policies: []platformGatePolicy{
+			{Name: "team-baseline", LiveFailCount: 3},
+			{Name: "prod-images", LiveFailCount: 1},
+		},
+	}
+	msg := err.Error()
+	for _, want := range []string{"team-baseline", "3", "prod-images", "1", "live failures exceed threshold"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("Error() = %q, want it to carry %q", msg, want)
+		}
+	}
+}
+
+func TestPlatformGateError_Error_NoDetailStaysHonest(t *testing.T) {
+	msg := (&PlatformGateError{}).Error()
+	if strings.HasSuffix(strings.TrimSpace(msg), ":") {
+		t.Errorf("Error() = %q, want never a bare trailing colon", msg)
+	}
+	if !strings.Contains(msg, "the platform provided no policy detail") {
+		t.Errorf("Error() = %q, want the honest no-detail placeholder (the same fallback as the job-log line)", msg)
+	}
+}
+
+// The same shape with NEITHER a blocking policy NOR a reason: the line still
+// says something honest rather than trailing off.
+func TestMaybePushPlatform_GateBlockingWithoutAnyDetailStaysHonest(t *testing.T) {
+	srv := gatePushServer(t, http.StatusAccepted, `{"gate":{"evaluated":true,"blocking":true,"policies":[]}}`)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	var err error
+	out := captureStderr(t, func() {
+		err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+	})
+	var gateErr *PlatformGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("maybePushPlatform = %v (%T), want a *PlatformGateError", err, err)
+	}
+	if !strings.Contains(out, "platform gate BLOCKED: the platform provided no policy detail") {
+		t.Errorf("stderr = %q, want the honest no-detail placeholder", out)
+	}
+}
+
+// blocking:false leaves the exit code alone.
+func TestMaybePushPlatform_GatePassingDoesNotFail(t *testing.T) {
+	srv := gatePushServer(t, http.StatusAccepted, `{"gate":{"evaluated":true,"blocking":false,"policies":[]}}`)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	if err := maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil); err != nil {
+		t.Fatalf("maybePushPlatform = %v, want nil: a non-blocking gate must not fail the run", err)
+	}
+}
+
+// evaluated:false is the platform's own explicit fail-open (e.g. nothing
+// configured to gate this project yet): the run proceeds, and the reason is
+// logged so the operator can see why no verdict was rendered.
+func TestMaybePushPlatform_GateNotEvaluatedFailsOpenWithReason(t *testing.T) {
+	srv := gatePushServer(t, http.StatusAccepted, `{"gate":{"evaluated":false,"reason":"no policy configured to gate this project"}}`)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	var err error
+	out := captureStderr(t, func() {
+		err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+	})
+	if err != nil {
+		t.Fatalf("maybePushPlatform = %v, want nil: evaluated:false must fail open", err)
+	}
+	if !strings.Contains(out, "no policy configured to gate this project") {
+		t.Errorf("stderr = %q, want the gate's reason logged", out)
+	}
+}
+
+// A 2xx response with no "gate" key at all (an old platform that predates
+// gate evaluation) must fail open with the distinct NO-VERDICT line - the
+// platform is up and the push landed, so emitting the alertable
+// "unavailable" sentence would false-positive every alert built on it
+// during a platform rollout (the PR-review finding). Never an error, and
+// never silently unexplained.
+func TestMaybePushPlatform_MissingGateKeyFailsOpenAsNoVerdict(t *testing.T) {
+	srv := gatePushServer(t, http.StatusAccepted, `{"ok":true}`)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	var err error
+	out := captureStderr(t, func() {
+		err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+	})
+	if err != nil {
+		t.Fatalf("maybePushPlatform = %v, want nil: a missing gate key must fail open", err)
+	}
+	if !strings.Contains(out, "platform returned no gate verdict, letting through") {
+		t.Errorf("stderr = %q, want the exact no-verdict sentence", out)
+	}
+	if strings.Contains(out, "gate unavailable, letting through") {
+		t.Errorf("stderr = %q, want NOT the alertable unavailable sentence on a healthy 2xx (the alerting contract)", out)
+	}
+}
+
+// An unparseable 2xx body is treated identically to a missing gate key: fail
+// open, the same no-verdict line, never an error.
+func TestMaybePushPlatform_UnparseableBodyFailsOpenAsNoVerdict(t *testing.T) {
+	srv := gatePushServer(t, http.StatusAccepted, `not json`)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	var err error
+	out := captureStderr(t, func() {
+		err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+	})
+	if err != nil {
+		t.Fatalf("maybePushPlatform = %v, want nil: an unparseable body must fail open", err)
+	}
+	if !strings.Contains(out, "platform returned no gate verdict, letting through") {
+		t.Errorf("stderr = %q, want the exact no-verdict sentence", out)
+	}
+	if strings.Contains(out, "gate unavailable, letting through") {
+		t.Errorf("stderr = %q, want NOT the alertable unavailable sentence on a healthy 2xx (the alerting contract)", out)
+	}
+}
+
+// The two class-distinguished fail-open sentences, pinned per failure class.
+// Every case must leave the exit code alone (err == nil).
+func TestMaybePushPlatform_ClassDistinguishedFailOpenSentences(t *testing.T) {
+	unavailable := "gate unavailable, letting through"
+	notRun := "gate NOT RUN: authentication/configuration failed"
+
+	tests := []struct {
+		name   string
+		status int
+		want   string
+	}{
+		{"401 unauthorized", http.StatusUnauthorized, notRun},
+		{"403 forbidden", http.StatusForbidden, notRun},
+		{"422 unprocessable", http.StatusUnprocessableEntity, notRun},
+		{"400 other 4xx (closest honest fit is NOT RUN)", http.StatusBadRequest, notRun},
+		{"404 other 4xx (closest honest fit is NOT RUN)", http.StatusNotFound, notRun},
+		{"500 internal server error", http.StatusInternalServerError, unavailable},
+		{"503 service unavailable", http.StatusServiceUnavailable, unavailable},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := gatePushServer(t, tc.status, "")
+			defer srv.Close()
+			restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+			defer restore()
+
+			var err error
+			out := captureStderr(t, func() {
+				err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+			})
+			if err != nil {
+				t.Fatalf("maybePushPlatform = %v, want nil: a remote push failure must never fail the run", err)
+			}
+			if !strings.Contains(out, tc.want) {
+				t.Errorf("status %d: stderr = %q, want the exact sentence %q", tc.status, out, tc.want)
+			}
+		})
+	}
+
+	t.Run("transport error (unreachable)", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		url := srv.URL
+		srv.Close() // nothing is listening now
+
+		restore := withPlatformTestEnv(t, url, "tok-123")
+		defer restore()
+
+		var err error
+		out := captureStderr(t, func() {
+			err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		})
+		if err != nil {
+			t.Fatalf("maybePushPlatform = %v, want nil: a transport failure must never fail the run", err)
+		}
+		if !strings.Contains(out, unavailable) {
+			t.Errorf("stderr = %q, want the exact sentence %q", out, unavailable)
+		}
+	})
+
+	// A 2xx means the push was accepted and the token was fine - this is
+	// never an auth/config problem, even though the body then failed to
+	// read (the connection dropped mid-response before the gate verdict
+	// could be decoded). And the platform is not DOWN either: it must get
+	// the distinct no-verdict line, keeping both alertable sentences
+	// precise (the PR-review finding).
+	t.Run("2xx with a body that fails to read", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("ResponseWriter does not support hijacking")
+			}
+			conn, buf, err := hj.Hijack()
+			if err != nil {
+				t.Fatalf("hijack: %v", err)
+			}
+			defer func() { _ = conn.Close() }()
+			// Declares a 100-byte body (so the 2xx status line is real and
+			// already sent) but only writes 5 bytes before the connection
+			// closes: the client's io.ReadAll(resp.Body) sees an
+			// unexpected EOF reading the declared-but-never-sent rest.
+			_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\nshort")
+			_ = buf.Flush()
+		}))
+		defer srv.Close()
+		restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+		defer restore()
+
+		var err error
+		out := captureStderr(t, func() {
+			err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		})
+		if err != nil {
+			t.Fatalf("maybePushPlatform = %v, want nil: a 2xx body-read failure must never fail the run", err)
+		}
+		if !strings.Contains(out, "platform returned no gate verdict, letting through") {
+			t.Errorf("stderr = %q, want the no-verdict sentence (a 2xx status must never classify as NOT-RUN or unavailable)", out)
+		}
+		if strings.Contains(out, notRun) {
+			t.Errorf("stderr = %q, want NOT the NOT-RUN sentence: a 2xx status means the push was accepted and the token was fine", out)
+		}
+		if strings.Contains(out, unavailable) {
+			t.Errorf("stderr = %q, want NOT the alertable unavailable sentence: the platform answered 2xx", out)
+		}
+	})
+}
+
+// The push-success line is unaffected by any of this: it stays exactly as
+// it was before the gate feature existed.
+func TestMaybePushPlatform_SuccessLineUnchangedOnPassingGate(t *testing.T) {
+	srv := gatePushServer(t, http.StatusAccepted, `{"gate":{"evaluated":true,"blocking":false}}`)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	out := captureStderr(t, func() {
+		if err := maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil); err != nil {
+			t.Fatalf("maybePushPlatform: %v", err)
+		}
+	})
+	if !strings.Contains(out, "✓ Results pushed to the platform:") {
+		t.Errorf("stderr = %q, want the unchanged push-success line", out)
+	}
+}
+
+// classifyExecError must map *PlatformGateError to the same exit code (1) as
+// a local score-gate failure: it is a verdict on the project, not a program
+// error. Unlike the local score gate, the terminal report never reflects a
+// platform block, so the reason must always be emitted, regardless of
+// --print.
+func TestClassifyExecError_PlatformGateError(t *testing.T) {
+	err := &PlatformGateError{Policies: []platformGatePolicy{{Name: "team-baseline", LiveFailCount: 3}}}
+	for _, printOutput := range []bool{true, false} {
+		prefix, code, emit := classifyExecError(err, printOutput)
+		if prefix != "Blocked" || code != 1 || !emit {
+			t.Errorf("classifyExecError(PlatformGateError, printOutput=%v) = (%q, %d, %v), want (Blocked, 1, true)", printOutput, prefix, code, emit)
+		}
+	}
+}
+
+// The precedence the plan fixes: a local score-gate failure and a platform
+// gate block can both occur on the same run. The local gate's error stays
+// primary (exit 1, same as before), but the platform gate's job-log line
+// must still have reached stderr - nothing about losing the precedence race
+// may swallow that message.
+func TestFinalizeRun_LocalGateAndPlatformGateBothPresent(t *testing.T) {
+	srv := gatePushServer(t, http.StatusAccepted, `{"gate":{"evaluated":true,"blocking":true,"policies":[
+		{"id":"p1","name":"team-baseline","enforcement":"block","blocking":true,"live_fail_count":3}
+	]}}`)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	var platformErr error
+	out := captureStderr(t, func() {
+		platformErr = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+	})
+	var gotGateErr *PlatformGateError
+	if !errors.As(platformErr, &gotGateErr) {
+		t.Fatalf("maybePushPlatform = %v, want a *PlatformGateError", platformErr)
+	}
+	if !strings.Contains(out, "team-baseline") || !strings.Contains(out, "3") {
+		t.Fatalf("stderr = %q, want the platform gate's job-log line naming team-baseline (3)", out)
+	}
+
+	failingGate := complianceSummary{minPoints: 100, score: scoreWithPoints(0), controlCount: 1}
+	result := &control.AnalysisResult{}
+	finalErr := finalizeRun(result, failingGate, platformErr)
+
+	var scoreErr *ScoreGateError
+	if !errors.As(finalErr, &scoreErr) {
+		t.Fatalf("finalizeRun = %v (%T), want the local *ScoreGateError to stay primary", finalErr, finalErr)
+	}
+	// Both messages are present: the local gate's message via the returned
+	// error (the primary exit reason), and the platform gate's job-log line
+	// already on stderr from the maybePushPlatform call above.
+}

--- a/cmd/platform_push.go
+++ b/cmd/platform_push.go
@@ -3,12 +3,15 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/getplumber/plumber/configuration"
 	"github.com/getplumber/plumber/control"
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
 	providerPkg "github.com/getplumber/plumber/provider"
 )
 
@@ -35,60 +38,146 @@ func effectivePlatformPush() (push bool, endpoint string) {
 	return endpoint != "", endpoint
 }
 
-// platformEnvelope is the body POSTed to the platform. It exists so the
-// analysis document can be pushed unchanged: everything the platform needs to
-// know that the document does not carry lives here, not in the report.
-//
-// results is an array from the first release even though local policy
-// resolution yields exactly one entry, because #368 makes it one entry per
-// policy. Growing it must not change the shape of anything else.
-type platformEnvelope struct {
-	SchemaVersion int              `json:"schemaVersion"`
-	Results       []platformResult `json:"results"`
+// The types below mirror the platform's ingestion.Push contract
+// (platform/backend/ingestion/contract.go in the monorepo) field-for-field:
+// same shape, same json tags, same optionality, snake_case throughout. That
+// file is the source of truth. A prior version of this file diverged from
+// it — results[].policy was sent as a {name,source,ref} object where the
+// contract declares a plain string — and every push was rejected by the real
+// parser (json.Unmarshal into a string field fails on an object) as a
+// result. See docs/platform-push-testing.md for how a push's raw wire bytes
+// are captured and checked against that contract shape, not just decoded
+// back into this package's own types.
+type platformPush struct {
+	SchemaVersion int                    `json:"schema_version"`
+	Provider      string                 `json:"provider,omitempty"`
+	Instance      string                 `json:"instance,omitempty"`
+	Project       platformProject        `json:"project"`
+	Ref           platformRef            `json:"ref"`
+	Pipeline      platformPipeline       `json:"pipeline"`
+	CLI           platformCLI            `json:"cli"`
+	Collection    platformCollectionMeta `json:"collection"`
+	// Results carries one entry per policy. Local policy resolution always
+	// yields exactly one; a multi-policy platform grows this array without
+	// changing the shape of anything else.
+	Results []platformPolicyResult `json:"results"`
 }
 
-// platformResult is one policy's verdict on this project.
-//
-// Degraded and DegradedReasons sit here rather than in the report because the
-// analysis JSON document carries no degradation signal at all: the flag reaches
-// SARIF (as invocations) and GitLab SAST (as scan.messages) and stops there.
-// Without them the platform would receive a partial scan and render it as a
-// complete one, with a score computed from missing data.
-type platformResult struct {
-	Policy          platformPolicy  `json:"policy"`
-	Degraded        bool            `json:"degraded"`
-	DegradedReasons []string        `json:"degradedReasons"`
-	Report          json.RawMessage `json:"report"`
+// platformProject is the informational project identity carried in the
+// body — NOT the authoritative one. The platform derives the authoritative
+// identity from the verified CI OIDC claims server-side (ADR-0003); this is
+// a convenience for display/search only.
+type platformProject struct {
+	Path string `json:"path,omitempty"`
+	ID   string `json:"id,omitempty"`
 }
 
-// platformPolicy identifies which policy produced the sibling report. Today
-// Source is either "local" (Ref names the .plumber.yaml file that was
-// actually read from disk) or "embedded" (the run used the config compiled
-// into the binary — a zero-config run, Ref empty, because no file was read
-// and claiming one would name a path that may not exist). Under #368 Source
-// also becomes "platform", with Name and Ref carrying what the platform
-// returned. A backend written against this keeps working across that change.
-type platformPolicy struct {
-	Name   string `json:"name"`
-	Source string `json:"source"`
-	Ref    string `json:"ref"`
+// platformRef is the analyzed git ref, read straight from the CI environment
+// (see platformRefFor). Tag is not populated by this build — the CLI has no
+// tag-pipeline source wired to this call site yet.
+type platformRef struct {
+	Branch string `json:"branch,omitempty"`
+	Tag    string `json:"tag,omitempty"`
+	SHA    string `json:"sha,omitempty"`
 }
 
-// platformPolicySourceLocal marks a policy descriptor whose Ref names a
-// .plumber.yaml file that was actually read from disk.
-const platformPolicySourceLocal = "local"
+// platformPipeline identifies the CI run that produced this push, read
+// straight from the CI environment (see platformPipelineFor). StartedAt is
+// not populated by this build (no CLI-side source for it yet).
+type platformPipeline struct {
+	ID        string `json:"id,omitempty"`
+	JobID     string `json:"job_id,omitempty"`
+	StartedAt string `json:"started_at,omitempty"`
+}
 
-// platformPolicySourceEmbedded marks a policy descriptor for a run that used
-// the config embedded in the binary (no .plumber.yaml on disk, no --config
-// pointing at a real file). Ref is empty in this case: the flag default
-// (".plumber.yaml") names no file that was actually read, and asserting it
-// as the descriptor's Ref would claim a local file that may not exist.
-const platformPolicySourceEmbedded = "embedded"
+// platformCLI carries the CLI version that produced the push. ComponentVersion
+// is not populated by this build — the GitLab component version is not
+// currently threaded through to the binary at this call site.
+type platformCLI struct {
+	Version          string `json:"version,omitempty"`
+	ComponentVersion string `json:"component_version,omitempty"`
+}
+
+// platformCollectionMeta is the honest degradation signal: whether data
+// collection was degraded this run. SnapshotCollectedAt is not populated —
+// the CLI has no snapshot concept yet. MissingFields is deliberately left
+// omitted too: result.DegradedReasons is human prose ("branch protection
+// could not be fetched (network or timeout)"), not the field-name list this
+// key expects, and forcing prose through it would misrepresent the contract
+// rather than honor it.
+type platformCollectionMeta struct {
+	Degraded            bool     `json:"degraded,omitempty"`
+	SnapshotCollectedAt string   `json:"snapshot_collected_at,omitempty"`
+	MissingFields       []string `json:"missing_fields,omitempty"`
+}
+
+// platformPolicyResult is one policy's verdict: what it ran (EffectiveConfig),
+// its explicit per-control findings, and the resulting score. Policy is a
+// plain string — the platform's contract has no name/source/ref object here
+// (a prior version of this file sent one; see the package doc above).
+type platformPolicyResult struct {
+	Policy string `json:"policy"`
+	// PolicyID is the /context-resolved uuid for Policy, when the run could
+	// resolve one (resolvePlatformPolicyID). A string, not a uuid type, and
+	// deliberately left "" rather than a placeholder when unresolved: with
+	// omitempty that means the key is genuinely absent from the wire, never
+	// present with a zero value — the CLI must never emit the literal
+	// all-zero uuid (see resolvePlatformPolicyID and
+	// matchPlatformContextPolicyID for how "" is reached).
+	PolicyID        string            `json:"policy_id,omitempty"`
+	EffectiveConfig json.RawMessage   `json:"effective_config,omitempty"`
+	Findings        []platformFinding `json:"findings"`
+	Score           platformScore     `json:"score"`
+}
+
+// platformFinding is one EXPLICIT per-control result entry — see
+// platformFindingsFor for how the list is built. A failed control
+// contributes one of these per underlying finding (Data populated); a
+// passed or not-evaluable control contributes exactly one with no Data.
+// Version/Requirement are not populated by this build (no CLI-side source
+// for either yet).
+type platformFinding struct {
+	Control     string          `json:"control"`
+	Version     string          `json:"version,omitempty"`
+	Requirement string          `json:"requirement,omitempty"`
+	Status      string          `json:"status"`
+	Data        json.RawMessage `json:"data,omitempty"`
+}
+
+// Finding-status vocabulary the platform's contract defines.
+// platformStatusNotEvaluable is never omitted for a degraded/could-not-
+// evaluate control — see platformFindingsFor.
+const (
+	platformStatusPass         = "pass"
+	platformStatusFail         = "fail"
+	platformStatusNotEvaluable = "not_evaluable"
+)
+
+// platformScore is the entry's Plumber Score. Points is
+// PlumberScoreResult.RawPointsUnclamped rounded to the nearest int — see
+// platformScoreFrom.
+type platformScore struct {
+	Letter string `json:"letter,omitempty"`
+	Points int    `json:"points"`
+}
+
+// platformScoreFrom converts the already-computed Plumber Score to the wire
+// shape. Points is RawPointsUnclamped — the SIGNED deficit with no floor at
+// zero (the contract stores it unclamped; the gate/badge's floored-at-zero
+// RawPoints is display-only) — rounded to the nearest int, matching what the
+// contract's Score.Points type actually is. Tolerates a nil score (no
+// production caller passes one today, but a best-effort push should never
+// panic a run over a nil pointer) by sending the zero value.
+func platformScoreFrom(score *control.PlumberScoreResult) platformScore {
+	if score == nil {
+		return platformScore{}
+	}
+	return platformScore{Letter: score.Score, Points: int(math.Round(score.RawPointsUnclamped))}
+}
 
 // policyNameFor derives a stable, human-meaningful policy name from the config
 // path: ".plumber.yaml" is the unnamed default, and any leading qualifier
-// ("team.plumber.yml", ".plumber.strict.yaml") names the policy. Under #368 the
-// platform supplies the name instead and this is not consulted.
+// ("team.plumber.yml", ".plumber.strict.yaml") names the policy.
 func policyNameFor(configPath string) string {
 	base := filepath.Base(strings.TrimSpace(configPath))
 	if base == "" || base == "." || base == string(filepath.Separator) {
@@ -108,54 +197,213 @@ func policyNameFor(configPath string) string {
 	}
 }
 
-// buildPlatformEnvelope wraps the analysis document for the platform. report
-// is embedded as json.RawMessage from the SAME buildAnalysisJSONReport call
-// that produced the --output file, so the two can never carry different DATA.
-// The bytes on the wire are not byte-identical to the --output file, though:
-// json.Marshal on the envelope re-serializes report compactly (as one field
-// nested inside a larger document) and HTML-escapes '<', '>', '&' in any
-// string values. That is intentional and left as-is — whitespace carries no
-// semantic meaning, and no real report contains those characters — but callers
-// must not assume the transmitted copy is a byte-for-byte match of the file.
-func buildPlatformEnvelope(report []byte, configPath string, degraded bool, reasons []string) ([]byte, error) {
-	if len(report) == 0 {
-		return nil, fmt.Errorf("empty analysis report")
+// platformPolicyNameFor is policyNameFor with one normalization on top:
+// builtinDefaultConfigSource ("built-in default") is the label
+// conf.ConfigFilePath carries for a zero-config run that read the config
+// embedded in the binary, not a real file — passing it to policyNameFor
+// unchanged would leak that internal sentinel string as the policy name
+// ("built-in default") instead of the clean "default" every other
+// zero-config path produces. Treated the same as an empty/unresolved path,
+// mirroring the special case the pre-contract-rework policy descriptor used
+// to apply (platformPolicyFor, since removed).
+func platformPolicyNameFor(configPath string) string {
+	if strings.TrimSpace(configPath) == builtinDefaultConfigSource {
+		return policyNameFor("")
 	}
-	if reasons == nil {
-		reasons = []string{}
+	return policyNameFor(configPath)
+}
+
+// buildPlatformPush builds the body POSTed to the platform, matching
+// ingestion.Push field-for-field (see the type doc comments above).
+// configPath is the resolved config path the caller computed
+// (conf.ConfigFilePath, falling back to the --config flag); it decides only
+// the policy NAME via platformPolicyNameFor. policyID is the /context-resolved
+// uuid for that name (resolvePlatformPolicyID), or "" when none was resolved;
+// it is threaded straight onto the single result entry's PolicyID field,
+// whose omitempty tag drops the key entirely when policyID is "".
+func buildPlatformPush(p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult, score *control.PlumberScoreResult, configPath, policyID string) ([]byte, error) {
+	forgeHost, projectPath, _ := resolveScoreTarget(p, conf)
+
+	var pc *configuration.PlumberConfig
+	var includeOnly, skip []string
+	if conf != nil {
+		pc = conf.PlumberConfig
+		includeOnly, skip = conf.ControlsFilter, conf.SkipControlsFilter
 	}
-	env := platformEnvelope{
+
+	push := platformPush{
 		SchemaVersion: 1,
-		Results: []platformResult{{
-			Policy:          platformPolicyFor(configPath),
-			Degraded:        degraded,
-			DegradedReasons: reasons,
-			Report:          json.RawMessage(report),
+		Provider:      p.Name(),
+		Instance:      forgeHost,
+		Project:       platformProject{Path: projectPath, ID: platformProjectID(p, conf)},
+		Ref:           platformRefFor(p),
+		Pipeline:      platformPipelineFor(p),
+		CLI:           platformCLI{Version: strings.TrimPrefix(Version, "v")},
+		Collection:    platformCollectionMeta{Degraded: result != nil && result.DataCollectionDegraded},
+		Results: []platformPolicyResult{{
+			Policy:          platformPolicyNameFor(configPath),
+			PolicyID:        policyID,
+			EffectiveConfig: platformEffectiveConfigRaw(pc),
+			Findings:        platformFindingsFor(p, result, pc, includeOnly, skip),
+			Score:           platformScoreFrom(score),
 		}},
 	}
-	body, err := json.Marshal(env)
+
+	body, err := json.Marshal(push)
 	if err != nil {
-		return nil, fmt.Errorf("marshal platform envelope: %w", err)
+		return nil, fmt.Errorf("marshal platform push: %w", err)
 	}
 	return body, nil
 }
 
-// platformPolicyFor derives the policy descriptor from the resolved config
-// path (the *configuration.Configuration's ConfigFilePath, see
-// maybePushPlatform). configPath is empty or equal to
-// builtinDefaultConfigSource ("built-in default", set by
-// loadEmbeddedDefaultConfig) exactly when the run never read a local
-// .plumber.yaml — the --config flag's own default is ".plumber.yaml"
-// regardless of whether that file exists, so it cannot be trusted to tell
-// the two cases apart. Only when a real file was read does the descriptor
-// claim "local" and carry its path; otherwise it claims "embedded" with no
-// Ref, so the descriptor never names a file that may not exist on disk.
-func platformPolicyFor(configPath string) platformPolicy {
-	ref := strings.TrimSpace(configPath)
-	if ref == "" || ref == builtinDefaultConfigSource {
-		return platformPolicy{Name: policyNameFor(""), Source: platformPolicySourceEmbedded, Ref: ""}
+// platformProjectID returns the project's stable numeric GitLab id when it is
+// cheaply available — conf.ProjectID, or the CI_PROJECT_ID env var GitLab CI
+// always exports — without an extra API round trip. GitHub has no equivalent
+// cheap numeric id at this call site, so this only ever returns non-empty for
+// a GitLab-shaped provider.
+func platformProjectID(p providerPkg.Provider, conf *configuration.Configuration) string {
+	if p.Name() == "github" {
+		return ""
 	}
-	return platformPolicy{Name: policyNameFor(ref), Source: platformPolicySourceLocal, Ref: ref}
+	if conf != nil && conf.ProjectID != 0 {
+		return strconv.Itoa(conf.ProjectID)
+	}
+	return strings.TrimSpace(os.Getenv("CI_PROJECT_ID"))
+}
+
+// platformRefFor reads the analyzed ref straight from the CI environment: the
+// running branch (ciRunBranch, already provider-aware) and the head commit
+// SHA via the provider's own CIEnvMapping (CI_COMMIT_SHA / GITHUB_SHA — the
+// same mapping resolveScoreTarget and the source-link builder use). Both are
+// "" outside CI; the omitempty tags on platformRef drop them rather than
+// sending a fabricated value.
+func platformRefFor(p providerPkg.Provider) platformRef {
+	return platformRef{
+		Branch: ciRunBranch(p),
+		SHA:    strings.TrimSpace(os.Getenv(p.CIEnvVars().CommitSHA)),
+	}
+}
+
+// platformPipelineFor reads the CI run's own identifiers straight from the
+// environment — GitLab's CI_PIPELINE_ID/CI_JOB_ID, GitHub's
+// GITHUB_RUN_ID/GITHUB_JOB. Never fabricated for a local run: both env vars
+// are simply unset there, and the omitempty tags drop them.
+func platformPipelineFor(p providerPkg.Provider) platformPipeline {
+	if p.Name() == "github" {
+		return platformPipeline{
+			ID:    strings.TrimSpace(os.Getenv("GITHUB_RUN_ID")),
+			JobID: strings.TrimSpace(os.Getenv("GITHUB_JOB")),
+		}
+	}
+	return platformPipeline{
+		ID:    strings.TrimSpace(os.Getenv("CI_PIPELINE_ID")),
+		JobID: strings.TrimSpace(os.Getenv("CI_JOB_ID")),
+	}
+}
+
+// platformEffectiveConfigRaw runs pc through buildPlumberConfigBlock — the
+// SAME builder the JSON report's plumberConfig block uses, so the platform
+// and the report describe this run's policy identically — and marshals it
+// for the wire. buildPlumberConfigBlock already falls back to the embedded
+// default when pc is nil or has no Raw, so this comes back empty only if
+// that builder itself ever does; the omitempty tag on EffectiveConfig then
+// drops it rather than sending "{}" or "null".
+func platformEffectiveConfigRaw(pc *configuration.PlumberConfig) json.RawMessage {
+	block := buildPlumberConfigBlock(pc)
+	if len(block) == 0 {
+		return nil
+	}
+	raw, err := json.Marshal(block)
+	if err != nil {
+		return nil
+	}
+	return raw
+}
+
+// platformFindingsFor builds the explicit-results findings list: one entry
+// per applicable control this run evaluated, reusing control.StatusFor — the
+// SAME four-state verdict (passed/failed/skipped/error) the --output JSON,
+// CSV and OCSF renderers already compute per control — rather than deriving
+// a second, possibly-diverging notion of "did this control pass" here.
+//
+//   - failed:  one entry PER underlying finding, status=fail, Data carrying
+//     that finding serialized exactly as opaengine.Finding.MarshalJSON
+//     already produces it.
+//   - passed:  one entry, status=pass, no Data.
+//   - error:   one entry, status=not_evaluable, no Data — NEVER omitted,
+//     because an empty findings list for a control that could not really be
+//     evaluated must not read as a silent pass.
+//   - skipped: OMITTED entirely. A control disabled in .plumber.yaml (or
+//     excluded via --controls/--skip-controls) is still visible in
+//     effective_config; "not evaluated by choice" is a different fact from
+//     "could not be evaluated" (not_evaluable), and folding them together
+//     would hide operator intent from the platform.
+//
+// includeOnly/skip are conf.ControlsFilter/SkipControlsFilter, applied via
+// control.MarkSkippedByFilter exactly as the terminal/JSON renderers do, so a
+// --skip-controls run's platform push agrees with what it printed.
+func platformFindingsFor(p providerPkg.Provider, result *control.AnalysisResult, pc *configuration.PlumberConfig, includeOnly, skip []string) []platformFinding {
+	out := []platformFinding{}
+	if pc == nil {
+		return out
+	}
+	entries := p.Controls(pc)
+	control.MarkSkippedByFilter(entries, includeOnly, skip)
+
+	var findings []opaengine.Finding
+	if result != nil {
+		findings = result.Findings
+	}
+	findingsByControl := control.FindingsByControl(findings)
+
+	for _, e := range entries {
+		fs := findingsByControl[e.ControlName]
+		switch control.StatusFor(e, result, len(fs)) {
+		case control.StatusSkipped:
+			continue
+		case control.StatusFailed:
+			for _, f := range fs {
+				out = append(out, platformFinding{
+					Control: platformFindingControlName(f),
+					Status:  platformStatusFail,
+					Data:    platformFindingDataRaw(f),
+				})
+			}
+		case control.StatusError:
+			out = append(out, platformFinding{Control: e.ControlName, Status: platformStatusNotEvaluable})
+		default: // control.StatusPassed
+			out = append(out, platformFinding{Control: e.ControlName, Status: platformStatusPass})
+		}
+	}
+	return out
+}
+
+// platformFindingControlName names a failed finding's control via the same
+// registry lookup FindingsByControl itself buckets by (control.LookupCode),
+// re-derived per finding rather than reused from the enclosing ControlEntry.
+// Falls back to the raw code string when the code has no registry entry —
+// never to the enclosing control's name, which would misattribute an
+// unclassified finding as belonging to it.
+func platformFindingControlName(f opaengine.Finding) string {
+	if info := control.LookupCode(control.ErrorCode(f.Code)); info != nil {
+		return info.ControlName
+	}
+	return f.Code
+}
+
+// platformFindingDataRaw serializes f exactly as opaengine.Finding.MarshalJSON
+// already produces it (code/severity/message/job/file/line/url/fingerprint +
+// Data keys, existing casing) — the flat shape the platform's finding
+// vocabulary is built to consume, not re-shaped or re-cased here. Marshal
+// only fails for a JSON-incompatible value inside f.Data (a channel, a
+// function), which Rego cannot produce; nil (omitted) is the safe fallback
+// if it ever did.
+func platformFindingDataRaw(f opaengine.Finding) json.RawMessage {
+	raw, err := json.Marshal(f)
+	if err != nil {
+		return nil
+	}
+	return raw
 }
 
 // PlatformTokenError reports that the run could not obtain the CI OIDC
@@ -185,17 +433,18 @@ func platformTokenFailure(reason string) error {
 }
 
 // maybePushPlatform pushes the analysis result to the configured platform.
-// It returns non-nil ONLY for a token failure; see PlatformTokenError. conf's
-// only use here is resolving which config file (if any) produced this run's
-// policy — for the platform record's policy descriptor — via
-// conf.ConfigFilePath, the RESOLVED path set once at load time (falling back
-// to the --config flag when conf is nil or the field is empty, e.g. in tests
-// that construct the payload directly). Project identity for the platform
-// record is a separate matter and still comes from the verified OIDC claims
-// server-side, never from operator-supplied config.
-func maybePushPlatform(p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult, payload []byte) error {
+// It returns non-nil ONLY for a token failure; see PlatformTokenError. conf
+// supplies the resolved config path/PlumberConfig/ProjectID/control filters
+// buildPlatformPush needs (falling back to the --config flag when conf is
+// nil or has no resolved path, e.g. in tests that call this directly);
+// result and score are threaded straight through so the platform, the
+// terminal banner and the JSON report can never disagree about a run's
+// findings or score. Project identity for the platform record is a separate
+// matter and still comes from the verified OIDC claims server-side, never
+// from operator-supplied config.
+func maybePushPlatform(p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult, score *control.PlumberScoreResult) error {
 	push, endpoint := effectivePlatformPush()
-	if !push || len(payload) == 0 {
+	if !push {
 		return nil
 	}
 
@@ -227,7 +476,8 @@ func maybePushPlatform(p providerPkg.Provider, conf *configuration.Configuration
 			configPath = resolved
 		}
 	}
-	body, err := buildPlatformEnvelope(payload, configPath, result.DataCollectionDegraded, result.DegradedReasons)
+	policyID := resolvePlatformPolicyID(p, conf, endpoint, token, configPath)
+	body, err := buildPlatformPush(p, conf, result, score, configPath, policyID)
 	if err != nil {
 		scoreWarn(fmt.Sprintf("platform push skipped: %v", err))
 		return nil
@@ -236,11 +486,15 @@ func maybePushPlatform(p providerPkg.Provider, conf *configuration.Configuration
 	// Every remote condition lands here, including 413 for an oversized body:
 	// the server is the authority on its own limit, so the CLI enforces none.
 	// The push is skipped whole rather than truncated, because the platform
-	// renders the record as the complete picture.
-	if err := postScoreReport(endpoint+"/api/v1/results", token, body); err != nil {
-		scoreWarn(fmt.Sprintf("platform push failed: %v", err))
+	// renders the record as the complete picture. On failure this is also
+	// the gate deadline: the same 15s transport timeout (scorePushHTTPTimeout)
+	// bounds both the push and the gate verdict it carries, so no separate
+	// gate timeout knob exists.
+	respBody, statusCode, err := postScoreReportForBody(endpoint+"/api/v1/pushes", token, body)
+	if err != nil {
+		scoreWarn(fmt.Sprintf("%s: %v", platformGateFailOpenLine(statusCode), err))
 		return nil
 	}
 	fmt.Fprintf(os.Stderr, "✓ Results pushed to the platform: %s\n", endpoint)
-	return nil
+	return evaluatePlatformGate(respBody)
 }

--- a/cmd/platform_push_test.go
+++ b/cmd/platform_push_test.go
@@ -8,12 +8,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/getplumber/plumber/configuration"
 	"github.com/getplumber/plumber/control"
+	defaultconfig "github.com/getplumber/plumber/defaultConfig"
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
 	providerPkg "github.com/getplumber/plumber/provider"
 )
 
@@ -84,13 +85,34 @@ func TestEffectiveScorePush_YieldsToPlatform(t *testing.T) {
 	}
 }
 
-// buildPublishPayload is the single gate deciding whether a payload exists for
-// BOTH publish paths — every maybePushPlatform/handleScorePublishing test
-// injects a payload directly, so only this test would catch a narrowed gate
-// (e.g. dropping the platformPush term): a --platform-only run would then get
-// nil and maybePushPlatform would silently do nothing, with the suite green.
-// Also pins that the bytes ARE buildAnalysisJSONReport's output, the
-// no-divergence promise in the doc comment.
+// The GitLab CI component wires PLUMBER_ANALYZE_PLATFORM to the sentinel
+// (https://platform.invalid) on EVERY run — it cannot default to empty because
+// an empty id_tokens audience is a template error. So a user who wants only the
+// badge push runs with pushScore=true AND platformURL=platformSentinelURL. The
+// sentinel is treated as "not configured", so it must NOT preempt the badge:
+// effectiveScorePush() has to still return true. This is the real every-run
+// GitLab-component configuration, and a regression that stopped special-casing
+// the sentinel would silently disable the badge for every such user.
+func TestEffectiveScorePush_SentinelDoesNotPreemptBadge(t *testing.T) {
+	origP, origS := platformURL, pushScore
+	defer func() { platformURL, pushScore = origP, origS }()
+
+	platformURL, pushScore = platformSentinelURL, true
+	if push, _ := effectiveScorePush(); !push {
+		t.Errorf("badge push = false with pushScore=true and platformURL=%q (the sentinel), want true: the sentinel must not preempt the badge", platformSentinelURL)
+	}
+	// And the sentinel must not itself enable a platform push.
+	if push, _ := effectivePlatformPush(); push {
+		t.Errorf("platform push = true for the sentinel %q, want false", platformSentinelURL)
+	}
+}
+
+// buildPublishPayload gates on scorePush alone: maybePushPlatform builds its
+// own structured push directly from result/conf/score (see buildPlatformPush)
+// and never reads this payload, so a --platform-only run must NOT pay the
+// marshal cost, while a --score-push run must still get the exact bytes the
+// badge always got. Also pins that those bytes ARE buildAnalysisJSONReport's
+// output, the no-divergence promise in the doc comment.
 func TestBuildPublishPayload_GateAndBytes(t *testing.T) {
 	origP, origS := platformURL, pushScore
 	defer func() { platformURL, pushScore = origP, origS }()
@@ -101,11 +123,11 @@ func TestBuildPublishPayload_GateAndBytes(t *testing.T) {
 	conf.PlumberConfig = &configuration.PlumberConfig{}
 	summary := complianceSummary{minPoints: 100, score: scoreWithPoints(100), scoreMode: true, controlCount: 1}
 
-	t.Run("platform-only run gets the exact report bytes", func(t *testing.T) {
-		platformURL, pushScore = "https://app.example.com", false
+	t.Run("badge-only run gets the exact report bytes", func(t *testing.T) {
+		platformURL, pushScore = "", true
 		payload := buildPublishPayload(prov, conf, result, summary)
 		if payload == nil {
-			t.Fatal("payload = nil for a --platform-only run: the platform push would silently never happen")
+			t.Fatal("payload = nil for a --score-push-only run: the badge push would silently never happen")
 		}
 		want, err := buildAnalysisJSONReport(result, conf.PlumberConfig, summary, jsonOutputParams{
 			provider: prov.Name(), includeOnly: conf.ControlsFilter, skip: conf.SkipControlsFilter,
@@ -118,10 +140,10 @@ func TestBuildPublishPayload_GateAndBytes(t *testing.T) {
 		}
 	})
 
-	t.Run("badge-only run gets a payload", func(t *testing.T) {
-		platformURL, pushScore = "", true
-		if buildPublishPayload(prov, conf, result, summary) == nil {
-			t.Fatal("payload = nil for a --score-push-only run: the badge push would silently never happen")
+	t.Run("platform-only run does not pay the marshal cost", func(t *testing.T) {
+		platformURL, pushScore = "https://app.example.com", false
+		if payload := buildPublishPayload(prov, conf, result, summary); payload != nil {
+			t.Errorf("payload = %d bytes for a --platform-only run, want nil: maybePushPlatform builds its own push and never reads this payload", len(payload))
 		}
 	})
 
@@ -140,188 +162,85 @@ func TestBuildPublishPayload_GateAndBytes(t *testing.T) {
 	})
 }
 
-// The report is embedded with the same DATA the file on disk gets: one
-// builder (buildAnalysisJSONReport) feeds both, so the two cannot drift.
-// json.Marshal on the envelope re-serializes report compactly (it is nested
-// inside a larger document) and would HTML-escape '<', '>', '&' — that is
-// accepted and intentional (see buildPlatformEnvelope's doc comment), so this
-// deliberately asserts semantic equality, not byte equality. The fixture is
-// indented, multi-line, and carries a unicode character so a naive compact-ASCII
-// fixture couldn't have masked a real mutation.
-func TestBuildPlatformEnvelope_EmbedsTheReportUnchanged(t *testing.T) {
-	report := []byte(`{
-  "projectPath": "org/repo",
-  "plumberScore": {
-    "score": "B"
-  },
-  "note": "café — pipeline ok"
-}`)
-
-	body, err := buildPlatformEnvelope(report, ".plumber.yaml", false, nil)
+// The platform parses schema_version and a plain-string results[].policy; a
+// prior version of this file sent schemaVersion (silently reads as the zero
+// value, 422s) and results[].policy as a {name,source,ref} object
+// (json.Unmarshal into ingestion.PolicyResult.Policy, a string, fails
+// outright). Decoding into platformPush would not catch either regression on
+// its own — a reverted json tag or field type still decodes cleanly into its
+// own (reverted) Go type — so this asserts the raw wire bytes instead, the
+// only way these failure modes, being silent or type-safe-in-isolation, are
+// actually caught.
+func TestBuildPlatformPush_KeysAreSnakeCaseAndPolicyIsAString(t *testing.T) {
+	body, err := buildPlatformPush(testProvider(t), nil, nil, nil, ".plumber.yaml", "")
 	if err != nil {
-		t.Fatalf("buildPlatformEnvelope: %v", err)
+		t.Fatalf("buildPlatformPush: %v", err)
 	}
-	var env platformEnvelope
-	if err := json.Unmarshal(body, &env); err != nil {
-		t.Fatalf("envelope does not round-trip: %v", err)
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("push does not parse as JSON: %v", err)
 	}
-	if env.SchemaVersion != 1 {
-		t.Errorf("schemaVersion = %d, want 1", env.SchemaVersion)
+	if v, ok := raw["schema_version"]; !ok || v != float64(1) {
+		t.Errorf("schema_version = %v (present=%v), want 1", v, ok)
 	}
-	if len(env.Results) != 1 {
-		t.Fatalf("results = %d, want exactly 1 while policy resolution is local", len(env.Results))
+	if _, ok := raw["schemaVersion"]; ok {
+		t.Error("schemaVersion is present on the wire: the platform reads schema_version only, and this silently 422s")
 	}
 
-	var want, got any
-	if err := json.Unmarshal(report, &want); err != nil {
-		t.Fatalf("fixture does not parse as JSON: %v", err)
+	results, _ := raw["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("results = %v, want exactly 1 entry", raw["results"])
 	}
-	if err := json.Unmarshal(env.Results[0].Report, &got); err != nil {
-		t.Fatalf("embedded report does not parse as JSON: %v", err)
+	entry, _ := results[0].(map[string]any)
+	policy, ok := entry["policy"]
+	if !ok {
+		t.Fatal("policy is missing on the entry")
 	}
-	if !reflect.DeepEqual(want, got) {
-		t.Errorf("embedded report is not semantically equal to the input:\n got %#v\nwant %#v", got, want)
+	if _, isString := policy.(string); !isString {
+		t.Errorf("policy = %#v (type %T), want a plain string: the contract's PolicyResult.Policy is `json:\"policy\"` string, not an object", policy, policy)
 	}
-}
-
-// The descriptor is per entry, not envelope-level, so #368 grows the array
-// without changing the shape.
-func TestBuildPlatformEnvelope_CarriesThePolicyDescriptor(t *testing.T) {
-	body, err := buildPlatformEnvelope([]byte(`{}`), "config/.plumber.strict.yaml", false, nil)
-	if err != nil {
-		t.Fatalf("buildPlatformEnvelope: %v", err)
+	if findingsVal, ok := entry["findings"]; !ok || findingsVal == nil {
+		t.Errorf("findings = %v, want an empty array (not null/absent) when no PlumberConfig is available to enumerate controls", findingsVal)
 	}
-	var env platformEnvelope
-	if err := json.Unmarshal(body, &env); err != nil {
-		t.Fatal(err)
+	if _, ok := entry["effective_config"]; !ok {
+		t.Error("effective_config is missing: buildPlumberConfigBlock falls back to the embedded default even with a nil PlumberConfig")
 	}
-	p := env.Results[0].Policy
-	if p.Source != "local" {
-		t.Errorf("policy.source = %q, want %q while the policy is a local file", p.Source, "local")
-	}
-	if p.Ref != "config/.plumber.strict.yaml" {
-		t.Errorf("policy.ref = %q, want the config path as given", p.Ref)
-	}
-	if p.Name != "strict" {
-		t.Errorf("policy.name = %q, want %q", p.Name, "strict")
-	}
-}
-
-// The bug this guards: a zero-config run never reads a .plumber.yaml file —
-// it loads the config embedded in the binary (loadEmbeddedDefaultConfig) —
-// but the --config flag still carries its own default (".plumber.yaml"),
-// which names no file that was actually read and may not even exist on
-// disk. builtinDefaultConfigSource is what conf.ConfigFilePath holds in that
-// case; the descriptor must not claim "local" for it. An empty configPath
-// (no resolved path known at all) gets the same treatment: safer to say
-// "not a local file" than to guess ".plumber.yaml".
-func TestBuildPlatformEnvelope_EmbeddedDefaultDoesNotClaimALocalFile(t *testing.T) {
-	for _, configPath := range []string{builtinDefaultConfigSource, "", "   "} {
-		body, err := buildPlatformEnvelope([]byte(`{}`), configPath, false, nil)
-		if err != nil {
-			t.Fatalf("buildPlatformEnvelope(%q): %v", configPath, err)
-		}
-		var env platformEnvelope
-		if err := json.Unmarshal(body, &env); err != nil {
-			t.Fatal(err)
-		}
-		p := env.Results[0].Policy
-		if p.Source != platformPolicySourceEmbedded {
-			t.Errorf("configPath=%q: policy.source = %q, want %q", configPath, p.Source, platformPolicySourceEmbedded)
-		}
-		if p.Ref != "" {
-			t.Errorf("configPath=%q: policy.ref = %q, want empty — no local file was read", configPath, p.Ref)
-		}
-		if p.Name != "default" {
-			t.Errorf("configPath=%q: policy.name = %q, want %q", configPath, p.Name, "default")
+	for _, obj := range []string{"project", "ref", "pipeline", "cli", "collection"} {
+		if _, ok := raw[obj]; !ok {
+			t.Errorf("%s is missing on the push (the contract has no omitempty on struct-typed top-level fields)", obj)
 		}
 	}
 }
 
-// maybePushPlatform must describe the config that was ACTUALLY loaded —
-// conf.ConfigFilePath, resolved once at load time (cmd/analyze_gitlab.go,
-// cmd/analyze_github.go) — not the raw --config flag value: the flag
-// defaults to ".plumber.yaml" whether or not that file exists, so using it
-// directly (the pre-fix behavior) claimed a local file even on a zero-config
-// run that read the embedded default instead.
-func TestMaybePushPlatform_DescriptorUsesResolvedConfigPathFromConf(t *testing.T) {
-	var gotBody []byte
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotBody, _ = io.ReadAll(r.Body)
-		w.WriteHeader(http.StatusAccepted)
-	}))
-	defer srv.Close()
-	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
-	defer restore()
-
-	// The --config flag still carries its unrelated default; conf.ConfigFilePath
-	// is what the run actually resolved, and must win.
-	origConfigFile := configFile
-	configFile = ".plumber.yaml"
-	defer func() { configFile = origConfigFile }()
-
-	conf := &configuration.Configuration{ConfigFilePath: builtinDefaultConfigSource}
-	if err := maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, []byte(`{}`)); err != nil {
-		t.Fatalf("maybePushPlatform: %v", err)
-	}
-	var env platformEnvelope
-	if err := json.Unmarshal(gotBody, &env); err != nil {
-		t.Fatal(err)
-	}
-	p := env.Results[0].Policy
-	if p.Source != platformPolicySourceEmbedded || p.Ref != "" {
-		t.Errorf("policy = %+v, want the embedded-default descriptor (source=%q, ref=\"\") even though --config defaults to %q", p, platformPolicySourceEmbedded, configFile)
-	}
-}
-
-// When conf carries no resolved path (nil conf, or an empty
-// ConfigFilePath, as in tests that build the payload directly), the
-// --config flag is still consulted as a fallback so the descriptor is never
-// simply blank for a run that DID read a real file.
-func TestMaybePushPlatform_FallsBackToConfigFlagWhenConfHasNoPath(t *testing.T) {
-	var gotBody []byte
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotBody, _ = io.ReadAll(r.Body)
-		w.WriteHeader(http.StatusAccepted)
-	}))
-	defer srv.Close()
-	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
-	defer restore()
-
-	origConfigFile := configFile
-	configFile = "config/.plumber.strict.yaml"
-	defer func() { configFile = origConfigFile }()
-
-	if err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, []byte(`{}`)); err != nil {
-		t.Fatalf("maybePushPlatform: %v", err)
-	}
-	var env platformEnvelope
-	if err := json.Unmarshal(gotBody, &env); err != nil {
-		t.Fatal(err)
-	}
-	p := env.Results[0].Policy
-	if p.Source != platformPolicySourceLocal || p.Ref != "config/.plumber.strict.yaml" {
-		t.Errorf("policy = %+v, want source=%q ref=%q from the --config flag fallback", p, platformPolicySourceLocal, "config/.plumber.strict.yaml")
-	}
-}
-
-// The analysis document has no degradation signal at all, so without these the
-// platform would render a partial scan as complete.
-func TestBuildPlatformEnvelope_MarksADegradedRun(t *testing.T) {
-	reasons := []string{"branch protection could not be fetched (network or timeout)"}
-	body, err := buildPlatformEnvelope([]byte(`{}`), ".plumber.yaml", true, reasons)
-	if err != nil {
-		t.Fatalf("buildPlatformEnvelope: %v", err)
-	}
-	var env platformEnvelope
-	if err := json.Unmarshal(body, &env); err != nil {
-		t.Fatal(err)
-	}
-	if !env.Results[0].Degraded {
-		t.Error("degraded = false, want true")
-	}
-	if len(env.Results[0].DegradedReasons) != 1 || env.Results[0].DegradedReasons[0] != reasons[0] {
-		t.Errorf("degradedReasons = %v, want %v", env.Results[0].DegradedReasons, reasons)
+// score.points is PlumberScoreResult.RawPointsUnclamped rounded to the
+// nearest int (math.Round rounds half away from zero) — the contract's
+// Score.Points is a signed int with no clamp (ADR-0020), unlike the
+// gate/badge's floored-at-zero RawPoints.
+func TestBuildPlatformPush_ScorePointsRoundToSignedInt(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  float64
+		want int
+	}{
+		{"positive half rounds away from zero", 82.5, 83},
+		{"negative unclamped deficit survives, rounded", -99.5, -100},
+		{"whole number is untouched", -42, -42},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			score := &control.PlumberScoreResult{Score: "E", RawPointsUnclamped: tc.raw}
+			body, err := buildPlatformPush(testProvider(t), nil, &control.AnalysisResult{}, score, ".plumber.yaml", "")
+			if err != nil {
+				t.Fatalf("buildPlatformPush: %v", err)
+			}
+			var push platformPush
+			if err := json.Unmarshal(body, &push); err != nil {
+				t.Fatal(err)
+			}
+			got := push.Results[0].Score
+			if got.Letter != "E" || got.Points != tc.want {
+				t.Errorf("score = %+v, want letter=E points=%d", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -339,9 +258,75 @@ func TestPolicyNameFor(t *testing.T) {
 	}
 }
 
-// The happy path: the push is a POST to {platform}/api/v1/results carrying the
-// bearer token and the envelope.
-func TestMaybePushPlatform_PostsTheEnvelope(t *testing.T) {
+// maybePushPlatform must name the policy from the config that was ACTUALLY
+// loaded — conf.ConfigFilePath, resolved once at load time — not the raw
+// --config flag value: the flag defaults to ".plumber.yaml" whether or not
+// that file exists, so using it directly would misname a zero-config run
+// that actually read the embedded default.
+func TestMaybePushPlatform_PolicyNameUsesResolvedConfigPathFromConf(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	// The --config flag still carries its unrelated default; conf.ConfigFilePath
+	// is what the run actually resolved, and must win.
+	origConfigFile := configFile
+	configFile = ".plumber.yaml"
+	defer func() { configFile = origConfigFile }()
+
+	conf := &configuration.Configuration{ConfigFilePath: builtinDefaultConfigSource}
+	if err := maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, nil); err != nil {
+		t.Fatalf("maybePushPlatform: %v", err)
+	}
+	var push platformPush
+	if err := json.Unmarshal(gotBody, &push); err != nil {
+		t.Fatal(err)
+	}
+	if got := push.Results[0].Policy; got != "default" {
+		t.Errorf("policy = %q, want %q (the embedded default), even though --config defaults to %q", got, "default", configFile)
+	}
+}
+
+// When conf carries no resolved path (nil conf, or an empty ConfigFilePath),
+// the --config flag is still consulted as a fallback so the policy name is
+// never simply "default" for a run that DID read a real file.
+func TestMaybePushPlatform_PolicyNameFallsBackToConfigFlagWhenConfHasNoPath(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	origConfigFile := configFile
+	configFile = "config/.plumber.strict.yaml"
+	defer func() { configFile = origConfigFile }()
+
+	if err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil); err != nil {
+		t.Fatalf("maybePushPlatform: %v", err)
+	}
+	var push platformPush
+	if err := json.Unmarshal(gotBody, &push); err != nil {
+		t.Fatal(err)
+	}
+	if got := push.Results[0].Policy; got != "strict" {
+		t.Errorf("policy = %q, want %q from the --config flag fallback", got, "strict")
+	}
+}
+
+// The happy path: the push is a POST to {platform}/api/v1/pushes carrying the
+// bearer token and the full contract shape — schema_version, a string
+// policy, findings, effective_config and score all present on the one
+// entry. Uses a real default PlumberConfig so findings enumerates the real
+// control catalog instead of coming back trivially empty.
+func TestMaybePushPlatform_PostsThePush(t *testing.T) {
 	var gotPath, gotAuth, gotType string
 	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -354,12 +339,18 @@ func TestMaybePushPlatform_PostsTheEnvelope(t *testing.T) {
 	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
 	defer restore()
 
-	err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, []byte(`{"projectPath":"org/repo"}`))
+	conf := &configuration.Configuration{ConfigFilePath: ".plumber.yaml", PlumberConfig: testDefaultPlumberConfig(t)}
+	result := &control.AnalysisResult{
+		CiValid:  true,
+		Findings: []opaengine.Finding{{Code: "ISSUE-101", Severity: "high", Message: "untrusted registry"}},
+	}
+	score := &control.PlumberScoreResult{Score: "B", RawPointsUnclamped: 82.5}
+	err := maybePushPlatform(testProvider(t), conf, result, score)
 	if err != nil {
 		t.Fatalf("maybePushPlatform returned %v, want nil on a 202", err)
 	}
-	if gotPath != "/api/v1/results" {
-		t.Errorf("path = %q, want /api/v1/results", gotPath)
+	if gotPath != "/api/v1/pushes" {
+		t.Errorf("path = %q, want /api/v1/pushes", gotPath)
 	}
 	if gotAuth != "Bearer tok-123" {
 		t.Errorf("Authorization = %q, want the bearer id-token", gotAuth)
@@ -367,17 +358,232 @@ func TestMaybePushPlatform_PostsTheEnvelope(t *testing.T) {
 	if gotType != "application/json" {
 		t.Errorf("Content-Type = %q, want application/json", gotType)
 	}
-	var env platformEnvelope
-	if err := json.Unmarshal(gotBody, &env); err != nil {
-		t.Fatalf("body is not an envelope: %v", err)
+	var push platformPush
+	if err := json.Unmarshal(gotBody, &push); err != nil {
+		t.Fatalf("body does not decode as a platformPush: %v", err)
 	}
-	if len(env.Results) != 1 || len(env.Results[0].Report) == 0 {
-		t.Errorf("body did not carry exactly one complete result: %s", gotBody)
+	if push.SchemaVersion != 1 {
+		t.Errorf("schema_version = %d, want 1", push.SchemaVersion)
+	}
+	if len(push.Results) != 1 {
+		t.Fatalf("results = %d, want exactly 1: %s", len(push.Results), gotBody)
+	}
+	entry := push.Results[0]
+	if entry.Policy != "default" {
+		t.Errorf("policy = %q, want %q (a plain string, not an object)", entry.Policy, "default")
+	}
+	if len(entry.Findings) == 0 {
+		t.Error("findings = 0, want at least the enumerated controls for this run")
+	}
+	if len(entry.EffectiveConfig) == 0 {
+		t.Error("effective_config = empty, want the (possibly default) policy block")
+	}
+	if entry.Score.Letter != "B" || entry.Score.Points != 83 {
+		t.Errorf("score = %+v, want letter=B points=83 (82.5 rounded)", entry.Score)
+	}
+}
+
+// The explicit-results model: one findings entry per applicable control.
+// A failing control contributes one entry per underlying finding (with
+// Data); a passing control contributes one bare {control,status:"pass"}
+// entry; a control that could not really be evaluated contributes one bare
+// {control,status:"not_evaluable"} entry — reusing control.StatusFor, the
+// same verdict the --output JSON/CSV/OCSF renderers already compute, not a
+// second notion of "did this control pass" invented here.
+func TestMaybePushPlatform_FindingsCoverPassFailAndNotEvaluable(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	conf := &configuration.Configuration{ConfigFilePath: ".plumber.yaml", PlumberConfig: testDefaultPlumberConfig(t)}
+	result := &control.AnalysisResult{
+		CiValid: true, // most controls read "passed" with zero findings
+		Findings: []opaengine.Finding{
+			{Code: "ISSUE-101", Severity: "high", Message: "untrusted registry", Job: "build", File: ".gitlab-ci.yml", Line: 4},
+		},
+		// ProtectionData stays nil on purpose: branchMustBeProtected never
+		// truly evaluated on this fixture (control/status.go StatusFor),
+		// giving a real not_evaluable case alongside the pass/fail ones.
+	}
+	if err := maybePushPlatform(testProvider(t), conf, result, &control.PlumberScoreResult{Score: "C"}); err != nil {
+		t.Fatalf("maybePushPlatform: %v", err)
+	}
+
+	var push platformPush
+	if err := json.Unmarshal(gotBody, &push); err != nil {
+		t.Fatalf("body does not decode as a platformPush: %v", err)
+	}
+	byControl := map[string]platformFinding{}
+	for _, f := range push.Results[0].Findings {
+		byControl[f.Control] = f
+	}
+
+	fail, ok := byControl["containerImageMustComeFromAuthorizedSources"]
+	if !ok || fail.Status != platformStatusFail {
+		t.Fatalf("containerImageMustComeFromAuthorizedSources = %+v (present=%v), want status=fail", fail, ok)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(fail.Data, &data); err != nil {
+		t.Fatalf("fail finding data does not parse: %v", err)
+	}
+	if data["code"] != "ISSUE-101" || data["message"] != "untrusted registry" {
+		t.Errorf("fail finding data = %v, want the flat Finding.MarshalJSON shape", data)
+	}
+
+	notEval, ok := byControl["branchMustBeProtected"]
+	if !ok || notEval.Status != platformStatusNotEvaluable || len(notEval.Data) != 0 {
+		t.Errorf("branchMustBeProtected = %+v (present=%v), want status=not_evaluable with no data", notEval, ok)
+	}
+
+	pass, ok := byControl["pipelineMustNotEnableDebugTrace"]
+	if !ok || pass.Status != platformStatusPass || len(pass.Data) != 0 {
+		t.Errorf("pipelineMustNotEnableDebugTrace = %+v (present=%v), want status=pass with no data", pass, ok)
+	}
+}
+
+// A control excluded via --skip-controls (the same e.Skipped flag a control
+// disabled in .plumber.yaml sets) is OMITTED from findings entirely: it is
+// still visible in effective_config, but "not evaluated by choice" is a
+// different fact than "could not be evaluated" (not_evaluable), and folding
+// them together would hide operator intent from the platform.
+func TestMaybePushPlatform_SkippedControlIsOmittedFromFindings(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	conf := &configuration.Configuration{
+		ConfigFilePath:     ".plumber.yaml",
+		PlumberConfig:      testDefaultPlumberConfig(t),
+		SkipControlsFilter: []string{"pipelineMustNotEnableDebugTrace"},
+	}
+	result := &control.AnalysisResult{CiValid: true}
+	if err := maybePushPlatform(testProvider(t), conf, result, nil); err != nil {
+		t.Fatalf("maybePushPlatform: %v", err)
+	}
+	var push platformPush
+	if err := json.Unmarshal(gotBody, &push); err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range push.Results[0].Findings {
+		if f.Control == "pipelineMustNotEnableDebugTrace" {
+			t.Errorf("a --skip-controls control appeared in findings: %+v, want it omitted entirely", f)
+		}
+	}
+	if len(push.Results[0].EffectiveConfig) == 0 {
+		t.Error("effective_config = empty, want the loaded policy block regardless of --skip-controls (a run-time filter, not a policy edit)")
+	}
+}
+
+// score.points is RawPointsUnclamped rounded to a signed int: a badly
+// failing project's true deficit goes negative even though the gate/badge's
+// RawPoints floors at zero (see platformScore's doc comment). The score is
+// threaded through from complianceSummary.score rather than recomputed
+// inside maybePushPlatform, so constructing the score directly is the
+// correct way to fixture a negative case: no need to synthesize enough
+// critical findings to drive ComputePlumberScore below zero.
+func TestMaybePushPlatform_NegativeScorePointsReachTheWire(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	// Measured on a 14-finding fixture in the design doc: real losses totaled
+	// 199.5, so the true value was -99.5 where the clamped RawPoints read 0.
+	// math.Round rounds half away from zero, so -99.5 -> -100.
+	score := &control.PlumberScoreResult{Score: "E", RawPointsUnclamped: -99.5}
+	if err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, score); err != nil {
+		t.Fatalf("maybePushPlatform: %v", err)
+	}
+	var push platformPush
+	if err := json.Unmarshal(gotBody, &push); err != nil {
+		t.Fatal(err)
+	}
+	got := push.Results[0].Score
+	if got.Letter != "E" || got.Points != -100 {
+		t.Errorf("score = %+v, want letter=E points=-100 (signed, not floored at zero)", got)
+	}
+}
+
+// No production caller passes a nil score (scoreMode is always on in
+// buildComplianceSummary), but a best-effort push crashing the run over a nil
+// pointer would be strictly worse than sending the zero value.
+func TestMaybePushPlatform_NilScoreDoesNotPanic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	if err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil); err != nil {
+		t.Fatalf("maybePushPlatform: %v", err)
+	}
+}
+
+// effective_config is conf.PlumberConfig run through buildPlumberConfigBlock
+// — the SAME builder the JSON report's plumberConfig block uses — reached via
+// conf rather than a separate parameter, so the config actually loaded for
+// this run (not just some default fallback) is what reaches the platform.
+func TestMaybePushPlatform_EffectiveConfigReflectsTheLoadedConfig(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	conf := &configuration.Configuration{
+		ConfigFilePath: ".plumber.yaml",
+		PlumberConfig:  &configuration.PlumberConfig{Source: ".plumber.yaml", Raw: "version: \"2.0\"\n"},
+	}
+	if err := maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, nil); err != nil {
+		t.Fatalf("maybePushPlatform: %v", err)
+	}
+	var push platformPush
+	if err := json.Unmarshal(gotBody, &push); err != nil {
+		t.Fatal(err)
+	}
+	raw := push.Results[0].EffectiveConfig
+	if len(raw) == 0 {
+		t.Fatal("effective_config = empty, want the loaded policy block")
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("effective_config does not parse: %v", err)
+	}
+	if got["source"] != ".plumber.yaml" {
+		t.Errorf(`effective_config["source"] = %v, want ".plumber.yaml"`, got["source"])
+	}
+	policy, _ := got["effectivePolicy"].(map[string]any)
+	if policy == nil || policy["version"] != "2.0" {
+		t.Errorf(`effective_config["effectivePolicy"] = %v, want the parsed config (version: "2.0")`, got["effectivePolicy"])
 	}
 }
 
 // Every remote condition warns and leaves the exit code alone: the platform
-// being unhappy must never gate somebody's pipeline.
+// being unhappy must never gate somebody's pipeline. Both halves matter —
+// asserting only err == nil would stay green if a refactor dropped the
+// warning call and turned the skipped push silent, the exact failure mode
+// this feature exists to prevent. Since the gate block landed, the warning
+// is one of the two class-distinguished sentences (see
+// cmd/platform_gate_test.go for the full class matrix) rather than the
+// single generic "platform push failed" line this test used to check.
 func TestMaybePushPlatform_RemoteFailuresOnlyWarn(t *testing.T) {
 	for _, status := range []int{
 		http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden,
@@ -391,8 +597,18 @@ func TestMaybePushPlatform_RemoteFailuresOnlyWarn(t *testing.T) {
 			restore := withPlatformTestEnv(t, srv.URL, "tok-123")
 			defer restore()
 
-			if err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, []byte(`{}`)); err != nil {
+			var err error
+			out := captureStderr(t, func() {
+				err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
+			})
+			if err != nil {
 				t.Errorf("status %d returned %v, want nil: a remote condition must not fail the run", status, err)
+			}
+			if !strings.Contains(out, "gate unavailable, letting through") && !strings.Contains(out, "gate NOT RUN: authentication/configuration failed") {
+				t.Errorf("status %d: stderr = %q, want one of the two class-distinguished fail-open sentences", status, out)
+			}
+			if !strings.Contains(out, http.StatusText(status)) {
+				t.Errorf("status %d: stderr = %q, want the server's status in the warning so the operator can diagnose it", status, out)
 			}
 		})
 	}
@@ -406,8 +622,15 @@ func TestMaybePushPlatform_UnreachableOnlyWarns(t *testing.T) {
 	restore := withPlatformTestEnv(t, url, "tok-123")
 	defer restore()
 
-	if err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, []byte(`{}`)); err != nil {
+	var err error
+	out := captureStderr(t, func() {
+		err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
+	})
+	if err != nil {
 		t.Errorf("unreachable platform returned %v, want nil", err)
+	}
+	if !strings.Contains(out, "gate unavailable, letting through") {
+		t.Errorf("stderr = %q, want the transport-failure class sentence", out)
 	}
 }
 
@@ -417,7 +640,7 @@ func TestMaybePushPlatform_MissingTokenFailsWithActionableMessage(t *testing.T) 
 	restore := withPlatformTestEnv(t, "https://app.example.com", "")
 	defer restore()
 
-	err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, []byte(`{}`))
+	err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
 	if err == nil {
 		t.Fatal("missing id-token returned nil, want an error: a silently skipped push is the failure mode this prevents")
 	}
@@ -449,7 +672,7 @@ func TestMaybePushPlatform_GitHubMissingGrantFailsWithActionableMessage(t *testi
 	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "")
 	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "")
 
-	err := maybePushPlatform(p, nil, &control.AnalysisResult{}, []byte(`{}`))
+	err := maybePushPlatform(p, nil, &control.AnalysisResult{}, nil)
 	if err == nil {
 		t.Fatal("missing GitHub id-token grant returned nil, want an error: a silently skipped push is the failure mode this prevents")
 	}
@@ -486,7 +709,7 @@ func TestMaybePushPlatform_GitHubTokenMintFailureReturnsPlatformTokenError(t *te
 	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", mint.URL)
 	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "req-token")
 
-	err := maybePushPlatform(p, nil, &control.AnalysisResult{}, []byte(`{}`))
+	err := maybePushPlatform(p, nil, &control.AnalysisResult{}, nil)
 	if err == nil {
 		t.Fatal("a failed token mint returned nil, want a *PlatformTokenError: the run must not proceed as if the push were merely skipped")
 	}
@@ -496,9 +719,12 @@ func TestMaybePushPlatform_GitHubTokenMintFailureReturnsPlatformTokenError(t *te
 	}
 }
 
-// The degraded markers must reach the wire, since that is what makes pushing a
-// degraded run safe rather than misleading.
-func TestMaybePushPlatform_SendsDegradedMarkers(t *testing.T) {
+// collection.degraded is the only degradation signal on the wire now (the
+// contract has no per-result degraded/degraded_reasons — see
+// platformCollectionMeta's doc comment for why DegradedReasons prose is not
+// forced into missing_fields). Without it the platform would render a
+// partial scan as complete.
+func TestMaybePushPlatform_SendsCollectionDegradedMarker(t *testing.T) {
 	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotBody, _ = io.ReadAll(r.Body)
@@ -512,15 +738,18 @@ func TestMaybePushPlatform_SendsDegradedMarkers(t *testing.T) {
 		DataCollectionDegraded: true,
 		DegradedReasons:        []string{"pipeline configuration could not be fetched (network or timeout)"},
 	}
-	if err := maybePushPlatform(testProvider(t), nil, result, []byte(`{}`)); err != nil {
+	if err := maybePushPlatform(testProvider(t), nil, result, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
-	var env platformEnvelope
-	if err := json.Unmarshal(gotBody, &env); err != nil {
+	var push platformPush
+	if err := json.Unmarshal(gotBody, &push); err != nil {
 		t.Fatal(err)
 	}
-	if !env.Results[0].Degraded || len(env.Results[0].DegradedReasons) != 1 {
-		t.Errorf("degraded markers did not reach the wire: %s", gotBody)
+	if !push.Collection.Degraded {
+		t.Errorf("collection.degraded = false, want true: %s", gotBody)
+	}
+	if len(push.Collection.MissingFields) != 0 {
+		t.Errorf("collection.missing_fields = %v, want omitted/empty: DegradedReasons is prose, not a field-name list", push.Collection.MissingFields)
 	}
 }
 
@@ -534,6 +763,19 @@ func testProvider(t *testing.T) providerPkg.Provider {
 		t.Skip("gitlab provider not registered")
 	}
 	return p
+}
+
+// testDefaultPlumberConfig loads the shipped default config the same way
+// production does (defaultconfig.Get()), giving tests a real, fully
+// populated *configuration.PlumberConfig so p.Controls(pc) enumerates the
+// real catalog instead of coming back empty.
+func testDefaultPlumberConfig(t *testing.T) *configuration.PlumberConfig {
+	t.Helper()
+	pc, _, _, err := configuration.LoadPlumberConfigFromBytes(defaultconfig.Get(), "test-default")
+	if err != nil {
+		t.Fatalf("LoadPlumberConfigFromBytes: %v", err)
+	}
+	return pc
 }
 
 // withPlatformTestEnv points the CLI at a stand-in platform and supplies (or
@@ -567,7 +809,7 @@ func TestMaybePushPlatform_TokenFailureIsAnnouncedNotOnlyReturned(t *testing.T) 
 
 	var err error
 	out := captureStderr(t, func() {
-		err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, []byte(`{}`))
+		err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
 	})
 
 	if err == nil {
@@ -576,5 +818,158 @@ func TestMaybePushPlatform_TokenFailureIsAnnouncedNotOnlyReturned(t *testing.T) 
 	if !strings.Contains(out, "id_tokens") && !strings.Contains(out, "id-token") {
 		t.Errorf("stderr = %q, want the actionable diagnosis printed at the point of failure; "+
 			"without it a run that also fails its gate reports nothing at all", out)
+	}
+}
+
+// The "a token failure fails the run" guarantee is not maybePushPlatform's
+// alone: it holds only because the callers capture platformErr and thread it
+// into finalizeRun. The unit tests above pin each half in isolation; this one
+// drives presentResultWithProvider — a real production caller — end to end, so
+// a refactor that passes finalizeRun a nil (or drops the assignment) fails
+// here instead of shipping a run that warns but exits 0. runWithProvider
+// shares the identical wiring but starts with p.Run (a live analysis), so the
+// caller that is exercisable hermetically stands in for both.
+func TestPresentResultWithProvider_ThreadsPlatformErrIntoTheExitCode(t *testing.T) {
+	origPrint := printOutput
+	printOutput = false // the terminal report is not under test
+	defer func() { printOutput = origPrint }()
+	newGateFlagsCmd(t) // reset gate globals: default points gate (min-points 100)
+
+	// A clean result with one enabled control scores 100 and passes the gate,
+	// so the ONLY thing deciding the returned error is the platform push.
+	conf := confWithDebugTrace()
+
+	t.Run("missing id-token fails the run", func(t *testing.T) {
+		restore := withPlatformTestEnv(t, "https://app.example.com", "")
+		defer restore()
+
+		var err error
+		_ = captureStderr(t, func() {
+			err = presentResultWithProvider(testProvider(t), nil, &control.AnalysisResult{CiValid: true}, conf)
+		})
+
+		var tokenErr *PlatformTokenError
+		if !errors.As(err, &tokenErr) {
+			t.Fatalf("err = %v, want a *PlatformTokenError: the caller must thread maybePushPlatform's error into finalizeRun, or a missing grant warns but stops failing the run", err)
+		}
+	})
+
+	t.Run("healthy push passes and actually POSTs", func(t *testing.T) {
+		pushed := false
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { pushed = true }))
+		defer srv.Close()
+		restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+		defer restore()
+
+		var err error
+		_ = captureStderr(t, func() {
+			err = presentResultWithProvider(testProvider(t), nil, &control.AnalysisResult{CiValid: true}, conf)
+		})
+
+		if err != nil {
+			t.Fatalf("err = %v, want nil: a passing gate with a healthy push must not fail the run", err)
+		}
+		if !pushed {
+			t.Fatal("the platform endpoint was never POSTed: the payload/push wiring is broken in the production caller path")
+		}
+	})
+}
+
+// The CI-identity fields (ref, pipeline, project.id) are read from CI env vars
+// and must reach the wire with the RIGHT value: the presence-only assertions in
+// TestBuildPlatformPush_* would still pass if the mapping were swapped (e.g.
+// GITHUB_JOB read into pipeline.id). These two tests pin each env var to a
+// distinct sentinel and assert it lands in the correct field, per provider —
+// so a dropped or crossed mapping fails loudly instead of shipping silent.
+func TestBuildPlatformPush_GitLabCIIdentityValuesReachTheWire(t *testing.T) {
+	p, ok := providerPkg.Get("gitlab")
+	if !ok {
+		t.Skip("gitlab provider not registered")
+	}
+	t.Setenv("CI_COMMIT_SHA", "sha-gl-111")
+	t.Setenv("CI_COMMIT_BRANCH", "branch-gl-222")
+	t.Setenv("CI_PIPELINE_ID", "pipe-gl-333")
+	t.Setenv("CI_JOB_ID", "job-gl-444")
+	t.Setenv("CI_PROJECT_ID", "proj-gl-555")
+
+	body, err := buildPlatformPush(p, nil, &control.AnalysisResult{}, nil, ".plumber.yaml", "")
+	if err != nil {
+		t.Fatalf("buildPlatformPush: %v", err)
+	}
+	var got struct {
+		Project struct {
+			ID string `json:"id"`
+		} `json:"project"`
+		Ref struct {
+			Branch string `json:"branch"`
+			SHA    string `json:"sha"`
+		} `json:"ref"`
+		Pipeline struct {
+			ID    string `json:"id"`
+			JobID string `json:"job_id"`
+		} `json:"pipeline"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal push: %v", err)
+	}
+	for _, c := range []struct{ field, want, have string }{
+		{"ref.sha", "sha-gl-111", got.Ref.SHA},
+		{"ref.branch", "branch-gl-222", got.Ref.Branch},
+		{"pipeline.id", "pipe-gl-333", got.Pipeline.ID},
+		{"pipeline.job_id", "job-gl-444", got.Pipeline.JobID},
+		{"project.id", "proj-gl-555", got.Project.ID},
+	} {
+		if c.have != c.want {
+			t.Errorf("%s = %q, want %q (env-var mapping dropped or crossed)", c.field, c.have, c.want)
+		}
+	}
+}
+
+func TestBuildPlatformPush_GitHubCIIdentityValuesReachTheWire(t *testing.T) {
+	p, ok := providerPkg.Get("github")
+	if !ok {
+		t.Skip("github provider not registered")
+	}
+	t.Setenv("GITHUB_SHA", "sha-gh-111")
+	t.Setenv("GITHUB_REF_TYPE", "branch")
+	t.Setenv("GITHUB_REF_NAME", "branch-gh-222")
+	t.Setenv("GITHUB_RUN_ID", "run-gh-333")
+	t.Setenv("GITHUB_JOB", "job-gh-444")
+
+	body, err := buildPlatformPush(p, nil, &control.AnalysisResult{}, nil, ".plumber.yaml", "")
+	if err != nil {
+		t.Fatalf("buildPlatformPush: %v", err)
+	}
+	var got struct {
+		Project struct {
+			ID string `json:"id"`
+		} `json:"project"`
+		Ref struct {
+			Branch string `json:"branch"`
+			SHA    string `json:"sha"`
+		} `json:"ref"`
+		Pipeline struct {
+			ID    string `json:"id"`
+			JobID string `json:"job_id"`
+		} `json:"pipeline"`
+	}
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal push: %v", err)
+	}
+	if got.Ref.SHA != "sha-gh-111" {
+		t.Errorf("ref.sha = %q, want %q", got.Ref.SHA, "sha-gh-111")
+	}
+	if got.Ref.Branch != "branch-gh-222" {
+		t.Errorf("ref.branch = %q, want %q", got.Ref.Branch, "branch-gh-222")
+	}
+	if got.Pipeline.ID != "run-gh-333" {
+		t.Errorf("pipeline.id = %q, want GITHUB_RUN_ID %q (not GITHUB_JOB)", got.Pipeline.ID, "run-gh-333")
+	}
+	if got.Pipeline.JobID != "job-gh-444" {
+		t.Errorf("pipeline.job_id = %q, want GITHUB_JOB %q", got.Pipeline.JobID, "job-gh-444")
+	}
+	// GitHub has no cheap numeric project id at this call site: it must stay empty.
+	if got.Project.ID != "" {
+		t.Errorf("project.id = %q, want empty for GitHub", got.Project.ID)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,17 +72,26 @@ func Execute() {
 //     threshold, so the reason is emitted only when the report was suppressed
 //     (--print=false, JSON/PBOM-only, CI capturing stderr), where it is the
 //     sole human-readable failure reason.
+//   - PlatformGateError → "Blocked", exit 1, same class as the local score
+//     gate - also a verdict on the project. Always emitted, unlike the local
+//     gate: the terminal report reflects only the local score, so on a run
+//     that passes locally but is blocked by the platform, the report would
+//     say "PASSED" while the process exits 1 unless this reason is printed
+//     regardless of --print.
 //   - DegradedError / IncompleteDataError → "Incomplete", exit 3. The run could
 //     not fully verify the project — also not a program error.
 //   - anything else → "Error", exit 2.
 func classifyExecError(err error, printOutput bool) (prefix string, code int, emit bool) {
 	var gateErr *ScoreGateError
 	var complianceErr *ComplianceError
+	var platformGateErr *PlatformGateError
 	var degradedErr *DegradedError
 	var incompleteErr *IncompleteDataError
 	switch {
 	case errors.As(err, &gateErr), errors.As(err, &complianceErr):
 		return "Blocked", 1, !printOutput
+	case errors.As(err, &platformGateErr):
+		return "Blocked", 1, true
 	case errors.As(err, &degradedErr), errors.As(err, &incompleteErr):
 		return "Incomplete", 3, true
 	default:

--- a/cmd/score_push.go
+++ b/cmd/score_push.go
@@ -251,27 +251,44 @@ func fetchGitHubActionsIDToken(reqURL, reqToken, audience string) (string, error
 // postScoreReport POSTs the report JSON to the score service. Any non-2xx is
 // an error (the caller turns it into a warning, never a failure).
 func postScoreReport(target, token string, payload []byte) error {
+	_, _, err := postScoreReportForBody(target, token, payload)
+	return err
+}
+
+// postScoreReportForBody is postScoreReport plus the 2xx response body and
+// status code, which the platform push needs to parse the gate block and
+// classify a failure into its fail-open class (see evaluatePlatformGate and
+// platformGateFailOpenLine). statusCode is 0 for a transport-level failure
+// (timeout, DNS, connection refused) where no response was ever received -
+// callers that only need the pass/fail outcome go through postScoreReport
+// instead, which never had a status code to report.
+func postScoreReportForBody(target, token string, payload []byte) (body []byte, statusCode int, err error) {
 	req, err := http.NewRequest(http.MethodPost, target, bytes.NewReader(payload))
 	if err != nil {
-		return err
+		return nil, 0, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := (&http.Client{Timeout: scorePushHTTPTimeout}).Do(req)
 	if err != nil {
-		return err
+		return nil, 0, err
 	}
 	defer func() { _ = resp.Body.Close() }()
+	statusCode = resp.StatusCode
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		msg := strings.TrimSpace(string(body))
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		msg := strings.TrimSpace(string(errBody))
 		if msg == "" {
-			return fmt.Errorf("%s", resp.Status)
+			return nil, statusCode, fmt.Errorf("%s", resp.Status)
 		}
-		return fmt.Errorf("%s: %s", resp.Status, msg)
+		return nil, statusCode, fmt.Errorf("%s: %s", resp.Status, msg)
 	}
-	return nil
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, statusCode, fmt.Errorf("read response body: %w", err)
+	}
+	return body, statusCode, nil
 }
 
 // hostOf extracts the host from a (possibly scheme-less) URL.

--- a/control/scoring_test.go
+++ b/control/scoring_test.go
@@ -182,3 +182,23 @@ func TestComputePlumberScore_KeepsUnclampedRawPoints(t *testing.T) {
 		t.Errorf("RawPointsUnclamped = %v, want %v (100 minus summed capped losses)", got.RawPointsUnclamped, want)
 	}
 }
+
+// When losses stay under 100 the clamp is a no-op, so the two raw values must
+// be the SAME number — a divergence here would mean the unclamped computation
+// drifted on the ordinary runs that make up virtually all real analyses, not
+// just the pathological >100-loss case the test above pins.
+func TestComputePlumberScore_UnclampedEqualsRawWithoutClamping(t *testing.T) {
+	got := ComputePlumberScore(map[ErrorCode]int{CodeDebugTraceEnabled: 1})
+
+	if got.RawPoints <= 0 || got.RawPoints >= 100 {
+		t.Fatalf("RawPoints = %v: the fixture must land strictly between 0 and 100 for this test to mean anything", got.RawPoints)
+	}
+	if got.RawPointsUnclamped != got.RawPoints {
+		t.Errorf("RawPointsUnclamped = %v, RawPoints = %v: must be equal when no clamping occurs", got.RawPointsUnclamped, got.RawPoints)
+	}
+
+	clean := ComputePlumberScore(map[ErrorCode]int{})
+	if clean.RawPoints != 100 || clean.RawPointsUnclamped != 100 {
+		t.Errorf("clean run: RawPoints = %v, RawPointsUnclamped = %v, want both 100", clean.RawPoints, clean.RawPointsUnclamped)
+	}
+}

--- a/docs/platform-push-testing.md
+++ b/docs/platform-push-testing.md
@@ -1,0 +1,69 @@
+# Testing the platform push
+
+The `--platform` push (`cmd/platform_push.go`) has no local way to run the
+platform's real parser, so `cmd/platform_push_test.go` verifies the wire
+bytes it sends instead of trusting its own types. This is what that
+capture-and-verify flow does and why it exists.
+
+## Decoding into our own struct proves nothing
+
+`buildPlatformPush` returns `[]byte`, and the obvious test is to
+`json.Unmarshal` that back into `platformPush` and assert on the Go values.
+That test would pass even if a field's `json` tag drifted from the contract:
+a reverted tag, or a field whose Go type no longer matches what the platform
+expects, still round-trips cleanly through its own (equally wrong) type. This
+is not hypothetical: a prior version of this file sent `results[].policy`
+as a `{name,source,ref}` object where the contract
+(`platform/backend/ingestion/contract.go` in the monorepo) declares a plain
+string, and every push was rejected: `json.Unmarshal` into a string field
+fails outright on an object. Decoding into `platformPush` never would have
+caught it, because both sides had drifted together.
+
+## The fix: assert on the raw wire shape
+
+`TestBuildPlatformPush_KeysAreSnakeCaseAndPolicyIsAString` unmarshals the
+push body into `map[string]any` instead of `platformPush`, and checks the
+JSON as the platform's parser would see it:
+
+- `schema_version` is present as `1` (a float64 after `any`-decoding), and
+  `schemaVersion` (the camelCase mistake) is absent.
+- `results[0].policy` decodes to a Go `string`, not a nested object.
+- `findings` and `effective_config` are present on every result entry.
+- `project`, `ref`, `pipeline`, `cli`, `collection` are present at the top
+  level (the contract has no `omitempty` on struct-typed top-level fields,
+  so a `nil` there would drop the key entirely).
+
+Because there is no Go type standing between the assertion and the bytes,
+a tag or shape regression fails this test even when it would silently
+decode clean into `platformPush`.
+
+## Capturing the bytes that actually go over the wire
+
+The rest of `platform_push_test.go` (`TestMaybePushPlatform_PostsThePush`
+and its siblings) runs `maybePushPlatform` end to end against an
+`httptest.Server` standing in for the platform, and reads the request body
+the server received:
+
+```go
+srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    gotBody, _ = io.ReadAll(r.Body)
+    w.WriteHeader(http.StatusAccepted)
+}))
+```
+
+This is what confirms the push is reachable and well-formed as a whole
+request (path, `Authorization: Bearer <token>`, `Content-Type`), not just
+that `buildPlatformPush`'s return value happens to look right in isolation.
+Combined with the raw-map assertion above, the same captured bytes are
+checked both for transport correctness and for wire-shape fidelity to the
+contract.
+
+## Keeping this in sync
+
+`platform/backend/ingestion/contract.go` in the monorepo is the source of
+truth for the shape. When it changes, update `platformPush` and its nested
+types in `cmd/platform_push.go` to match, then extend
+`TestBuildPlatformPush_KeysAreSnakeCaseAndPolicyIsAString` (or add a sibling
+raw-map assertion) for the new or changed field: a change that only touches
+the Go struct and its own round-trip test would repeat the exact failure
+mode this file exists to catch.


### PR DESCRIPTION
## Platform push: restore the contract wire, key by policy_id, act on the gate

Completes the CLI half of the coordinated platform release (the monorepo's `docs/contracts/cli-task-p3-gate-and-uuid.md`, pieces b and c), and fixes something urgent found on the way.

### The urgent part first: v0.4.37's `--platform` push cannot reach the platform

The `#410` branch was force-pushed between review and merge: the merged `cmd/platform_push.go` posts a camelCase envelope with `policy` as an object to `/api/v1/results` - the platform serves `/api/v1/pushes` and its contract wants snake_case with `policy` as a plain string. Proven live against the real platform stack: every 0.4.37 push gets a 404, fails open with a warning, and no data ever lands. The template (`platform` input + `id_tokens`), `action.yml`, and the recipe-v3 identity changes merged correctly and are untouched here - only the push wire was clobbered.

Commit `7b8b455` restores the reviewed implementation byte-exact (recovered from the pre-force-push head, still on GitHub as `60787ce`; the only deltas are two gofmt hunks in a test file). Consider a caveat in 0.4.37's release notes that `--platform` is inert in that version.

### The task set (pieces b and c)

- **`policy_id` from `/context`** (`8458863`): when `--platform` is configured, one GET of the platform's self-only `/context` per run; the locally-derived policy name is matched against the served policy set by **exact name equality** (the same key the platform's own one-version name tolerance resolves on, moved client-side - flagging the interpretation for your review since the task doc did not spell out the matching rule); exactly one match stamps `policy_id` on the pushed result. No match, an ambiguous match, or any `/context` failure: one log line, the push proceeds name-only exactly as today. The zero-uuid rule is solved structurally: `PolicyID` is a plain string with `omitempty`, so an unresolved id omits the key - a test pins that `00000000-` can never appear on the wire.
- **The gate block** (`0eea405` + `612fd5d`): a 2xx push response's `gate` object now governs the job. `blocking: true` exits 1 with a job-log line naming every blocking policy and its live-fail count. `evaluated: false` (out-of-order) and every remote failure fail open - with the two class-distinguished sentences, verbatim as the alerting contract: `gate unavailable, letting through` (timeout, connection error, 5xx, and a 2xx whose body could not be read) vs `gate NOT RUN: authentication/configuration failed` (401/403/422; other 4xx are bucketed here as the closest honest fit - a code comment says so). The HTTP status and server message ride along after the sentence for diagnosability. A missing `gate` key (an older platform) is silently fail-open. The gate deadline stays the existing 15s push timeout; no new knob. The only conditions that can ever fail a run remain the deliberate id-token failure (unchanged from #410) and an explicit `blocking: true`.

### Verified end to end

A five-leg e2e of this branch's binary against the real platform stack (real OIDC verification, real ingest + issue engine + gate, real dismissal API): blocking exits 1 naming the policy; the pushed `policy_id` (resolved through the CLI's real `/context` call) attributes issues by uuid; dismissing the issues un-blocks the next run's exit code; both fail-open sentences appear with exit 0 on a dead platform and a bad token respectively. Full CLI suite green; red-first TDD throughout (the red commits genuinely fail at their parents).

### Small notes for review

- `docs/platform-push-testing.md` now exists (the doc a code comment referenced but nobody wrote), describing the wire-shape capture tests accurately; the comment's overclaim about the platform's parser was corrected.
- README documents the gate behavior and quotes both fail-open sentences.
- `evaluated: false` logs its own reason line; the spec mandates the two exact sentences only for the remote-failure classes.
- A degraded run (exit 3) that the platform would also block still exits 3 - the pre-existing exit precedence is unchanged, with the gate line still printed.
- The restored files keep their original author's em dashes (provenance over style); all newly-authored lines are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UB7mfYbNHvoNzhh36bj9yc
