### PR TITLE
feat(cli): add --no-controls to produce artifacts without a verdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,36 @@ plumber analyze \
   --pbom-cyclonedx cdx.json
 ```
 
+### Artifacts without a verdict
+
+To produce an artifact (typically the PBOM) and nothing else, pass
+`--no-controls`. No control is evaluated, no score is computed, and the run
+exits `0` as long as data collection succeeded:
+
+```bash
+plumber analyze --pbom-cyclonedx cdx.json --no-controls --print=false
+```
+
+It overrides whatever `.plumber.yaml` enables, so the same config keeps working
+for a normal `plumber analyze` in another job. Nothing the run produces claims a
+verdict: the JSON, CSV and OCSF reports mark every control `skipped` rather than
+`passed`, and the PBOM records the collected inventory (images, includes,
+upstream versions) with no compliance flags on it, per-image or per-include.
+
+The run still fails (exit 3) when data collection did not produce a usable
+pipeline: a degraded collection, a `.gitlab-ci.yml` that was fetched but does
+not parse, or (on GitLab) no CI configuration at all. In each case the
+inventory would be empty, and an empty PBOM must not ship as a complete one.
+
+Flags that read or publish a verdict are ignored, with a notice naming them:
+`--min-points`, `--min-score`, `--threshold`, `--badge`, `--score-push`,
+`--mr-comment`, `--platform`, and also `--sarif` / `--glsast`. Those last two
+are security reports with no honest empty form: an empty SARIF is what makes
+GitHub Code Scanning clear previously-reported alerts, and an empty GitLab SAST
+report shows a clean Security Dashboard. Writing them from a run that evaluated
+nothing would dismiss real alerts, so they are skipped rather than emitted
+empty.
+
 More details:
 
 - PBOM docs: [`docs/PBOM.md`](./docs/PBOM.md)
@@ -366,7 +396,7 @@ More details:
 
 | Code | Meaning |
 |---|---|
-| `0` | The Plumber Score meets the gate (`--min-points` / `--min-score`) |
+| `0` | The Plumber Score meets the gate (`--min-points` / `--min-score`), or `--no-controls` was used and data collection succeeded |
 | `1` | The Plumber Score is below the gate (or the deprecated `--threshold` is not met) |
 | `2` | Invalid usage, configuration, or a runtime / provider / auth / network failure |
 | `3` | A check could not be verified and `--fail-warnings` is set (e.g. an action version that could not be resolved) |

--- a/cmd/analyze_github.go
+++ b/cmd/analyze_github.go
@@ -44,16 +44,17 @@ func loadGitHubConfig() (*configuration.PlumberConfig, string, error) {
 	return plumberConfig, configPath, nil
 }
 
-func runGitHubAnalyze(info *utils.GitRemoteInfo, controlsFilterList, skipControlsList []string) error {
-	plumberConfig, configPath, err := loadGitHubConfig()
-	if err != nil {
-		return err
-	}
-
-	if printOutput {
-		printBanner()
-	}
-
+// buildGitHubLocalConf constructs the analysis Configuration for the
+// local-clone GitHub flow. Extracted from runGitHubAnalyze so the wiring
+// (in particular the control scope, which carries --no-controls) is
+// reachable from a test without running an analysis, mirroring
+// buildGitLabConf.
+func buildGitHubLocalConf(
+	info *utils.GitRemoteInfo,
+	plumberConfig *configuration.PlumberConfig,
+	configPath string,
+	controlsFilterList, skipControlsList []string,
+) *configuration.Configuration {
 	conf := configuration.NewDefaultConfiguration()
 	conf.ConfigFilePath = configPath
 	conf.ProjectPath = info.ProjectPath
@@ -65,11 +66,10 @@ func runGitHubAnalyze(info *utils.GitRemoteInfo, controlsFilterList, skipControl
 	conf.IsLocalProject = true
 	conf.Branch = defaultBranch
 	conf.PlumberConfig = plumberConfig
-	conf.ControlsFilter = controlsFilterList
-	conf.SkipControlsFilter = skipControlsList
+	applyControlScope(conf, controlsFilterList, skipControlsList)
 	// API host for the settings/metadata controls. Precedence:
 	//   1. --github-url, if the user passed it explicitly;
-	//   2. otherwise the git remote host, when it is not github.com — this
+	//   2. otherwise the git remote host, when it is not github.com - this
 	//      is a GitHub Enterprise Server clone, so target its API directly
 	//      (mirrors how the GitLab path auto-uses the remote URL). go-gh
 	//      resolves the matching token (GH_ENTERPRISE_TOKEN / gh auth login
@@ -80,8 +80,40 @@ func runGitHubAnalyze(info *utils.GitRemoteInfo, controlsFilterList, skipControl
 		apiHost = info.Host
 	}
 	conf.GithubAPIHost = apiHost
+	return conf
+}
 
-	printGitHubAuthBanner(apiHost, false)
+// buildGitHubRemoteConf is the upstream-fetch counterpart of
+// buildGitHubLocalConf, extracted for the same reason.
+func buildGitHubRemoteConf(
+	owner, repo, ref, apiHost string,
+	plumberConfig *configuration.PlumberConfig,
+	configPath string,
+	controlsFilterList, skipControlsList []string,
+) *configuration.Configuration {
+	conf := configuration.NewDefaultConfiguration()
+	conf.ConfigFilePath = configPath
+	conf.ProjectPath = owner + "/" + repo
+	conf.Branch = ref
+	conf.PlumberConfig = plumberConfig
+	conf.GithubAPIHost = apiHost
+	applyControlScope(conf, controlsFilterList, skipControlsList)
+	return conf
+}
+
+func runGitHubAnalyze(info *utils.GitRemoteInfo, controlsFilterList, skipControlsList []string) error {
+	plumberConfig, configPath, err := loadGitHubConfig()
+	if err != nil {
+		return err
+	}
+
+	if printOutput {
+		printBanner()
+	}
+
+	conf := buildGitHubLocalConf(info, plumberConfig, configPath, controlsFilterList, skipControlsList)
+
+	printGitHubAuthBanner(conf.GithubAPIHost, false)
 
 	p, ok := plumberprovider.Get("github")
 	if !ok {
@@ -120,14 +152,7 @@ func runGitHubAnalyzeRemote(host, project, ref string, controlsFilterList, skipC
 	apiHost := strings.TrimPrefix(strings.TrimPrefix(host, "https://"), "http://")
 	printGitHubAuthBanner(apiHost, true)
 
-	conf := configuration.NewDefaultConfiguration()
-	conf.ConfigFilePath = configPath
-	conf.ProjectPath = owner + "/" + repo
-	conf.Branch = ref
-	conf.PlumberConfig = plumberConfig
-	conf.GithubAPIHost = apiHost
-	conf.ControlsFilter = controlsFilterList
-	conf.SkipControlsFilter = skipControlsList
+	conf := buildGitHubRemoteConf(owner, repo, ref, apiHost, plumberConfig, configPath, controlsFilterList, skipControlsList)
 
 	p, ok := plumberprovider.Get("github")
 	if !ok {

--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -66,7 +66,17 @@ var (
 	platformURL       string
 	controlsFilter    string
 	skipControls      string
-	ciConfigPath      string
+	// noControls (--no-controls) turns off control evaluation for the run.
+	// It overrides .plumber.yaml, for the case where the user wants an
+	// artifact (typically the PBOM) and not a verdict. Nothing is
+	// evaluated, so there is no score and no gate.
+	//
+	// It carries a PLUMBER_ANALYZE_NO_CONTROLS fallback like every other
+	// analyze flag. Anyone able to set that variable can already neutralise
+	// the gate through PLUMBER_ANALYZE_MIN_POINTS / _THRESHOLD, so the env
+	// surface is a property of the whole flag set, not of this flag.
+	noControls   bool
+	ciConfigPath string
 )
 
 const (
@@ -114,11 +124,17 @@ Optional flags:
   --score-endpoint   Score service base URL (default https://score.getplumber.io); override only for a self-hosted score service (optional)
   --controls         Run only listed controls (comma-separated)
   --skip-controls    Skip listed controls (comma-separated)
+  --no-controls      Run no control at all: collect the pipeline, write the requested inventory
+                     artifacts (PBOM, JSON, CSV, OCSF), skip evaluation, withhold the score, exit 0.
+                     Every control reports as skipped, never passed. --sarif / --glsast are NOT
+                     written (an empty security report clears existing alerts). Overrides the
+                     controls enabled in .plumber.yaml; cannot be combined with --controls /
+                     --skip-controls
   --fail-warnings    Treat configuration warnings as errors (exit 2)
   --ci-config-path   Override the CI configuration file path (default: auto-detected from GitLab project settings, usually .gitlab-ci.yml)
 
 Exit codes:
-  0  Analysis passed (score gate met)
+  0  Analysis passed (score gate met, or --no-controls with data collection intact)
   1  Gate failure (Plumber Score below --min-points / --min-score, or deprecated --threshold not met)
   2  Runtime error (configuration error, network failure, missing token, etc.)
 
@@ -140,6 +156,9 @@ Examples:
 
   # Analyze a project that uses a custom CI configuration file path
   plumber analyze --ci-config-path my-custom-ci.yml
+
+  # PBOM only: no control evaluated, no score, no gate (exit 0 unless collection fails)
+  plumber analyze --pbom-cyclonedx pbom.cdx --no-controls --print=false
 `,
 	RunE: runAnalyze,
 }
