### PR TITLE
fix(docker): stamp version metadata into the published image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,6 +237,11 @@ jobs:
             type=semver,pattern={{major}},value=${{ needs.release.outputs.new_release_version }}
             type=raw,value=latest
 
+      # Same timestamp format as the release binaries' BUILD_DATE above.
+      - name: Compute build date
+        id: build_date
+        run: echo "date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         id: push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -246,6 +251,13 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Stamp version metadata into the binary (Dockerfile ARGs feeding
+          # -X ldflags on cmd/version.go); without these the image reports
+          # "plumber version dev" (getplumber/plumber#425).
+          build-args: |
+            VERSION=${{ needs.release.outputs.new_release_version }}
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ steps.build_date.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # Always rebuild the `runtime` stage so `apk upgrade` re-runs and pulls

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,18 @@ RUN go mod download
 # Copy source code
 COPY . .
 
+# Version metadata stamped into the binary (cmd/version.go). The release
+# workflow passes these as build args so `plumber version` in the published
+# image reports the release, matching the ldflags used for the release
+# binaries in release.yml. Plain `docker build` (ci.yml, local) keeps the
+# dev defaults. Declared here, after the cacheable dependency layers, so a
+# changing BUILD_DATE never invalidates `go mod download`.
+ARG VERSION=dev
+ARG COMMIT=none
+ARG BUILD_DATE=unknown
+
 # Build static binary
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o plumber .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/getplumber/plumber/cmd.Version=${VERSION} -X github.com/getplumber/plumber/cmd.Commit=${COMMIT} -X github.com/getplumber/plumber/cmd.BuildDate=${BUILD_DATE}" -o plumber .
 
 # Final stage - Alpine (small, has shell for CI compatibility)
 # Named `runtime` so CI can target it with build-push-action's `no-cache-filter:


### PR DESCRIPTION
Fixes #425

## Problem

`plumber version` inside the published Docker image reports:

```
plumber version dev
  commit: none
  built:  unknown
```

while the downloaded release binaries report the real version.

## Root cause

release.yml stamps the release binaries with `-X github.com/getplumber/plumber/cmd.Version=... / cmd.Commit=... / cmd.BuildDate=...` ldflags, but the docker job builds the image straight from the Dockerfile, whose `go build` only passes `-s -w`. The binary in the image therefore keeps the compile-time defaults from `cmd/version.go` (`dev` / `none` / `unknown`).

## Fix

- Dockerfile: add `VERSION` / `COMMIT` / `BUILD_DATE` build args (defaulting to the current dev values) and feed them into the same `-X` ldflags the release binaries use. The args are declared after the dependency layers so a changing `BUILD_DATE` never invalidates the `go mod download` cache.
- release.yml (docker job): pass the three build args to `docker/build-push-action`, with `COMMIT=${{ github.sha }}` matching what the release binaries embed and `BUILD_DATE` computed in the same format as the binary build step.

Plain `docker build` with no args (ci.yml grype scan, local builds) keeps today's dev output.

## Verification

Built the image locally from this branch:

- with `--build-arg VERSION=9.9.9-test --build-arg COMMIT=abc1234def --build-arg BUILD_DATE=2026-08-21T00:00:00Z`:

  ```
  plumber version 9.9.9-test
    commit: abc1234def
    built:  2026-08-21T00:00:00Z
  ```

- with no build args (ci.yml path): unchanged `dev` / `none` / `unknown` defaults.

The published image will pick this up at the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)