@@ -187,6 +206,7 @@ func init() {
 	analyzeCmd.Flags().StringVar(&platformURL, "platform", "", "Plumber platform base URL; setting it pushes this run's full results there over CI OIDC (implies the push, and takes precedence over --score-push)")
 	analyzeCmd.Flags().StringVar(&controlsFilter, "controls", "", "Run only listed controls (comma-separated)")
 	analyzeCmd.Flags().StringVar(&skipControls, "skip-controls", "", "Skip listed controls (comma-separated)")
+	analyzeCmd.Flags().BoolVar(&noControls, "no-controls", false, "Run no controls at all: collect the pipeline and write the requested inventory artifacts (PBOM, JSON, CSV, OCSF), skip evaluation, withhold the score, and never fail the gate")
 	analyzeCmd.Flags().BoolVar(&failWarnings, "fail-warnings", false, "Treat configuration warnings as errors (exit 2)")
 	analyzeCmd.Flags().StringVar(&ciConfigPath, "ci-config-path", "", "Override the CI configuration file path (default: auto-detected from GitLab project settings, usually .gitlab-ci.yml)")
 
@@ -255,6 +275,11 @@ func buildRunHeaderRows(providerName string, result *control.AnalysisResult, con
 		rows = append(rows, headerRow{"CI config", "local file"})
 	case "remote":
 		rows = append(rows, headerRow{"CI config", "fetched from " + providerDisplayName(providerName)})
+	}
+	// Say it once, in the header, so the report never looks like a scan that
+	// found nothing wrong.
+	if conf.NoControls {
+		rows = append(rows, headerRow{"Controls", "none (--no-controls)"})
 	}
 
 	return rows
@@ -361,6 +386,11 @@ func validateProviderFlags(flags analyzeFlags) error {
 func parseControlsFilters() (includeOnly, skip []string, err error) {
 	if controlsFilter != "" && skipControls != "" {
 		return nil, nil, fmt.Errorf("--controls and --skip-controls cannot be used together")
+	}
+	// "evaluate nothing" and "evaluate this subset" are contradictory
+	// requests. Letting one silently win would hide a broken CI invocation.
+	if noControls && (controlsFilter != "" || skipControls != "") {
+		return nil, nil, fmt.Errorf("--no-controls cannot be combined with --controls / --skip-controls: it runs no control at all")
 	}
 	includeOnly, err = parseControlsFilter(controlsFilter)
 	if err != nil {
@@ -474,8 +504,7 @@ func buildGitLabConf(
 	conf.Branch = defaultBranch
 	conf.PlumberConfig = plumberConfig
 	conf.GitRepoRoot = remote.repoRoot
-	conf.ControlsFilter = controlsFilterList
-	conf.SkipControlsFilter = skipControlsList
+	applyControlScope(conf, controlsFilterList, skipControlsList)
 	conf.CIConfigPathOverride = ciConfigPath
 
 	// Local CI file support only applies when the local repo IS the analyzed
@@ -520,6 +549,7 @@ var envKeys = map[string]string{
 	"platform":       "PLUMBER_ANALYZE_PLATFORM",
 	"controls":       "PLUMBER_ANALYZE_CONTROLS",
 	"skip-controls":  "PLUMBER_ANALYZE_SKIP_CONTROLS",
+	"no-controls":    "PLUMBER_ANALYZE_NO_CONTROLS",
 	"fail-warnings":  "PLUMBER_ANALYZE_FAIL_WARNINGS",
 	"ci-config-path": "PLUMBER_ANALYZE_CI_CONFIG_PATH",
 	"verbose":        "PLUMBER_ANALYZE_VERBOSE",
@@ -651,6 +681,7 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 		func() error { return envBoolFallback(cmd, "score-point", envKeys["score-point"], &showScorePoint) },
 		func() error { return envBoolFallback(cmd, "score-push", envKeys["score-push"], &pushScore) },
 		func() error { return envBoolFallback(cmd, "fail-warnings", envKeys["fail-warnings"], &failWarnings) },
+		func() error { return envBoolFallback(cmd, "no-controls", envKeys["no-controls"], &noControls) },
 	} {
 		if err := apply(); err != nil {
 			return err
@@ -820,6 +851,12 @@ func buildAnalysisJSONReport(result *control.AnalysisResult, pc *configuration.P
 		}
 	}
 	output["passed"] = s.passed()
+	// `passed` means "the gate was met", and under --no-controls there was no
+	// gate to fail. Say so explicitly so a consumer can tell that apart from
+	// "everything was checked and is clean" without reading every block.
+	if p.noControls {
+		output["noControls"] = true
+	}
 	if scoreMode && score != nil {
 		output["plumberScore"] = score
 	}
@@ -838,7 +875,7 @@ func buildAnalysisJSONReport(result *control.AnalysisResult, pc *configuration.P
 	// CLI does NOT classify standard-vs-custom (it's the untrusted client); the
 	// score service classifies server-side from this object and its hash.
 	output["plumberConfig"] = buildPlumberConfigBlock(pc)
-	for k, v := range legacyResultsByName(result, pc, provider, includeOnly, skip) {
+	for k, v := range legacyResultsByName(result, pc, provider, includeOnly, skip, p.noControls) {
 		output[k] = v
 	}
 
@@ -1231,7 +1268,14 @@ type jsonOutputParams struct {
 	provider    string
 	includeOnly []string
 	skip        []string
+	// noControls mirrors conf.NoControls so the report can say plainly that
+	// nothing was evaluated instead of leaving a consumer to infer it.
+	noControls bool
 }
+
+// noControlsSkipReason is the SkipReason stamped on every control of a
+// --no-controls run, in the JSON blocks and anywhere else a skip is explained.
+const noControlsSkipReason = "no controls requested (--no-controls)"
 
 // complianceSummary bundles the computed gate values passed to outputText.
 type complianceSummary struct {
@@ -1247,6 +1291,10 @@ type complianceSummary struct {
 	score        *control.PlumberScoreResult
 	scoreMode    bool
 	scorePoint   bool
+	// noControls records that the run asked for no controls (--no-controls),
+	// which is what tells the gate and the renderer apart a deliberate
+	// zero-control run from a misconfiguration that evaluated nothing.
+	noControls bool
 }
 
 // pointsGateActive reports whether the points gate applies: either it was set
@@ -1260,6 +1308,17 @@ func (s complianceSummary) pointsGateActive() bool {
 // describing the failure. The deprecated --threshold gate wins when supplied;
 // otherwise the Plumber Score gates the run.
 func (s complianceSummary) gateErr() error {
+	// --no-controls asked for exactly this: nothing evaluated. Every gate
+	// below reads something the run deliberately did not produce (the
+	// passing-controls percentage, the score), so all of them are inert,
+	// the deprecated --threshold included. This check must stay first: a CI
+	// template that sets --threshold or --min-points globally must not turn
+	// a deliberate artifact-only run into a failure. The zero-control
+	// fail-closed further down exists to catch a run that MEANT to check
+	// something and checked nothing, which is not this.
+	if s.noControls {
+		return nil
+	}
 	if s.thresholdSet {
 		if s.compliance < s.threshold {
 			return &ComplianceError{Compliance: s.compliance, Threshold: s.threshold}
@@ -1298,6 +1357,13 @@ func (s complianceSummary) passed() bool {
 // gateLine renders the active gate and its outcome as one human-readable
 // sentence fragment, e.g. "score A — 100.0/100 pts, required ≥ 100 pts".
 func (s complianceSummary) gateLine() string {
+	// Same precedence as gateErr: --no-controls makes every gate inert, the
+	// deprecated --threshold included, so the line must not describe a
+	// threshold that did not run. Reversed, `--no-controls --threshold 100`
+	// renders "PASSED (0.0% of controls passing, deprecated threshold 100%)".
+	if s.noControls {
+		return "no controls requested, nothing to score"
+	}
 	if s.thresholdSet {
 		return fmt.Sprintf("%.1f%% of controls passing, deprecated threshold %.0f%%", s.compliance, s.threshold)
 	}
@@ -1406,6 +1472,19 @@ func printBanner() {
 		styleMuted.Render("Join our community:"),
 		styleAccent.Render("https://getplumber.io/discord"),
 	)
+}
+
+// printCIErrors prints just the CI-configuration errors, without the
+// "no controls could be evaluated" headline. Used on a --no-controls run,
+// where zero controls is the request but an unparseable CI config still
+// has to be explained: it is why the inventory came out empty.
+func printCIErrors(result *control.AnalysisResult) {
+	fmt.Printf(fmtIndentLine, styleError.Render("CI configuration errors:"))
+	bullet := styleError.Render("•")
+	for _, e := range result.CiErrors {
+		fmt.Printf("    %s %s\n", bullet, sanitizeTerminal(e))
+	}
+	fmt.Println()
 }
 
 // printNoControlsWarning prints the warning block shown when zero controls
@@ -1640,6 +1719,27 @@ func printStatusSectionHeader(name, glyph, color string) {
 // modernised two-column layout: a large grade badge on the left, and
 // a side panel on the right with points, progress bar, meaning text,
 // severity chips, and any Critical malus warning.
+// printNoControlsSummary replaces the score banner on a --no-controls run.
+//
+// Simply omitting the banner is not enough: an output with no score in it
+// reads as a rendering glitch, and leaves the reader to guess whether
+// nothing was found or nothing was checked. Those are opposite conclusions,
+// so the run says which one it is, in the place the grade would have been.
+func printNoControlsSummary() {
+	sep := styleRule.Render(strings.Repeat("─", hrWidth))
+	fmt.Println()
+	fmt.Println(" " + sep)
+	fmt.Println(" " + styleMuted.Render("Plumber Score"))
+	fmt.Println()
+	fmt.Printf(" %s\n", styleFail.Render("No control was run (--no-controls)"))
+	fmt.Printf(" %s\n", styleFail.Render("No Plumber Score: nothing was evaluated, so this run makes no claim"))
+	fmt.Printf(" %s\n", styleFail.Render("about the pipeline."))
+	fmt.Printf(" %s\n", styleMuted.Render("The artifacts it wrote contain the collected inventory only."))
+	fmt.Println()
+	fmt.Println(" " + sep)
+	fmt.Println()
+}
+
 func printSummaryScoreBanner(score *control.PlumberScoreResult, scoreMode, degraded bool) {
 	if score == nil || !scoreMode {
 		return

--- a/cmd/analyze_gitlab_test.go
+++ b/cmd/analyze_gitlab_test.go
@@ -91,6 +91,42 @@ func TestParseControlsFilters_BothSet(t *testing.T) {
 	}
 }
 
+// --no-controls means "evaluate nothing"; --controls / --skip-controls mean
+// "evaluate this subset". Asking for both is a contradiction, and silently
+// letting one win would hide a broken CI invocation, so it is a usage error.
+func TestParseControlsFilters_NoControlsConflicts(t *testing.T) {
+	origInclude, origSkip, origNone := controlsFilter, skipControls, noControls
+	defer func() { controlsFilter, skipControls, noControls = origInclude, origSkip, origNone }()
+
+	for _, tc := range []struct{ name, include, skip string }{
+		{"with --controls", "pipelineMustNotEnableDebugTrace", ""},
+		{"with --skip-controls", "", "pipelineMustNotEnableDebugTrace"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			controlsFilter, skipControls, noControls = tc.include, tc.skip, true
+			_, _, err := parseControlsFilters()
+			if err == nil || !strings.Contains(err.Error(), "--no-controls") {
+				t.Fatalf("expected a --no-controls conflict error, got %v", err)
+			}
+		})
+	}
+}
+
+// --no-controls on its own is not a conflict.
+func TestParseControlsFilters_NoControlsAlone(t *testing.T) {
+	origInclude, origSkip, origNone := controlsFilter, skipControls, noControls
+	defer func() { controlsFilter, skipControls, noControls = origInclude, origSkip, origNone }()
+
+	controlsFilter, skipControls, noControls = "", "", true
+	include, skip, err := parseControlsFilters()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(include) != 0 || len(skip) != 0 {
+		t.Fatalf("expected no filters, got include=%v skip=%v", include, skip)
+	}
+}
+
 func TestParseControlsFilters_IncludeOnly(t *testing.T) {
 	origInclude, origSkip := controlsFilter, skipControls
 	controlsFilter = "pipelineMustNotEnableDebugTrace,containerImageMustNotUseForbiddenTags"

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -48,6 +48,57 @@ func runWithProvider(p provider.Provider, cmd *cobra.Command, conf *configuratio
 		return err
 	}
 
+	return publishAndFinalize(p, cmd, result, conf, summary)
+}
+
+// publishAndFinalize is the tail both analyze entry points share: publish the
+// run (badge, score service, platform), let the provider run its post-analysis
+// actions, then map the outcome onto the exit code. Keeping it in one place is
+// what stops the two paths from drifting on things like the --no-controls
+// guard below.
+func publishAndFinalize(p provider.Provider, cmd *cobra.Command, result *control.AnalysisResult, conf *configuration.Configuration, summary complianceSummary) error {
+	// Everything here publishes or comments on a verdict. Under
+	// --no-controls there is no verdict: a badge, a score push, a platform
+	// push or an MR comment built from a run that evaluated nothing would
+	// assert a clean pipeline nobody checked. Skip them and say which flags
+	// were ignored, rather than erroring, because CI templates set these
+	// globally and a hard failure would make --no-controls unusable in
+	// exactly the templated pipeline that wants it.
+	if conf.NoControls {
+		warnInertFlagsUnderNoControls()
+		// A CI config that was fetched but does not parse is not a
+		// successful collection: the collector sets LimitedAnalysis and
+		// returns early, so the inventory is empty. It is deliberately not
+		// marked DataCollectionDegraded (it is a user-fixable finding), so
+		// on a normal run the zero-control gate is what catches it.
+		// --no-controls removes that gate, and exiting 0 here would ship an
+		// empty PBOM as if it were complete and swallow the errors.
+		if len(result.CiErrors) > 0 {
+			return &IncompleteDataError{Reasons: result.CiErrors}
+		}
+		// A CI config that is absent, or unusable without producing error
+		// strings (the collector's INVALID-status branch), leaves nothing to
+		// inventory, so an empty PBOM is not a result.
+		//
+		// The condition is GitLabProvider.ComputeCompliance's own, verbatim,
+		// so the two cannot drift apart about what "no usable pipeline"
+		// means. It is scoped to GitLab because the providers disagree here
+		// on purpose: GitLab zeroes the control count on a missing or
+		// invalid CI (so a normal run fails the gate), while GitHub keeps
+		// its count for a repo with no workflows, restored in 0.4.0 so
+		// fleet scanners do not fail on CI-less repositories. --no-controls
+		// removes the gate, so it must not quietly reverse either stance.
+		//
+		// Note the ordering: the publish suppression above is unconditional,
+		// so an unusable collection cannot reach the score service either.
+		// A --no-controls run never publishes, whether it ends in success
+		// or in one of the failures below.
+		if p.Name() == "gitlab" && (result.CiMissing || !result.CiValid) {
+			return &IncompleteDataError{Reasons: []string{"no usable CI configuration found in the project, nothing to inventory"}}
+		}
+		return finalizeRun(result, summary, nil)
+	}
+
 	jsonPayload := buildPublishPayload(p, conf, result, summary)
 	handleScorePublishing(p, conf, result, summary, jsonPayload)
 	platformErr := maybePushPlatform(p, conf, result, summary.score)
@@ -59,11 +110,85 @@ func runWithProvider(p provider.Provider, cmd *cobra.Command, conf *configuratio
 		ScoreMode:  summary.scoreMode,
 		ScorePoint: summary.scorePoint,
 	}
-	if err := p.PostAnalysisActions(cmd, result, conf, pas); err != nil {
-		return err
+	if cmd != nil {
+		if err := p.PostAnalysisActions(cmd, result, conf, pas); err != nil {
+			return err
+		}
 	}
 
 	return finalizeRun(result, summary, platformErr)
+}
+
+// inertFlagsUnderNoControls lists the flags that read or publish a score and
+// are therefore no-ops on a --no-controls run, so the user is told once
+// instead of quietly getting less than they asked for.
+func inertFlagsUnderNoControls() []string {
+	var ignored []string
+	for _, f := range []struct {
+		name string
+		set  bool
+	}{
+		{"--min-points", minPointsSet},
+		{"--min-score", minScore != ""},
+		{"--threshold", thresholdSet},
+		{"--score", showScore},
+		{"--score-point", showScorePoint},
+		{"--badge", badge},
+		{"--score-push", pushScore},
+		{"--mr-comment", mrComment},
+		{"--platform", platformURL != ""},
+		{"--sarif", sarifFile != ""},
+		{"--glsast", glsastFile != ""},
+	} {
+		if f.set {
+			ignored = append(ignored, f.name)
+		}
+	}
+	return ignored
+}
+
+// warnInertFlagsUnderNoControls prints that one-time notice.
+func warnInertFlagsUnderNoControls() {
+	if ignored := inertFlagsUnderNoControls(); len(ignored) > 0 {
+		fmt.Fprintf(os.Stderr, "Note: --no-controls evaluated nothing, so there is no score to gate or publish; ignored: %s\n", joinStrings(ignored))
+	}
+}
+
+// applyControlScope copies the run's control-scope flags onto conf: which
+// controls to run (--controls / --skip-controls) and whether to run any at
+// all (--no-controls).
+//
+// The three analyze entry points all go through here rather than assigning
+// the fields themselves. The whole --no-controls safety chain (score
+// withholding, MarkAllSkipped, publish suppression, the gate no-op) keys off
+// conf.NoControls, so one provider path quietly losing the assignment would
+// evaluate everything, score it and publish it for a user who asked for no
+// verdict at all.
+func applyControlScope(conf *configuration.Configuration, includeOnly, skip []string) {
+	conf.ControlsFilter = includeOnly
+	conf.SkipControlsFilter = skip
+	conf.NoControls = noControls
+}
+
+// providerControlEntries returns the provider's catalog with this run's skip
+// semantics already applied: --no-controls marks every entry skipped, so no
+// artifact can stamp a verdict on a control that never ran; otherwise the
+// --controls / --skip-controls filter applies as usual.
+//
+// Every artifact writer that reports a PER-CONTROL status must go through
+// here. control.StatusFor returns "passed" for an unskipped control with
+// zero findings on a valid run, and under --no-controls the two filters are
+// empty by construction (they are mutually exclusive with the flag), so a
+// writer calling MarkSkippedByFilter directly marks nothing and reports a
+// clean posture for a run that evaluated nothing.
+func providerControlEntries(p provider.Provider, conf *configuration.Configuration) []control.ControlEntry {
+	entries := p.Controls(conf.PlumberConfig)
+	if conf.NoControls {
+		control.MarkAllSkipped(entries, noControlsSkipReason)
+		return entries
+	}
+	control.MarkSkippedByFilter(entries, conf.ControlsFilter, conf.SkipControlsFilter)
+	return entries
 }
 
 // buildComplianceSummary assembles the gate inputs for a run: the Plumber
@@ -71,7 +196,13 @@ func runWithProvider(p provider.Provider, cmd *cobra.Command, conf *configuratio
 // deprecated --threshold gate — the legacy passing-controls percentage.
 func buildComplianceSummary(p provider.Provider, result *control.AnalysisResult, conf *configuration.Configuration) complianceSummary {
 	compliance, controlCount := p.ComputeCompliance(result, conf)
-	scoreMode := true // the score banner is shown by default (#218); --score is a no-op
+	// The score banner is shown by default (#218); --score is a no-op.
+	// Under --no-controls nothing was evaluated, so zero findings would
+	// otherwise compute a perfect 100/100 and stamp it on the banner, the
+	// JSON report, the PBOM and the CycloneDX output. scoreMode=false is
+	// the existing withhold-the-score path (every consumer already guards
+	// on a nil score), so the outputs carry no score instead of a fake one.
+	scoreMode := !conf.NoControls
 	return complianceSummary{
 		compliance:   compliance,
 		controlCount: controlCount,
@@ -83,6 +214,7 @@ func buildComplianceSummary(p provider.Provider, result *control.AnalysisResult,
 		score:        computeScoreResult(result, scoreMode),
 		scoreMode:    scoreMode,
 		scorePoint:   showScorePoint,
+		noControls:   conf.NoControls,
 	}
 }
 
@@ -91,14 +223,26 @@ func buildComplianceSummary(p provider.Provider, result *control.AnalysisResult,
 func outputTextWithProvider(p provider.Provider, result *control.AnalysisResult, conf *configuration.Configuration, s complianceSummary, controlsFilterList, skipControlsList []string) error {
 	renderRunHeader(p, result, conf)
 
-	if s.controlCount == 0 {
+	// The zero-control warning describes a run that meant to check something
+	// and could not. Under --no-controls that is the request, not a failure;
+	// the header already says so. CI errors are the exception: they are why
+	// the artifacts are empty, so they stay visible.
+	switch {
+	case s.controlCount == 0 && !s.noControls:
 		printNoControlsWarning(result)
+	case s.noControls && len(result.CiErrors) > 0:
+		printCIErrors(result)
 	}
 	if result.DataCollectionDegraded {
 		renderDegradedCaveat(result.DegradedReasons)
 	}
 
 	controls, groups := buildProviderControlSummariesAndGroups(p, result, conf, controlsFilterList, skipControlsList)
+	// Nothing was selected, so listing every control as "skipped" is noise
+	// that reads like a misconfiguration.
+	if s.noControls {
+		controls, groups = nil, nil
+	}
 	// On a degraded run the per-control verdict is untrustworthy; render only
 	// the findings we DID surface (a real violation on partial data is still
 	// real) and drop the green stat blocks (#220).
@@ -129,11 +273,16 @@ func outputTextWithProvider(p provider.Provider, result *control.AnalysisResult,
 	// On a degraded run suppress the issues table when empty (it would imply a
 	// clean pipeline we never evaluated) and the score, which would present
 	// partial data as a verdict (#220).
-	if !result.DataCollectionDegraded || len(result.Findings) > 0 {
+	// Under --no-controls there are no controls to tabulate, and an empty
+	// "(none with open issues)" table reads like a clean scan.
+	if (!result.DataCollectionDegraded || len(result.Findings) > 0) && !s.noControls {
 		printIssuesTable(controls)
 		fmt.Println()
 	}
 
+	if s.noControls {
+		printNoControlsSummary()
+	}
 	printSummaryScoreBanner(s.score, s.scoreMode, result.DataCollectionDegraded)
 	if s.scorePoint && s.score != nil && !result.DataCollectionDegraded {
 		printScoreBreakdown(s.score)
@@ -189,7 +338,7 @@ func writeOutputsWithProvider(p provider.Provider, result *control.AnalysisResul
 		fmt.Fprintf(os.Stderr, "Note: data collection was incomplete — artifacts are written but marked degraded; treat them as partial.\n")
 	}
 	if outputFile != "" {
-		params := jsonOutputParams{filePath: outputFile, provider: p.Name(), includeOnly: conf.ControlsFilter, skip: conf.SkipControlsFilter}
+		params := jsonOutputParams{filePath: outputFile, provider: p.Name(), includeOnly: conf.ControlsFilter, skip: conf.SkipControlsFilter, noControls: conf.NoControls}
 		if err := writeJSONToFile(result, conf.PlumberConfig, s, params); err != nil {
 			return err
 		}
@@ -207,13 +356,20 @@ func writeOutputsWithProvider(p provider.Provider, result *control.AnalysisResul
 		}
 		fmt.Fprintf(os.Stderr, "PBOM (CycloneDX) written to: %s\n", pbomCycloneDXFile)
 	}
-	if sarifFile != "" {
+	// SARIF and the GitLab SAST report have no honest empty form. An
+	// empty SARIF is the documented signal that makes Code Scanning clear
+	// previously-reported alerts, and buildGLSAST leaves Scan.Status at
+	// "success", so uploading either from a run that evaluated nothing
+	// dismisses real alerts and shows a clean dashboard for a pipeline
+	// nobody checked. There is no field that fixes that, so they are not
+	// written at all; warnInertFlagsUnderNoControls names them.
+	if sarifFile != "" && !conf.NoControls {
 		if err := writeSARIFToFile(result, sarifFile, p.Name()); err != nil {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "SARIF written to: %s\n", sarifFile)
 	}
-	if glsastFile != "" {
+	if glsastFile != "" && !conf.NoControls {
 		if err := writeGLSASTToFile(result, glsastFile, p.Name()); err != nil {
 			return err
 		}
@@ -250,22 +406,7 @@ func presentResultWithProvider(p provider.Provider, cmd *cobra.Command, result *
 	if err := writeOutputsWithProvider(p, result, conf, summary); err != nil {
 		return err
 	}
-	jsonPayload := buildPublishPayload(p, conf, result, summary)
-	handleScorePublishing(p, conf, result, summary, jsonPayload)
-	platformErr := maybePushPlatform(p, conf, result, summary.score)
-	pas := provider.PostActionSummary{
-		Passed:     summary.passed(),
-		GateLine:   summary.gateLine(),
-		Score:      summary.score,
-		ScoreMode:  summary.scoreMode,
-		ScorePoint: summary.scorePoint,
-	}
-	if cmd != nil {
-		if err := p.PostAnalysisActions(cmd, result, conf, pas); err != nil {
-			return err
-		}
-	}
-	return finalizeRun(result, summary, platformErr)
+	return publishAndFinalize(p, cmd, result, conf, summary)
 }
 
 func joinStrings(ss []string) string {

--- a/cmd/csv.go
+++ b/cmd/csv.go
@@ -177,8 +177,7 @@ func csvStatusReason(status string, e control.ControlEntry, result *control.Anal
 // writeCSVToFile walks the provider's control catalog and writes the per-control
 // CSV posture to filePath.
 func writeCSVToFile(p provider.Provider, result *control.AnalysisResult, conf *configuration.Configuration, filePath string) error {
-	entries := p.Controls(conf.PlumberConfig)
-	control.MarkSkippedByFilter(entries, conf.ControlsFilter, conf.SkipControlsFilter)
+	entries := providerControlEntries(p, conf)
 	records := buildCSV(entries, result)
 
 	var buf bytes.Buffer

--- a/cmd/gate_test.go
+++ b/cmd/gate_test.go
@@ -129,6 +129,54 @@ func TestGate_NoControlsFailsDespitePerfectScore(t *testing.T) {
 	}
 }
 
+// TestGate_NoControlsFlagPasses is the counterpart of the test above: the
+// zero-control fail-closed exists to catch a run that MEANT to check
+// something and checked nothing. --no-controls means the user asked for
+// nothing to be checked, so the same zero must pass. There is no score to
+// gate on either, which is why the gate has nothing left to fail.
+//
+// This is what lets a PBOM-only pipeline exit 0 without pretending it was
+// scored.
+func TestGate_NoControlsFlagPasses(t *testing.T) {
+	s := complianceSummary{minPoints: 100, controlCount: 0, noControls: true}
+	if err := s.gateErr(); err != nil {
+		t.Fatalf("--no-controls must not fail the gate, got %v", err)
+	}
+	if !s.passed() {
+		t.Fatal("--no-controls must report passed")
+	}
+	if !strings.Contains(s.gateLine(), "no controls requested") {
+		t.Fatalf("gateLine %q must say the run asked for no controls, not that scoring failed", s.gateLine())
+	}
+}
+
+// TestGate_NoControlsFlagIgnoresScoreGates pins that the score gates are
+// inert rather than fatal under --no-controls. A CI template that sets
+// --min-points or --min-score globally must not turn a deliberate
+// PBOM-only run into a failure: with nothing evaluated there is no score
+// for those gates to read.
+func TestGate_NoControlsFlagIgnoresScoreGates(t *testing.T) {
+	s := complianceSummary{
+		minPoints: 100, minPointsSet: true, minScore: "A",
+		controlCount: 0, noControls: true,
+	}
+	if err := s.gateErr(); err != nil {
+		t.Fatalf("score gates must be inert under --no-controls, got %v", err)
+	}
+
+	// The deprecated --threshold gate normally wins over everything, and it
+	// reads the passing-controls percentage, which is 0 when nothing ran. It
+	// must be inert too, or --no-controls would still fail for anyone whose
+	// CI template still passes --threshold.
+	withThreshold := complianceSummary{
+		thresholdSet: true, threshold: 100, compliance: 0,
+		controlCount: 0, noControls: true,
+	}
+	if err := withThreshold.gateErr(); err != nil {
+		t.Fatalf("the deprecated --threshold gate must be inert under --no-controls, got %v", err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // gateErr — deprecated --threshold gate
 // ---------------------------------------------------------------------------

--- a/cmd/legacy_json.go
+++ b/cmd/legacy_json.go
@@ -42,9 +42,20 @@ func _minAccessLevelGitlab(levels []gitlab.BranchProtectionAccessLevel) int {
 // applied via control.MarkSkippedByFilter so the per-block `skipped:`
 // field tracks both the YAML enabled flag AND the CLI filter. Pass
 // nil/empty when no filter is active.
-func legacyResultsByName(result *control.AnalysisResult, pc *configuration.PlumberConfig, provider string, includeOnly, skip []string) map[string]any {
+func legacyResultsByName(result *control.AnalysisResult, pc *configuration.PlumberConfig, provider string, includeOnly, skip []string, noControls bool) map[string]any {
 	if result == nil || pc == nil {
 		return nil
+	}
+	// --no-controls: the blocks still describe the catalog, but every one of
+	// them must read as "not evaluated". `status` exists so consumers stop
+	// inferring a pass from an empty issues list, so it is exactly the field
+	// that has to tell the truth for a run that evaluated nothing.
+	markSkipped := func(entries []control.ControlEntry) {
+		if noControls {
+			control.MarkAllSkipped(entries, noControlsSkipReason)
+			return
+		}
+		control.MarkSkippedByFilter(entries, includeOnly, skip)
 	}
 	out := map[string]any{}
 	findingsByControl := control.FindingsByControl(result.Findings)
@@ -52,7 +63,7 @@ func legacyResultsByName(result *control.AnalysisResult, pc *configuration.Plumb
 	switch provider {
 	case "github":
 		entries := control.GitHubControls(pc)
-		control.MarkSkippedByFilter(entries, includeOnly, skip)
+		markSkipped(entries)
 		for _, e := range entries {
 			fs := findingsByControl[e.ControlName]
 			key, block := buildLegacyResultGitHub(e, result, pc, fs)
@@ -63,7 +74,7 @@ func legacyResultsByName(result *control.AnalysisResult, pc *configuration.Plumb
 		}
 	default:
 		entries := control.GitLabControls(pc)
-		control.MarkSkippedByFilter(entries, includeOnly, skip)
+		markSkipped(entries)
 		for _, e := range entries {
 			fs := findingsByControl[e.ControlName]
 			key, block := buildLegacyResult(e, result, pc, fs)

--- a/cmd/no_controls_outputs_test.go
+++ b/cmd/no_controls_outputs_test.go
@@ -1,0 +1,958 @@
+package cmd
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/control"
+	"github.com/getplumber/plumber/gitlab"
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
+	"github.com/getplumber/plumber/internal/ir"
+	"github.com/getplumber/plumber/provider"
+	"github.com/getplumber/plumber/utils"
+	"github.com/spf13/cobra"
+)
+
+// noControlsPC loads the shipped default config, so these tests assert on
+// what a real user's artifacts look like rather than on a hand-built config.
+func noControlsPC(t *testing.T) *configuration.PlumberConfig {
+	t.Helper()
+	pc, _, _, err := configuration.LoadPlumberConfig("../defaultConfig/.plumber.yaml")
+	if err != nil {
+		t.Fatalf("load shipped default config: %v", err)
+	}
+	return pc
+}
+
+// TestJSONReport_NoControlsDoesNotClaimControlsPassed pins that the JSON
+// artifact cannot be read as a clean scan. Withholding the score is not
+// enough: the per-control `*Result` blocks are built from the catalog, not
+// from the score, so with zero findings on a valid run every one of them
+// would otherwise stamp `status: "passed"` for a control that never ran.
+//
+// The `status` field exists precisely so consumers stop inferring pass from
+// an empty issues list, so it is the field that must tell the truth here.
+//
+// Both providers are covered because legacyResultsByName has two genuinely
+// separate branches (GitHub blocks come from buildLegacyResultGitHub), and
+// the GitLab half passing says nothing about the GitHub one.
+func TestJSONReport_NoControlsDoesNotClaimControlsPassed(t *testing.T) {
+	pc := noControlsPC(t)
+	for _, prov := range []string{"gitlab", "github"} {
+		t.Run(prov, func(t *testing.T) {
+			result := &control.AnalysisResult{CiValid: true, ProjectPath: "group/project"}
+			path := filepath.Join(t.TempDir(), "analysis.json")
+
+			conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
+			s := buildComplianceSummary(&provider.GitLabProvider{}, result, conf)
+			params := jsonOutputParams{filePath: path, provider: prov, noControls: conf.NoControls}
+			if err := writeJSONToFile(result, pc, s, params); err != nil {
+				t.Fatalf("write json: %v", err)
+			}
+
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read json: %v", err)
+			}
+			var out map[string]any
+			if err := json.Unmarshal(raw, &out); err != nil {
+				t.Fatalf("parse json: %v", err)
+			}
+
+			if out["noControls"] != true {
+				t.Errorf("the report must say explicitly that no control ran, got noControls=%v", out["noControls"])
+			}
+			if _, ok := out["plumberScore"]; ok {
+				t.Errorf("the score must be withheld, got %v", out["plumberScore"])
+			}
+
+			checked := 0
+			for k, v := range out {
+				if !strings.HasSuffix(k, "Result") {
+					continue
+				}
+				block, ok := v.(map[string]any)
+				if !ok {
+					continue
+				}
+				checked++
+				if block["status"] != control.StatusSkipped {
+					t.Errorf("%s: status %v, want %q: a control that never ran must not report passed", k, block["status"], control.StatusSkipped)
+				}
+				// The legacy `skipped` boolean is not emitted by every block;
+				// when it is, it must agree with the status.
+				if b, ok := block["skipped"]; ok && b != true {
+					t.Errorf("%s: skipped=%v, want true", k, b)
+				}
+			}
+			if checked == 0 {
+				t.Fatal("no per-control blocks in the report, this test would pass vacuously")
+			}
+		})
+	}
+}
+
+// A run WITHOUT the flag must still report real per-control verdicts, on
+// both providers: that is what stops the assertions above from passing by
+// the blocks simply being absent.
+func TestJSONReport_ControlsStillReportedByDefault(t *testing.T) {
+	pc := noControlsPC(t)
+	for _, prov := range []string{"gitlab", "github"} {
+		t.Run(prov, func(t *testing.T) {
+			result := &control.AnalysisResult{CiValid: true, ProjectPath: "group/project"}
+			path := filepath.Join(t.TempDir(), "analysis.json")
+
+			conf := &configuration.Configuration{PlumberConfig: pc}
+			s := buildComplianceSummary(&provider.GitLabProvider{}, result, conf)
+			if err := writeJSONToFile(result, pc, s, jsonOutputParams{filePath: path, provider: prov}); err != nil {
+				t.Fatalf("write json: %v", err)
+			}
+			raw, _ := os.ReadFile(path)
+			var out map[string]any
+			if err := json.Unmarshal(raw, &out); err != nil {
+				t.Fatalf("parse json: %v", err)
+			}
+			if _, ok := out["noControls"]; ok {
+				t.Error("noControls must be absent on a normal run")
+			}
+			passed := 0
+			for k, v := range out {
+				if block, ok := v.(map[string]any); ok && strings.HasSuffix(k, "Result") {
+					if block["status"] == control.StatusPassed {
+						passed++
+					}
+				}
+			}
+			if passed == 0 {
+				t.Fatal("a normal clean run must still report passed controls")
+			}
+		})
+	}
+}
+
+// complianceAssertionProps are the CycloneDX properties that state a
+// VERDICT about a component rather than record what was collected. They are
+// all derived from findings, so on a --no-controls run every one of them
+// must be absent: the artifact may list what the pipeline uses, and may not
+// say whether it is acceptable.
+//
+// plumber:up-to-date is in the list because the GitHub generator repurposes
+// Include.UpToDate as its action-pinning indicator.
+var complianceAssertionProps = []string{
+	"plumber:authorized",
+	"plumber:forbidden-tag",
+	"plumber:up-to-date",
+	"plumber:archived",
+	"plumber:has-cve",
+	"plumber:advisories",
+}
+
+// gitLabPBOMFixture is a result carrying one collected image and one
+// tracked include, so both verdict surfaces of the PBOM are exercised: the
+// per-image flags AND the include `upToDate` field. An include is required
+// here, not optional: without one, processIncludes produces nothing and any
+// assertion about include verdicts passes vacuously.
+func gitLabPBOMFixture() *control.AnalysisResult {
+	origin := gitlab.GitlabPipelineOriginDataFull{}
+	origin.OriginType = "include"
+	origin.FromPlumber = true
+	origin.PlumberOrigin = gitlab.GitlabPipelineJobPlumberOrigin{Path: "group/templates", LatestVersion: "2.0.0"}
+	origin.GitlabIncludeOrigin = gitlab.IncludeOriginWithoutRef{Location: "group/templates/ci.yml", Project: "group/templates"}
+	origin.Version = "1.0.0"
+	// Out of date upstream: this is exactly what includesMustBeUpToDate
+	// reports, so the PBOM must not state it on a run that ran no control.
+	origin.UpToDate = false
+
+	// processIncludes suppresses the upToDate verdict in TWO branches, and
+	// they are reached by different origin shapes: FromPlumber above, and
+	// the GitLab CI/CD Catalog component below. A fixture with only the
+	// first leaves the component guard untested, so a regression there
+	// would leak the verdict into a --no-controls PBOM undetected.
+	component := gitlab.GitlabPipelineOriginDataFull{}
+	component.OriginType = "component"
+	component.FromGitlabCatalog = true
+	component.GitlabComponent = gitlab.GitlabPipelineJobGitlabComponent{
+		ComponentName:          "scan",
+		ComponentLatestVersion: "3.0.0",
+		ComponentIncludePath:   "gitlab.example/group/components/scan",
+	}
+	component.GitlabIncludeOrigin = gitlab.IncludeOriginWithoutRef{Location: "gitlab.example/group/components/scan", Project: "group/components"}
+	component.Version = "2.0.0"
+	component.UpToDate = false
+
+	return &control.AnalysisResult{
+		CiValid:     true,
+		ProjectPath: "group/project",
+		PipelineImageData: &gitlab.GitlabPipelineImageData{
+			CiValid: true,
+			Images: []gitlab.GitlabPipelineImageInfo{
+				{Link: "docker.io/library/alpine:latest", Name: "alpine", Tag: "latest", Registry: "docker.io", Job: "build"},
+			},
+		},
+		PipelineOriginData: &gitlab.GitlabPipelineOriginData{
+			CiValid: true,
+			Origins: []gitlab.GitlabPipelineOriginDataFull{origin, component},
+		},
+	}
+}
+
+// gitHubPBOMFixture carries one image and one action, plus the findings
+// that make the GitHub compliance builder actually populate its maps.
+//
+// The findings are the point. On the GitHub path every consumed compliance
+// field is derived from result.Findings, so a fixture with none makes
+// BuildGitHubPBOMCompliance return empty maps and NO verdict property is
+// emitted whether or not --no-controls suppressed it: an assertion that the
+// properties are absent would hold either way and test nothing.
+//
+// A real --no-controls run does have zero findings (evaluatePolicies
+// returns early), so this fixture is deliberately not that run. It pins the
+// WRITER's contract, which is what the guard actually promises: verdicts are
+// suppressed because the user asked for no controls, not because the
+// findings slice happened to be empty. That is the property that has to
+// survive a future compliance field sourced from collected state.
+func gitHubPBOMFixture() *control.AnalysisResult {
+	return &control.AnalysisResult{
+		CiValid:     true,
+		ProjectPath: "owner/repo",
+		GitHubPipeline: &ir.NormalizedPipeline{
+			Provider:    ir.Provider("github"),
+			ProjectPath: "owner/repo",
+			Jobs: []ir.Job{{
+				Name:  "build",
+				Image: &ir.Image{Name: "alpine", Tag: "latest", Registry: "docker.io"},
+				Uses:  []ir.Action{{Uses: "actions/checkout@v4"}},
+			}},
+		},
+		Findings: []opaengine.Finding{
+			{
+				Code: string(control.CodeActionUnpinned),
+				Data: map[string]any{"uses": "actions/checkout@v4"},
+			},
+			{
+				Code: string(control.CodeActionArchivedRepo),
+				Data: map[string]any{"uses": "actions/checkout@v4"},
+			},
+			{
+				Code: string(control.CodeImageForbiddenTag),
+				Data: map[string]any{"link": "docker.io/alpine:latest"},
+			},
+		},
+	}
+}
+
+// TestPBOM_NoControlsDoesNotAssertCompliance covers every PBOM writer on
+// every provider: four call sites, each routing through its own
+// noControlsAware* guard, and the CycloneDX pair is the documented primary
+// use case of the flag (`--pbom-cyclonedx cdx.json --no-controls`).
+//
+// The flags these guards suppress come from findings, not from the score,
+// so withholding the score is not enough: a zero-findings run would
+// otherwise stamp forbiddenTag:false / authorized:true on every image and
+// assert exactly the checks --no-controls skipped, inside the artifact the
+// flag exists to produce.
+func TestPBOM_NoControlsDoesNotAssertCompliance(t *testing.T) {
+	pc := noControlsPC(t)
+	// mustMention names the entries that have to appear in the artifact for
+	// the assertions below to mean anything. For GitLab that is BOTH include
+	// shapes: processIncludes suppresses the upToDate verdict in two
+	// separate branches (a Plumber-tracked include and a GitLab CI/CD
+	// Catalog component), and a fixture with only one leaves the other
+	// guard unexercised.
+	gitLabIncludes := []string{"group/templates/ci.yml", "gitlab.example/group/components/scan"}
+	for _, tc := range []struct {
+		name        string
+		provider    provider.Provider
+		result      *control.AnalysisResult
+		cycloneDX   bool
+		mustMention []string
+	}{
+		{"gitlab/pbom", &provider.GitLabProvider{}, gitLabPBOMFixture(), false, gitLabIncludes},
+		{"gitlab/cyclonedx", &provider.GitLabProvider{}, gitLabPBOMFixture(), true, gitLabIncludes},
+		{"github/pbom", &provider.GitHubProvider{}, gitHubPBOMFixture(), false, []string{"actions/checkout"}},
+		{"github/cyclonedx", &provider.GitHubProvider{}, gitHubPBOMFixture(), true, []string{"actions/checkout"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "pbom.json")
+			conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
+			var err error
+			if tc.cycloneDX {
+				err = tc.provider.WritePBOMCycloneDX(tc.result, conf, path, nil, false)
+			} else {
+				err = tc.provider.WritePBOM(tc.result, conf, path, nil, false)
+			}
+			if err != nil {
+				t.Fatalf("write pbom: %v", err)
+			}
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read pbom: %v", err)
+			}
+
+			for _, want := range tc.mustMention {
+				if !strings.Contains(string(raw), want) {
+					t.Fatalf("%q missing from the artifact; the verdict assertions below would be vacuous", want)
+				}
+			}
+
+			if tc.cycloneDX {
+				assertCycloneDXClaimsNothing(t, raw)
+				return
+			}
+			assertPBOMClaimsNothing(t, raw)
+		})
+	}
+}
+
+func assertCycloneDXClaimsNothing(t *testing.T, raw []byte) {
+	t.Helper()
+	var cdx struct {
+		Components []struct {
+			Name       string `json:"name"`
+			Properties []struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			} `json:"properties"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal(raw, &cdx); err != nil {
+		t.Fatalf("parse cyclonedx: %v", err)
+	}
+	if len(cdx.Components) == 0 {
+		t.Fatal("the CycloneDX output must still carry the collected inventory")
+	}
+	for _, c := range cdx.Components {
+		for _, prop := range c.Properties {
+			for _, banned := range complianceAssertionProps {
+				if prop.Name == banned {
+					t.Errorf("component %q asserts %s=%s for a control that never ran", c.Name, prop.Name, prop.Value)
+				}
+			}
+		}
+	}
+	if strings.Contains(string(raw), "plumber:score") {
+		t.Error("the CycloneDX output must not carry a score")
+	}
+}
+
+func assertPBOMClaimsNothing(t *testing.T, raw []byte) {
+	t.Helper()
+	var bom struct {
+		ContainerImages []map[string]any `json:"containerImages"`
+		Includes        []map[string]any `json:"includes"`
+		PlumberScore    any              `json:"plumberScore"`
+	}
+	if err := json.Unmarshal(raw, &bom); err != nil {
+		t.Fatalf("parse pbom: %v", err)
+	}
+	if len(bom.ContainerImages) == 0 {
+		t.Fatal("the PBOM must still carry the collected image inventory")
+	}
+	if len(bom.Includes) == 0 {
+		t.Fatal("the PBOM must still carry the collected include inventory, otherwise the include assertions are vacuous")
+	}
+	if bom.PlumberScore != nil {
+		t.Errorf("the PBOM must not carry a score, got %v", bom.PlumberScore)
+	}
+	for _, entry := range append(append([]map[string]any{}, bom.ContainerImages...), bom.Includes...) {
+		for _, k := range []string{"authorized", "forbiddenTag", "upToDate", "archived", "hasCve", "advisories"} {
+			if v, ok := entry[k]; ok {
+				t.Errorf("%v asserts %s=%v for a control that never ran", entry["image"], k, v)
+			}
+		}
+	}
+}
+
+// TestPBOM_ComplianceStillAssertedByDefault stops the test above from
+// passing vacuously: without the flag, the GitLab PBOM does stamp the
+// per-image verdict on every image, which is the behaviour --no-controls
+// has to suppress.
+func TestPBOM_ComplianceStillAssertedByDefault(t *testing.T) {
+	pc := noControlsPC(t)
+	path := filepath.Join(t.TempDir(), "pbom.json")
+	conf := &configuration.Configuration{PlumberConfig: pc}
+	if err := (&provider.GitLabProvider{}).WritePBOM(gitLabPBOMFixture(), conf, path, nil, false); err != nil {
+		t.Fatalf("write pbom: %v", err)
+	}
+	raw, _ := os.ReadFile(path)
+	var bom struct {
+		ContainerImages []map[string]any `json:"containerImages"`
+		Includes        []map[string]any `json:"includes"`
+	}
+	if err := json.Unmarshal(raw, &bom); err != nil {
+		t.Fatalf("parse pbom: %v", err)
+	}
+	if len(bom.ContainerImages) == 0 || len(bom.Includes) < 2 {
+		t.Fatalf("fixture produced %d images and %d includes, expected both include shapes", len(bom.ContainerImages), len(bom.Includes))
+	}
+	for _, img := range bom.ContainerImages {
+		if _, ok := img["authorized"]; !ok {
+			t.Fatalf("without --no-controls the PBOM must still carry the per-image verdict, got %v", img)
+		}
+	}
+	// The include verdict too: suppressing it must be scoped to
+	// --no-controls, not a blanket removal.
+	for _, inc := range bom.Includes {
+		if _, ok := inc["upToDate"]; !ok {
+			t.Fatalf("without --no-controls the PBOM must still carry the include verdict, got %v", inc)
+		}
+		if inc["latestVersion"] == nil || inc["latestVersion"] == "" {
+			t.Fatalf("latestVersion is collected data and must survive either way, got %v", inc)
+		}
+	}
+
+	// Same on the GitHub writer, whose compliance fields come from a
+	// separate builder. Without this the GitHub half of the suppression
+	// test above could pass by emitting nothing at all.
+	ghPath := filepath.Join(t.TempDir(), "gh-pbom.json")
+	if err := (&provider.GitHubProvider{}).WritePBOM(gitHubPBOMFixture(), &configuration.Configuration{PlumberConfig: pc}, ghPath, nil, false); err != nil {
+		t.Fatalf("write github pbom: %v", err)
+	}
+	ghRaw, _ := os.ReadFile(ghPath)
+	var ghBOM struct {
+		ContainerImages []map[string]any `json:"containerImages"`
+		Includes        []map[string]any `json:"includes"`
+	}
+	if err := json.Unmarshal(ghRaw, &ghBOM); err != nil {
+		t.Fatalf("parse github pbom: %v", err)
+	}
+	verdicts := 0
+	for _, entry := range append(append([]map[string]any{}, ghBOM.ContainerImages...), ghBOM.Includes...) {
+		for _, k := range []string{"forbiddenTag", "upToDate", "archived"} {
+			if _, ok := entry[k]; ok {
+				verdicts++
+			}
+		}
+	}
+	if verdicts == 0 {
+		t.Fatal("without --no-controls the GitHub PBOM must carry its verdicts, otherwise the GitHub suppression subtests prove nothing")
+	}
+}
+
+// recordingProvider wraps the real GitLab provider so the test only has to
+// override the one method it observes; embedding keeps it a full Provider.
+type recordingProvider struct {
+	*provider.GitLabProvider
+	postCalled bool
+}
+
+func (p *recordingProvider) PostAnalysisActions(cmd *cobra.Command, result *control.AnalysisResult, conf *configuration.Configuration, s provider.PostActionSummary) error {
+	p.postCalled = true
+	return nil
+}
+
+// TestPublishAndFinalize_NoControlsSkipsPublishing pins the guard that is
+// the whole safety of the feature. Nothing else stops a fake publish: under
+// --no-controls with --score-push set, effectiveScorePush() still returns
+// true, the run is not degraded, and buildPublishPayload still yields a
+// payload, so the early return is the only thing keeping a badge or a
+// platform push built from zero findings off the wire.
+func TestPublishAndFinalize_NoControlsSkipsPublishing(t *testing.T) {
+	oPush, oPlatform := pushScore, platformURL
+	defer func() { pushScore, platformURL = oPush, oPlatform }()
+	pushScore, platformURL = true, ""
+
+	result := &control.AnalysisResult{CiValid: true, ProjectPath: "group/project"}
+	pc := noControlsPC(t)
+
+	p := &recordingProvider{GitLabProvider: &provider.GitLabProvider{}}
+	conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
+	s := buildComplianceSummary(p, result, conf)
+	var err error
+	stderr := captureStderr(t, func() {
+		err = publishAndFinalize(p, &cobra.Command{}, result, conf, s)
+	})
+	if err != nil {
+		t.Fatalf("--no-controls run must not fail: %v", err)
+	}
+	if p.postCalled {
+		t.Fatal("post-analysis actions (badge, MR comment) must not run for a run that evaluated nothing")
+	}
+	// The score push is a separate call from PostAnalysisActions and would
+	// POST a report built from zero findings. handleScorePublishing always
+	// announces itself on stderr when it runs, whether it publishes or
+	// explains why it skipped, so the absence of any of its messages is the
+	// evidence that it was never entered at all.
+	//
+	// The ignored-flags notice legitimately mentions --score-push, so it is
+	// removed before looking for push output.
+	var pushOutput []string
+	for _, line := range strings.Split(stderr, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "Note: --no-controls") {
+			continue
+		}
+		if strings.Contains(line, "score-push") || strings.Contains(line, "score push") || strings.Contains(line, "Score published") {
+			pushOutput = append(pushOutput, line)
+		}
+	}
+	if len(pushOutput) > 0 {
+		t.Errorf("the score push must not be attempted at all for a run that evaluated nothing, got:\n%s", strings.Join(pushOutput, "\n"))
+	}
+	if !strings.Contains(stderr, "ignored: --score-push") {
+		t.Errorf("the notice must tell the user --score-push was ignored, stderr:\n%s", stderr)
+	}
+
+	// Mirror case: the publish path still runs without the flag. Score push
+	// off so the assertion is about PostAnalysisActions and nothing reaches
+	// the network.
+	pushScore = false
+	p2 := &recordingProvider{GitLabProvider: &provider.GitLabProvider{}}
+	conf2 := &configuration.Configuration{PlumberConfig: pc}
+	s2 := buildComplianceSummary(p2, result, conf2)
+	_ = publishAndFinalize(p2, &cobra.Command{}, result, conf2, s2)
+	if !p2.postCalled {
+		t.Fatal("without --no-controls the post-analysis actions must still run")
+	}
+}
+
+// TestOutputText_NoControlsRendersNothingLikeACleanScan pins the terminal
+// rendering branches. Their whole purpose is that the report must not read
+// like a scan that found nothing wrong, so each of them is a one-line guard
+// whose removal produces exactly that: the "no controls evaluated" failure
+// warning, or an empty "(none with open issues)" table, or every catalog
+// control listed as skipped.
+func TestOutputText_NoControlsRendersNothingLikeACleanScan(t *testing.T) {
+	oPrint := printOutput
+	defer func() { printOutput = oPrint }()
+	printOutput = true
+
+	result := &control.AnalysisResult{CiValid: true, ProjectPath: "group/project", CIConfigSource: "remote"}
+	pc := noControlsPC(t)
+	p := &provider.GitLabProvider{}
+	conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true, GitlabURL: "https://gitlab.example"}
+	s := buildComplianceSummary(p, result, conf)
+
+	out := captureStdout(t, func() {
+		if err := outputTextWithProvider(p, result, conf, s, nil, nil); err != nil {
+			t.Fatalf("render: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "none (--no-controls)") {
+		t.Errorf("the header must state that no control ran, got:\n%s", out)
+	}
+	if strings.Contains(out, "No controls could be evaluated") {
+		t.Errorf("the zero-control FAILURE warning must not fire when zero controls is the request, got:\n%s", out)
+	}
+	if strings.Contains(out, "none with open issues") {
+		t.Errorf("an empty issues table reads as a clean scan, got:\n%s", out)
+	}
+	if strings.Contains(out, "Skipped Controls") {
+		t.Errorf("nothing was selected, so no control should be listed as skipped, got:\n%s", out)
+	}
+	if !strings.Contains(out, "no controls requested, nothing to score") {
+		t.Errorf("the status line must say the run asked for no controls, got:\n%s", out)
+	}
+
+	// The score is not merely absent, it is explained. An output that just
+	// omits the banner reads as a rendering glitch; the run has to say that
+	// nothing was evaluated and that there is therefore no score, or a
+	// reader is left to infer which of the two happened.
+	if !strings.Contains(out, "No control was run") {
+		t.Errorf("the output must state plainly that no control ran, got:\n%s", out)
+	}
+	if !strings.Contains(out, "No Plumber Score") {
+		t.Errorf("the output must state plainly that there is no score, got:\n%s", out)
+	}
+	// ... and no actual grade anywhere.
+	if strings.Contains(out, "/ 100 pts") {
+		t.Errorf("a points figure must never be rendered for a run that evaluated nothing, got:\n%s", out)
+	}
+}
+
+// TestCSVAndOCSF_NoControlsDoNotClaimControlsPassed extends the JSON rule to
+// the other two artifact writers that report a PER-CONTROL verdict. Both
+// build their rows from the provider catalog and stamp control.StatusFor,
+// which returns StatusPassed for an unskipped control with zero findings on
+// a valid run. Under --no-controls the filters are empty by construction
+// (they are mutually exclusive with the flag), so nothing would mark them
+// skipped and every control would report as passing.
+//
+// This matters more here than in the terminal: OCSF and CSV are consumed by
+// GRC platforms and security tooling, which would ingest a fully compliant
+// posture for a run that evaluated nothing.
+func TestCSVAndOCSF_NoControlsDoNotClaimControlsPassed(t *testing.T) {
+	pc := noControlsPC(t)
+	result := &control.AnalysisResult{CiValid: true, ProjectPath: "group/project"}
+	p := &provider.GitLabProvider{}
+
+	t.Run("csv", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "out.csv")
+		conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
+		if err := writeCSVToFile(p, result, conf, path); err != nil {
+			t.Fatalf("write csv: %v", err)
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read csv: %v", err)
+		}
+		records, err := csv.NewReader(strings.NewReader(string(raw))).ReadAll()
+		if err != nil {
+			t.Fatalf("parse csv: %v", err)
+		}
+		if len(records) < 2 {
+			t.Fatal("the CSV must still list the catalog, otherwise this passes vacuously")
+		}
+		for _, row := range records[1:] {
+			if row[3] == control.StatusPassed {
+				t.Errorf("control %q reports passed for a run that evaluated nothing", row[2])
+			}
+		}
+	})
+
+	t.Run("ocsf", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "out.ocsf.json")
+		conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
+		if err := writeOCSFToFile(p, result, conf, path); err != nil {
+			t.Fatalf("write ocsf: %v", err)
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read ocsf: %v", err)
+		}
+		var events []struct {
+			Compliance struct {
+				Status   string `json:"status"`
+				StatusID int    `json:"status_id"`
+			} `json:"compliance"`
+			Message string `json:"message"`
+		}
+		if err := json.Unmarshal(raw, &events); err != nil {
+			t.Fatalf("parse ocsf: %v", err)
+		}
+		if len(events) == 0 {
+			t.Fatal("the OCSF output must still list the catalog, otherwise this passes vacuously")
+		}
+		for _, e := range events {
+			// status_id 1 is OCSF "Pass".
+			if e.Compliance.StatusID == 1 {
+				t.Errorf("OCSF event reports Pass for a run that evaluated nothing: %s", e.Message)
+			}
+		}
+	})
+}
+
+// TestPublishAndFinalize_NoControlsStillFailsOnDegradedData pins the exit
+// code the README and the help text promise: --no-controls exits 0 only
+// when data collection succeeded. An incomplete collection means an
+// incomplete PBOM inventory, so it must still fail (exit 3), and the flag
+// must not be a way to silence that.
+//
+// The guarantee holds only because the --no-controls early return routes
+// through finalizeRun rather than returning nil directly, which is exactly
+// the kind of detail a later refactor of this shared tail would drop.
+func TestPublishAndFinalize_NoControlsStillFailsOnDegradedData(t *testing.T) {
+	pc := noControlsPC(t)
+	p := &recordingProvider{GitLabProvider: &provider.GitLabProvider{}}
+	conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
+	degraded := &control.AnalysisResult{
+		CiValid:                true,
+		ProjectPath:            "group/project",
+		DataCollectionDegraded: true,
+		DegradedReasons:        []string{"merged CI configuration could not be fetched"},
+	}
+
+	err := publishAndFinalize(p, &cobra.Command{}, degraded, conf, buildComplianceSummary(p, degraded, conf))
+	var incomplete *IncompleteDataError
+	if !errors.As(err, &incomplete) {
+		t.Fatalf("--no-controls must not suppress the degraded-collection failure, got %v", err)
+	}
+
+	// Mirror: an intact collection exits 0.
+	intact := &control.AnalysisResult{CiValid: true, ProjectPath: "group/project"}
+	if err := publishAndFinalize(p, &cobra.Command{}, intact, conf, buildComplianceSummary(p, intact, conf)); err != nil {
+		t.Fatalf("--no-controls on an intact collection must exit 0, got %v", err)
+	}
+}
+
+// TestSecurityReports_NotWrittenUnderNoControls covers the two artifacts
+// that have no honest empty form. SARIF and the GitLab SAST report exist to
+// tell a security dashboard what was found, and an empty one is not a
+// neutral statement: writeSARIFToFile's own contract is that "a clean run
+// produces a valid empty-results document so downstream Code Scanning
+// clears any previously-reported alerts", and buildGLSAST leaves
+// Scan.Status at its "success" default unless collection was degraded.
+//
+// So a --no-controls run that uploaded them would dismiss existing Code
+// Scanning alerts and show a clean GitLab Security Dashboard for a pipeline
+// nobody checked. There is no field to set that fixes this, so the files
+// are not written at all and the flags are named in the ignored list.
+func TestSecurityReports_NotWrittenUnderNoControls(t *testing.T) {
+	oSarif, oGLSAST := sarifFile, glsastFile
+	defer func() { sarifFile, glsastFile = oSarif, oGLSAST }()
+
+	dir := t.TempDir()
+	sarifFile = filepath.Join(dir, "out.sarif")
+	glsastFile = filepath.Join(dir, "gl-sast-report.json")
+
+	pc := noControlsPC(t)
+	result := &control.AnalysisResult{CiValid: true, ProjectPath: "group/project"}
+	p := &provider.GitLabProvider{}
+	conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
+
+	if err := writeOutputsWithProvider(p, result, conf, buildComplianceSummary(p, result, conf)); err != nil {
+		t.Fatalf("write outputs: %v", err)
+	}
+	for _, f := range []string{sarifFile, glsastFile} {
+		if _, err := os.Stat(f); err == nil {
+			t.Errorf("%s was written; an empty security report clears existing alerts", filepath.Base(f))
+		}
+	}
+
+	ignored := strings.Join(inertFlagsUnderNoControls(), ",")
+	for _, flag := range []string{"--sarif", "--glsast"} {
+		if !strings.Contains(ignored, flag) {
+			t.Errorf("%s must be named in the ignored-flag notice, got %q", flag, ignored)
+		}
+	}
+
+	// Mirror: without the flag both are written as usual.
+	conf2 := &configuration.Configuration{PlumberConfig: pc}
+	if err := writeOutputsWithProvider(p, result, conf2, buildComplianceSummary(p, result, conf2)); err != nil {
+		t.Fatalf("write outputs: %v", err)
+	}
+	for _, f := range []string{sarifFile, glsastFile} {
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("without --no-controls %s must still be written: %v", filepath.Base(f), err)
+		}
+	}
+}
+
+// TestGateLine_NoControlsWinsOverDeprecatedThreshold pins that gateLine and
+// gateErr agree on precedence. gateErr puts the noControls short-circuit
+// first, so --threshold is inert; gateLine must say the same thing, or
+// `--no-controls --threshold 100` renders "PASSED (0.0% of controls
+// passing, deprecated threshold 100%)", a status line that contradicts
+// itself and the flag.
+func TestGateLine_NoControlsWinsOverDeprecatedThreshold(t *testing.T) {
+	s := complianceSummary{
+		thresholdSet: true, threshold: 100, compliance: 0,
+		controlCount: 0, noControls: true,
+	}
+	if err := s.gateErr(); err != nil {
+		t.Fatalf("precondition: the gate must pass, got %v", err)
+	}
+	if got := s.gateLine(); got != "no controls requested, nothing to score" {
+		t.Fatalf("gateLine %q must match the gate it describes", got)
+	}
+}
+
+// TestBuildGitLabConf_WiresNoControls covers the flag-to-config wiring
+// itself. Every other test in this file starts from a Configuration with
+// NoControls already set, so a dropped assignment in a config builder would
+// leave the whole safety chain keyed off a false value and no test would
+// notice: the run would evaluate everything, score it, and publish it.
+func TestBuildGitLabConf_WiresNoControls(t *testing.T) {
+	orig := noControls
+	defer func() { noControls = orig }()
+
+	noControls = true
+	conf := buildGitLabConf("https://gitlab.example", "token", analyzeFlags{}, gitLabRemoteInfo{}, noControlsPC(t), nil, nil)
+	if !conf.NoControls {
+		t.Fatal("--no-controls must reach the Configuration the analysis reads")
+	}
+
+	noControls = false
+	conf = buildGitLabConf("https://gitlab.example", "token", analyzeFlags{}, gitLabRemoteInfo{}, noControlsPC(t), nil, nil)
+	if conf.NoControls {
+		t.Fatal("NoControls must be false without the flag")
+	}
+}
+
+// TestApplyControlScope_IsTheSingleWiringPoint pins the helper the three
+// analyze entry points share. Keeping the three fields together in one
+// place is what stops one provider path from silently losing --no-controls
+// in a future refactor of a config builder.
+func TestApplyControlScope_IsTheSingleWiringPoint(t *testing.T) {
+	orig := noControls
+	defer func() { noControls = orig }()
+
+	noControls = true
+	conf := &configuration.Configuration{}
+	applyControlScope(conf, []string{"a"}, []string{"b"})
+	if !conf.NoControls {
+		t.Error("NoControls not wired")
+	}
+	if len(conf.ControlsFilter) != 1 || len(conf.SkipControlsFilter) != 1 {
+		t.Errorf("filters not wired: %v %v", conf.ControlsFilter, conf.SkipControlsFilter)
+	}
+}
+
+// TestNoControls_HasEnvFallback pins that --no-controls carries a
+// PLUMBER_ANALYZE_* fallback like every other analyze flag, so the GitLab
+// CI component (which passes settings as env vars, not flags) can reach it.
+//
+// It is deliberately not special-cased: anyone able to set this variable can
+// already neutralise the gate with PLUMBER_ANALYZE_MIN_POINTS=0 or
+// PLUMBER_ANALYZE_THRESHOLD=0, so withholding the fallback here would buy no
+// security while making one flag behave unlike the rest.
+func TestNoControls_HasEnvFallback(t *testing.T) {
+	if envKeys["no-controls"] != "PLUMBER_ANALYZE_NO_CONTROLS" {
+		t.Fatalf("--no-controls must keep its env fallback like every other flag, got %q", envKeys["no-controls"])
+	}
+}
+
+// TestPublishAndFinalize_NoControlsFailsOnInvalidCIConfig covers the one
+// collection failure that is deliberately NOT marked degraded: a
+// .gitlab-ci.yml that was fetched but does not parse. The collector sets
+// LimitedAnalysis and returns early, so no images or includes are
+// gathered and the PBOM is empty.
+//
+// On a normal run the zero-control gate catches this and the errors are
+// printed. --no-controls removes that gate, so without an explicit check
+// the run exits 0 with an empty inventory and swallows the errors,
+// contradicting the documented "exit 0 only if data collection succeeded".
+func TestPublishAndFinalize_NoControlsFailsOnInvalidCIConfig(t *testing.T) {
+	pc := noControlsPC(t)
+	p := &recordingProvider{GitLabProvider: &provider.GitLabProvider{}}
+	conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
+	invalid := &control.AnalysisResult{
+		CiValid:     false,
+		ProjectPath: "group/project",
+		CiErrors:    []string{"jobs config should contain at least one visible job"},
+	}
+
+	err := publishAndFinalize(p, &cobra.Command{}, invalid, conf, buildComplianceSummary(p, invalid, conf))
+	var incomplete *IncompleteDataError
+	if !errors.As(err, &incomplete) {
+		t.Fatalf("--no-controls must not exit 0 on an unusable CI config, got %v", err)
+	}
+}
+
+// TestOutputText_NoControlsStillShowsCIErrors: the failure above has to be
+// explicable. The zero-control warning is suppressed under --no-controls
+// (it is the request, not a failure), which would also hide the CI errors
+// that explain why the artifacts are empty.
+func TestOutputText_NoControlsStillShowsCIErrors(t *testing.T) {
+	oPrint := printOutput
+	defer func() { printOutput = oPrint }()
+	printOutput = true
+
+	pc := noControlsPC(t)
+	p := &provider.GitLabProvider{}
+	conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true, GitlabURL: "https://gitlab.example"}
+	invalid := &control.AnalysisResult{
+		CiValid:     false,
+		ProjectPath: "group/project",
+		CiErrors:    []string{"jobs config should contain at least one visible job"},
+	}
+
+	out := captureStdout(t, func() {
+		if err := outputTextWithProvider(p, invalid, conf, buildComplianceSummary(p, invalid, conf), nil, nil); err != nil {
+			t.Fatalf("render: %v", err)
+		}
+	})
+	if !strings.Contains(out, "jobs config should contain at least one visible job") {
+		t.Errorf("the CI errors explain the empty artifacts and must be shown, got:\n%s", out)
+	}
+}
+
+// TestPublishAndFinalize_NoControlsAndMissingCIConfig covers the third
+// collection-failure mode, and the deliberate asymmetry between providers.
+//
+// A GitLab project with no .gitlab-ci.yml sets CiMissing without setting
+// CiErrors or DataCollectionDegraded, so neither of the other two guards
+// fires. On a normal run the zero-control gate catches it
+// (TestGate_ProviderZeroControlSemantics pins "GitLab CiMissing must
+// fail"), and --no-controls removes that gate, so it needs its own check or
+// it ships an empty PBOM as a successful inventory.
+//
+// GitHub is the opposite on purpose: a repo with no workflows keeps its
+// control count and passes, restored in 0.4.0 so fleet scanners do not fail
+// on CI-less repositories. --no-controls must not quietly reverse that.
+func TestPublishAndFinalize_NoControlsAndMissingCIConfig(t *testing.T) {
+	pc := noControlsPC(t)
+	missing := func() *control.AnalysisResult {
+		return &control.AnalysisResult{CiMissing: true, CiValid: true, ProjectPath: "group/project"}
+	}
+
+	t.Run("gitlab fails", func(t *testing.T) {
+		p := &recordingProvider{GitLabProvider: &provider.GitLabProvider{}}
+		conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
+		result := missing()
+		err := publishAndFinalize(p, &cobra.Command{}, result, conf, buildComplianceSummary(p, result, conf))
+		var incomplete *IncompleteDataError
+		if !errors.As(err, &incomplete) {
+			t.Fatalf("a GitLab project with no CI config has no pipeline to inventory; want IncompleteDataError, got %v", err)
+		}
+	})
+
+	t.Run("github still passes", func(t *testing.T) {
+		p := &provider.GitHubProvider{}
+		conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
+		result := missing()
+		if err := publishAndFinalize(p, nil, result, conf, buildComplianceSummary(p, result, conf)); err != nil {
+			t.Fatalf("a CI-less GitHub repo must keep passing (fleet scans), got %v", err)
+		}
+	})
+}
+
+// TestPublishAndFinalize_NoControlsFailsOnInvalidCIWithoutErrors covers the
+// GitLab collector state that reports an unusable CI config while leaving
+// the error list empty: the origin collector's branch fires on
+// `Status == "INVALID"` OR a non-empty error list, and with a non-empty
+// ConfString it sets CiValid=false / CiMissing=false and never populates
+// CiErrors.
+//
+// A guard keyed on CiErrors alone therefore misses it and ships an empty
+// PBOM with exit 0. The check mirrors GitLabProvider.ComputeCompliance's
+// own condition (CiMissing || !CiValid) so the two cannot disagree about
+// what "no usable pipeline" means.
+func TestPublishAndFinalize_NoControlsFailsOnInvalidCIWithoutErrors(t *testing.T) {
+	pc := noControlsPC(t)
+	p := &recordingProvider{GitLabProvider: &provider.GitLabProvider{}}
+	conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
+	invalid := &control.AnalysisResult{
+		CiValid:     false,
+		CiMissing:   false,
+		CiErrors:    nil, // the whole point: INVALID status, no error strings
+		ProjectPath: "group/project",
+	}
+
+	err := publishAndFinalize(p, &cobra.Command{}, invalid, conf, buildComplianceSummary(p, invalid, conf))
+	var incomplete *IncompleteDataError
+	if !errors.As(err, &incomplete) {
+		t.Fatalf("an invalid CI config with no error strings must still fail, got %v", err)
+	}
+}
+
+// TestBuildGitHubConf_WiresNoControls is the GitHub counterpart of
+// TestBuildGitLabConf_WiresNoControls. applyControlScope is unit-tested on
+// its own, but nothing pinned that the GitHub entry points actually call
+// it: a future edit reverting either to direct conf.ControlsFilter
+// assignments would drop conf.NoControls silently, and a GitHub
+// --no-controls run would evaluate everything, score it and publish it.
+func TestBuildGitHubConf_WiresNoControls(t *testing.T) {
+	orig := noControls
+	defer func() { noControls = orig }()
+	pc := noControlsPC(t)
+
+	for _, tc := range []struct {
+		name  string
+		build func() *configuration.Configuration
+	}{
+		{"local clone", func() *configuration.Configuration {
+			return buildGitHubLocalConf(&utils.GitRemoteInfo{ProjectPath: "owner/repo", RepoRoot: "/tmp/repo"}, pc, ".plumber.yaml", nil, nil)
+		}},
+		{"remote", func() *configuration.Configuration {
+			return buildGitHubRemoteConf("owner", "repo", "main", "github.com", pc, ".plumber.yaml", nil, nil)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			noControls = true
+			if !tc.build().NoControls {
+				t.Fatal("--no-controls must reach the Configuration the analysis reads")
+			}
+			noControls = false
+			if tc.build().NoControls {
+				t.Fatal("NoControls must be false without the flag")
+			}
+		})
+	}
+}

--- a/cmd/no_controls_test.go
+++ b/cmd/no_controls_test.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/control"
+	"github.com/getplumber/plumber/provider"
+)
+
+// TestBuildComplianceSummary_NoControlsWithholdsScore pins the honest
+// outcome of a --no-controls run: no score, anywhere. Zero findings would
+// otherwise compute a perfect 100/100, and stamping that on the terminal
+// banner, the JSON report, the PBOM and the CycloneDX output would present
+// "we checked nothing" as "we checked everything and it was clean".
+//
+// scoreMode=false is the existing withhold-the-score path (every consumer
+// already guards on a nil score), so this reuses it rather than adding a
+// second way to say the same thing.
+func TestBuildComplianceSummary_NoControlsWithholdsScore(t *testing.T) {
+	result := &control.AnalysisResult{CiValid: true}
+
+	for _, p := range []provider.Provider{&provider.GitLabProvider{}, &provider.GitHubProvider{}} {
+		t.Run(p.Name(), func(t *testing.T) {
+			conf := &configuration.Configuration{NoControls: true}
+			s := buildComplianceSummary(p, result, conf)
+			if s.score != nil {
+				t.Fatalf("--no-controls must withhold the score, got %+v", s.score)
+			}
+			if s.scoreMode {
+				t.Fatal("--no-controls must turn score mode off so every output withholds it")
+			}
+			if s.controlCount != 0 {
+				t.Fatalf("controlCount: got %d, want 0", s.controlCount)
+			}
+			if !s.noControls {
+				t.Fatal("the summary must carry the flag so the gate and the renderer can tell it apart from a misconfiguration")
+			}
+		})
+	}
+}
+
+// A run WITHOUT the flag keeps computing a score: the default behaviour is
+// untouched by this feature.
+func TestBuildComplianceSummary_ScoreStillComputedByDefault(t *testing.T) {
+	result := &control.AnalysisResult{CiValid: true}
+	conf := &configuration.Configuration{}
+	s := buildComplianceSummary(&provider.GitLabProvider{}, result, conf)
+	if s.score == nil || !s.scoreMode {
+		t.Fatal("without --no-controls the score must still be computed")
+	}
+	if s.noControls {
+		t.Fatal("noControls must be false without the flag")
+	}
+}
+
+// TestInertFlagsUnderNoControls names every flag that reads or publishes a
+// score, so a --no-controls run tells the user once what it ignored instead
+// of quietly doing less than they asked. These are warned about rather than
+// rejected: CI templates set them globally, and erroring would make
+// --no-controls unusable in exactly the templated pipeline that wants it.
+func TestInertFlagsUnderNoControls(t *testing.T) {
+	oMinPointsSet, oMinScore, oThresholdSet := minPointsSet, minScore, thresholdSet
+	oShowScore, oShowScorePoint, oBadge := showScore, showScorePoint, badge
+	oPushScore, oMRComment, oPlatformURL := pushScore, mrComment, platformURL
+	defer func() {
+		minPointsSet, minScore, thresholdSet = oMinPointsSet, oMinScore, oThresholdSet
+		showScore, showScorePoint, badge = oShowScore, oShowScorePoint, oBadge
+		pushScore, mrComment, platformURL = oPushScore, oMRComment, oPlatformURL
+	}()
+
+	minPointsSet, minScore, thresholdSet = false, "", false
+	showScore, showScorePoint, badge, pushScore, mrComment, platformURL = false, false, false, false, false, ""
+	if got := inertFlagsUnderNoControls(); len(got) != 0 {
+		t.Fatalf("nothing set: expected no notice, got %v", got)
+	}
+
+	minPointsSet, badge, platformURL = true, true, "https://platform.example"
+	got := inertFlagsUnderNoControls()
+	want := []string{"--min-points", "--badge", "--platform"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}

--- a/cmd/ocsf.go
+++ b/cmd/ocsf.go
@@ -346,8 +346,7 @@ func ocsfScanUID(result *control.AnalysisResult, now int64) string {
 // to filePath. Provider-agnostic: every control is listed with an explicit
 // status, so the file is never empty and absence never reads as a pass.
 func writeOCSFToFile(p provider.Provider, result *control.AnalysisResult, conf *configuration.Configuration, filePath string) error {
-	entries := p.Controls(conf.PlumberConfig)
-	control.MarkSkippedByFilter(entries, conf.ControlsFilter, conf.SkipControlsFilter)
+	entries := providerControlEntries(p, conf)
 	now := time.Now().UTC().UnixMilli()
 	events := buildOCSF(entries, result, p.Name(), now, ocsfScanUID(result, now))
 	return writeOCSFEvents(events, filePath)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -65,6 +65,13 @@ type Configuration struct {
 	ControlsFilter []string
 	// SkipControlsFilter skips the listed controls when set;
 	SkipControlsFilter []string
+	// NoControls turns off control evaluation entirely for this run
+	// (--no-controls). It is a command-line override that wins over the
+	// config: the controls enabled in .plumber.yaml are ignored, no policy
+	// is evaluated, and with nothing evaluated there is no score and no
+	// gate to fail. Collectors still run, because the PBOM and the JSON
+	// report are built from the same collected data.
+	NoControls bool
 
 	// ProgressFunc is an optional callback invoked during analysis to report progress.
 	// step: current step number (1-based), total: total number of steps, message: description.

--- a/control/catalog.go
+++ b/control/catalog.go
@@ -557,6 +557,18 @@ func MarkSkippedByFilter(entries []ControlEntry, includeOnly, skip []string) {
 	}
 }
 
+// MarkAllSkipped marks every entry skipped with the given reason. It backs
+// --no-controls: the catalog still describes what Plumber COULD have checked,
+// but nothing was evaluated, so no entry may report a verdict. Without this,
+// a zero-findings run stamps `status: "passed"` on every control that never
+// ran, which is the false green the flag exists to avoid.
+func MarkAllSkipped(entries []ControlEntry, reason string) {
+	for i := range entries {
+		entries[i].Skipped = true
+		entries[i].SkipReason = reason
+	}
+}
+
 // GitHubControlCompliance returns the binary compliance percentage for a
 // single GitHub control: 100 when no findings, 0 otherwise. The stats
 // parameter is reserved for future per-control percentage overrides.

--- a/control/no_controls_test.go
+++ b/control/no_controls_test.go
@@ -1,0 +1,46 @@
+package control
+
+import (
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/internal/ir"
+	"github.com/sirupsen/logrus"
+)
+
+// TestNoControls_SkipsPolicyEvaluation pins the --no-controls contract at the
+// engine boundary: when the user asked for no controls, no policy is
+// evaluated at all. Filtering the findings afterwards would not be the same
+// thing, because a policy that crashes takes the whole run's findings with it
+// (Engine.Evaluate returns on the first module error), so a run that
+// evaluates nothing is also a run nothing can break.
+func TestNoControls_SkipsPolicyEvaluation(t *testing.T) {
+	pc, _, _, err := configuration.LoadPlumberConfig("../.plumber.yaml")
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	pipeline := &ir.NormalizedPipeline{
+		Provider:      ir.Provider("gitlab"),
+		ProjectPath:   "group/project",
+		DefaultBranch: "main",
+		Jobs: []ir.Job{
+			// Hardcoded origin plus a bare `pip install`: enough to make at
+			// least one enabled control fire on a normal run.
+			{Name: "build", OriginKind: "hardcoded", Scripts: []string{"pip install requests"}},
+		},
+	}
+
+	conf := &configuration.Configuration{ProjectPath: "group/project", PlumberConfig: pc}
+	if got := evaluatePolicies(logrus.NewEntry(logrus.New()), conf, "gitlab", pipeline); len(got) == 0 {
+		t.Fatal("fixture must produce findings without --no-controls, otherwise this test proves nothing")
+	}
+
+	conf.NoControls = true
+	got := evaluatePolicies(logrus.NewEntry(logrus.New()), conf, "gitlab", pipeline)
+	if len(got) != 0 {
+		t.Fatalf("--no-controls must evaluate nothing, got %d findings", len(got))
+	}
+	if got == nil {
+		t.Fatal("must return an empty non-nil slice so JSON marshals [] and not null")
+	}
+}

--- a/control/task.go
+++ b/control/task.go
@@ -324,11 +324,20 @@ func runRegoEngine(
 // restrict which controls' findings reach the caller. Callers pass
 // "gitlab" or "github". Anything else returns no findings.
 func evaluatePolicies(l *logrus.Entry, conf *configuration.Configuration, provider string, pipeline *ir.NormalizedPipeline) []opaengine.Finding {
-	l.WithField("provider", provider).Info("Running Rego/OPA rule engine")
 	// Empty (non-nil) so the eventual JSON output marshals an empty
 	// findings array as `[]`, not `null` — `null` makes downstream
 	// jq pipelines like `.findings[]` blow up on a clean run.
 	empty := []opaengine.Finding{}
+	// --no-controls: the user asked for no controls, so nothing is loaded
+	// and nothing is evaluated. Filtering the findings afterwards would not
+	// be equivalent: Engine.Evaluate returns on the first module error, so a
+	// single crashing policy takes every finding with it. A run that
+	// evaluates nothing is a run no policy can break.
+	if conf.NoControls {
+		l.WithField("provider", provider).Info("Control evaluation disabled (--no-controls)")
+		return empty
+	}
+	l.WithField("provider", provider).Info("Running Rego/OPA rule engine")
 	engine := opaengine.New()
 	skip := func(filename string, content []byte) bool {
 		return IsRegoFileBenchedForProvider(content, provider)

--- a/pbom/generate.go
+++ b/pbom/generate.go
@@ -25,11 +25,14 @@ type IncludeOverrideData struct {
 
 // Generator creates PBOMs from pipeline analysis data
 type Generator struct {
-	projectPath      string
-	projectID        int
-	gitlabURL        string
-	branch           string
-	complianceData   *ImageComplianceData
+	projectPath    string
+	projectID      int
+	gitlabURL      string
+	branch         string
+	complianceData *ImageComplianceData
+	// suppressVerdicts drops the collected-but-verdict-bearing include
+	// fields; see WithoutComplianceVerdicts.
+	suppressVerdicts bool
 	includeOverrides *IncludeOverrideData
 	githubData       *GitHubComplianceData
 }
@@ -45,6 +48,20 @@ func NewGenerator(projectPath string, projectID int, gitlabURL, branch string) *
 }
 
 // WithComplianceData attaches compliance results so the PBOM includes authorized/forbiddenTag fields
+// WithoutComplianceVerdicts suppresses the include fields that state a
+// CONTROL'S CONCLUSION rather than what was collected. It backs
+// --no-controls.
+//
+// `UpToDate` is the one that matters: unlike the image flags it is computed
+// during data collection (the origin collector probes the upstream ref), so
+// it survives even when no policy is evaluated, and it is exactly what
+// includesMustBeUpToDate reports. `LatestVersion` is kept: the upstream
+// version is a collected fact and asserts nothing on its own.
+func (g *Generator) WithoutComplianceVerdicts() *Generator {
+	g.suppressVerdicts = true
+	return g
+}
+
 func (g *Generator) WithComplianceData(data *ImageComplianceData) *Generator {
 	g.complianceData = data
 	return g
@@ -166,8 +183,10 @@ func (g *Generator) processIncludes(originData *gitlab.GitlabPipelineOriginData)
 		// Add version info if available
 		if origin.FromPlumber {
 			inc.LatestVersion = origin.PlumberOrigin.LatestVersion
-			upToDate := origin.UpToDate
-			inc.UpToDate = &upToDate
+			if !g.suppressVerdicts {
+				upToDate := origin.UpToDate
+				inc.UpToDate = &upToDate
+			}
 		}
 
 		// Add component-specific info
@@ -177,8 +196,10 @@ func (g *Generator) processIncludes(originData *gitlab.GitlabPipelineOriginData)
 
 			if origin.FromGitlabCatalog {
 				inc.LatestVersion = origin.GitlabComponent.ComponentLatestVersion
-				upToDate := origin.UpToDate
-				inc.UpToDate = &upToDate
+				if !g.suppressVerdicts {
+					upToDate := origin.UpToDate
+					inc.UpToDate = &upToDate
+				}
 			}
 		}
 

--- a/provider/compliance_test.go
+++ b/provider/compliance_test.go
@@ -70,6 +70,20 @@ func TestGitLabProvider_ComputeCompliance(t *testing.T) {
 		}
 	})
 
+	// --no-controls wins over the config: the controls enabled in
+	// .plumber.yaml are ignored, so the count is zero even though this
+	// config enables two. Zero is what makes the gate a no-op, and it is
+	// also what keeps a 100%% "all controls pass" reading from being
+	// reported for controls that never ran.
+	t.Run("no-controls ignores the enabled controls", func(t *testing.T) {
+		result := &control.AnalysisResult{CiValid: true}
+		conf := &configuration.Configuration{PlumberConfig: gitLabPC(t), NoControls: true}
+		pct, n := p.ComputeCompliance(result, conf)
+		if pct != 0.0 || n != 0 {
+			t.Fatalf("NoControls: got (%v, %d), want (0, 0)", pct, n)
+		}
+	})
+
 	t.Run("one of two controls fails", func(t *testing.T) {
 		result := &control.AnalysisResult{
 			CiValid: true,
@@ -122,6 +136,16 @@ func TestGitHubProvider_ComputeCompliance(t *testing.T) {
 		pct, n := p.ComputeCompliance(result, conf)
 		if pct != 100.0 || n != 2 {
 			t.Fatalf("no findings: got (%v, %d), want (100, 2)", pct, n)
+		}
+	})
+
+	// Same override as the GitLab path: --no-controls beats the config.
+	t.Run("no-controls ignores the enabled controls", func(t *testing.T) {
+		result := &control.AnalysisResult{}
+		conf := &configuration.Configuration{PlumberConfig: gitHubPC(t), NoControls: true}
+		pct, n := p.ComputeCompliance(result, conf)
+		if pct != 0.0 || n != 0 {
+			t.Fatalf("NoControls: got (%v, %d), want (0, 0)", pct, n)
 		}
 	})
 

--- a/provider/github.go
+++ b/provider/github.go
@@ -25,6 +25,12 @@ func (p *GitHubProvider) Controls(pc *configuration.PlumberConfig) []control.Con
 }
 
 func (p *GitHubProvider) ComputeCompliance(result *control.AnalysisResult, conf *configuration.Configuration) (float64, int) {
+	// --no-controls wins over the config: the controls enabled in
+	// .plumber.yaml are ignored, so nothing is evaluated and nothing is
+	// counted. The zero is what makes the gate a no-op.
+	if conf.NoControls {
+		return 0.0, 0
+	}
 	findingsByControl := control.FindingsByControl(result.Findings)
 	entries := control.GitHubControls(conf.PlumberConfig)
 	control.MarkSkippedByFilter(entries, conf.ControlsFilter, conf.SkipControlsFilter)
@@ -72,13 +78,27 @@ func (p *GitHubProvider) RunRemote(conf *configuration.Configuration) (*control.
 	return result, nil
 }
 
+// noControlsAwareGitHubCompliance is the GitHub twin of
+// noControlsAwareImageCompliance: the per-image and per-action flags are
+// derived from findings, so on a --no-controls run they would assert
+// compliance for checks that never ran, inside the artifact the flag exists
+// to produce. Nil means the PBOM records the inventory and claims nothing.
+// conf is required, as everywhere else on this path (the writers read
+// conf.GithubAPIHost unconditionally).
+func noControlsAwareGitHubCompliance(result *control.AnalysisResult, conf *configuration.Configuration) *pbom.GitHubComplianceData {
+	if conf.NoControls {
+		return nil
+	}
+	return pbom.BuildGitHubPBOMCompliance(result)
+}
+
 func (p *GitHubProvider) WritePBOM(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool) error {
 	host := conf.GithubAPIHost
 	if host == "" {
 		host = "github.com"
 	}
 	gen := pbom.NewGitHubGenerator(result.ProjectPath, host, conf.Branch).
-		WithGitHubComplianceData(pbom.BuildGitHubPBOMCompliance(result))
+		WithGitHubComplianceData(noControlsAwareGitHubCompliance(result, conf))
 	bom := gen.GenerateFromGitHubIR(result.GitHubPipeline)
 	bom.PlumberScore = pbom.BuildPlumberScoreSummary(score, scoreMode)
 
@@ -98,7 +118,7 @@ func (p *GitHubProvider) WritePBOMCycloneDX(result *control.AnalysisResult, conf
 		host = "github.com"
 	}
 	gen := pbom.NewGitHubGenerator(result.ProjectPath, host, conf.Branch).
-		WithGitHubComplianceData(pbom.BuildGitHubPBOMCompliance(result))
+		WithGitHubComplianceData(noControlsAwareGitHubCompliance(result, conf))
 	bom := gen.GenerateFromGitHubIR(result.GitHubPipeline)
 	bom.PlumberScore = pbom.BuildPlumberScoreSummary(score, scoreMode)
 	cdx := bom.ToCycloneDX("")

--- a/provider/gitlab.go
+++ b/provider/gitlab.go
@@ -26,6 +26,12 @@ func (p *GitLabProvider) Controls(pc *configuration.PlumberConfig) []control.Con
 }
 
 func (p *GitLabProvider) ComputeCompliance(result *control.AnalysisResult, conf *configuration.Configuration) (float64, int) {
+	// --no-controls wins over the config: the controls enabled in
+	// .plumber.yaml are ignored, so nothing is evaluated and nothing is
+	// counted. The zero is what makes the gate a no-op.
+	if conf.NoControls {
+		return 0.0, 0
+	}
 	if result.CiMissing || !result.CiValid {
 		return 0.0, 0
 	}
@@ -66,12 +72,30 @@ func (p *GitLabProvider) RunRemote(_ *configuration.Configuration) (*control.Ana
 	return nil, ErrNoRemote
 }
 
+// noControlsAwareImageCompliance returns the per-image compliance flags, or
+// nil when the run evaluated nothing. The flags are derived from findings,
+// not from the score, so an empty findings slice would otherwise mark every
+// image forbiddenTag:false / authorized:true and assert the very image
+// checks --no-controls skipped, inside the artifact the flag exists to
+// produce. With nil the PBOM records the inventory and claims nothing.
+// conf is required, as everywhere else on this path (the writers read
+// conf.GitlabURL unconditionally).
+func noControlsAwareImageCompliance(result *control.AnalysisResult, conf *configuration.Configuration) *pbom.ImageComplianceData {
+	if conf.NoControls {
+		return nil
+	}
+	return pbom.BuildImageComplianceData(result)
+}
+
 func (p *GitLabProvider) WritePBOM(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool) error {
-	complianceData := pbom.BuildImageComplianceData(result)
+	complianceData := noControlsAwareImageCompliance(result, conf)
 	overrideData := pbom.BuildIncludeOverrideData(result)
 	gen := pbom.NewGenerator(result.ProjectPath, result.ProjectID, conf.GitlabURL, conf.Branch).
 		WithComplianceData(complianceData).
 		WithIncludeOverrideData(overrideData)
+	if conf.NoControls {
+		gen = gen.WithoutComplianceVerdicts()
+	}
 	bom := gen.Generate(result.PipelineImageData, result.PipelineOriginData)
 	bom.PlumberScore = pbom.BuildPlumberScoreSummary(score, scoreMode)
 
@@ -86,11 +110,14 @@ func (p *GitLabProvider) WritePBOM(result *control.AnalysisResult, conf *configu
 }
 
 func (p *GitLabProvider) WritePBOMCycloneDX(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool) error {
-	complianceData := pbom.BuildImageComplianceData(result)
+	complianceData := noControlsAwareImageCompliance(result, conf)
 	overrideData := pbom.BuildIncludeOverrideData(result)
 	gen := pbom.NewGenerator(result.ProjectPath, result.ProjectID, conf.GitlabURL, conf.Branch).
 		WithComplianceData(complianceData).
 		WithIncludeOverrideData(overrideData)
+	if conf.NoControls {
+		gen = gen.WithoutComplianceVerdicts()
+	}
 	bom := gen.Generate(result.PipelineImageData, result.PipelineOriginData)
 	bom.PlumberScore = pbom.BuildPlumberScoreSummary(score, scoreMode)
 	cdx := bom.ToCycloneDX("")


### PR DESCRIPTION
## Why

Some users want the PBOM (or the JSON report) and nothing else. The analysis is not what they are after, and today there is no way to say that.

`--controls` is an **intersection** filter, not an enabler, so the only routes to zero controls are accidental. And a run that evaluates zero controls fails closed with exit 1 by design since v0.4.0.

A user hit exactly this. Their pipeline runs `plumber config generate` then `plumber analyze --pbom-cyclonedx pbom.cdx --controls pipelineMustNotIncludeHardcodedJobs`. It worked on v0.4.2 and broke on v0.4.41, because v0.4.25 (`aebf2d1`) deliberately disabled `pipelineMustNotIncludeHardcodedJobs` in the shipped default. Their filter went from "one control runs" to "no control runs", and the job started failing even though `pbom.cdx` was written correctly every time.

## What

`--no-controls` makes "no controls, just the artifact" a first-class request. It is a **command-line override that wins over `.plumber.yaml`**, so the same config keeps working unchanged for a normal `plumber analyze` in another job. No second config file, no config edit.

```bash
plumber analyze --pbom-cyclonedx pbom.cdx --no-controls --print=false
```

**Behaviour**

- **No policy is evaluated at all.** Filtering findings afterwards would not be equivalent: `Engine.Evaluate` returns on the first module error, so a run that evaluates nothing is also a run no policy can break.
- **Collectors still run**, because the PBOM and the JSON report are built from the same collected data. There is nothing to save by skipping them.
- **No score is computed.** Zero findings would otherwise read as a perfect 100/100 and stamp "we checked everything and it was clean" on the banner, the JSON, the PBOM and the CycloneDX output. `scoreMode=false` is the existing withhold-the-score path, so every consumer already handles a nil score.
- **Every gate is inert**, the deprecated `--threshold` included, and the publishing paths (badge, score push, platform push, MR comment) are skipped with a one-line notice naming the ignored flags. Warning rather than erroring is deliberate: CI templates set these globally, and a hard failure would make `--no-controls` unusable in exactly the templated pipeline that wants it.
- **Exit 0** when data collection succeeds. Exit 2 (runtime/config) and exit 3 (degraded collection, `--fail-warnings`) are unchanged: an incomplete collection still means an incomplete PBOM, so it must still fail.
- Combining it with `--controls` / `--skip-controls` is a usage error (exit 2). "Evaluate nothing" and "evaluate this subset" are contradictory, and silently letting one win would hide a broken CI invocation.

Available as `PLUMBER_ANALYZE_NO_CONTROLS` too, like every other analyze flag.

## Refactor included

`runWithProvider` and `presentResultWithProvider` carried drifted copies of the same publish-and-finalize tail. That is why the GitHub path initially bypassed the guard above, caught during end-to-end testing. The tail is now one `publishAndFinalize` helper used by both.

## Verification

Full `go test ./...` green, `go vet` clean. Every test was watched failing before the implementation.

End-to-end against a real repository with the built binary:

```
$ plumber analyze --no-controls --pbom-cyclonedx pbom.cdx --min-points 100 --badge
  Project    getplumber/plumber
  Platform   GitHub
  Config     .plumber.yaml
  CI config  local file
  Controls   none (--no-controls)

  Status: PASSED (no controls requested, nothing to score)

PBOM (CycloneDX) written to: pbom.cdx
Note: --no-controls evaluated nothing, so there is no score to gate or publish; ignored: --min-points, --badge
EXIT=0        # PBOM has 20 components; no score banner, no badge published
```

Also verified: the conflict error exits 2, `PLUMBER_ANALYZE_NO_CONTROLS=true` works, and a plain `plumber analyze` is unchanged (21 passed controls, score A, 100.0/100, exit 0).

New tests: policy evaluation is genuinely skipped (`control`), both providers report a zero control count (`provider`), the gate passes and the score gates including `--threshold` stay inert (`cmd`), the score is withheld while a normal run still computes one (`cmd`), the flag conflict errors, and the inert-flag notice lists the right flags. The pre-existing `TestGate_NoControlsFailsDespitePerfectScore` still pins the fail-closed behaviour for a run that meant to check something and checked nothing.

## Related

Companion to #434, which fixes the `unsafe_variable_expansion.rego` crash visible in the same user's logs. The two are independent: #434 stops one policy from silently voiding every finding, this PR gives users a supported way to opt out of evaluation entirely.

Still open from that report and **not** in this PR: `--controls <a control disabled in config>` produces a confusing exit 1 with every control labelled "(disabled in configuration)", including the ones excluded by the filter. A clear error at parse time plus an honest `SkipReason` is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDkbDA2xTxKsn6wv5f8fPx