### PR TITLE
feat(controls): ship artipacked, graded by exploitability (ISSUE-307 low + ISSUE-310 high)

### DIFF
--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -857,6 +857,18 @@ github:
       enabled: true
 
     # ===========================================
+    # Checkout must not persist credentials
+    # ===========================================
+    # By default `actions/checkout` writes the GITHUB_TOKEN into the
+    # cloned repository's `.git/config`, where it survives for the rest
+    # of the job. Any later step that uploads `.git` as an artifact or
+    # runs fork-controlled code can then exfiltrate the token. The fix
+    # is a one-liner: `with: persist-credentials: false`. Flags any
+    # `actions/checkout` step that omits it or sets it to `true`.
+    checkoutMustNotPersistCredentials:
+      enabled: true
+
+    # ===========================================
     # Workflows must declare permissions
     # ===========================================
     # Workflows without an explicit `permissions:` block fall back to

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -47,6 +47,7 @@ const (
 	compAuthorizedActions  = "Restrict third-party actions to authorized sources"
 	compDangerousTriggers  = "Flag dangerous workflow triggers (pull_request_target, workflow_run, …)"
 	compPRTargetHead       = "Forbid pull_request_target workflows that check out the PR head"
+	compCheckoutPersist    = "Forbid actions/checkout that persists the GITHUB_TOKEN (persist-credentials: false)"
 	compDeclarePermissions = "Require workflows to declare an explicit permissions: block"
 	compReusableSecrets    = "Forbid reusable-workflow calls using secrets: inherit"
 	compOverprovSecrets    = "Forbid exporting the entire secrets context (toJson(secrets))"
@@ -818,6 +819,7 @@ func compositionOptionsForProviders(providers []string) []string {
 			compAuthorizedActions,
 			compDangerousTriggers,
 			compPRTargetHead,
+			compCheckoutPersist,
 			compDeclarePermissions,
 			compReusableSecrets,
 			compOverprovSecrets,
@@ -1431,6 +1433,9 @@ func (st *initWizardState) toPlumberConfig() *configuration.PlumberConfig {
 			}
 			if compSelected(st, compPRTargetHead) {
 				gh.Controls.PullRequestTargetMustNotCheckoutHead = &configuration.EnabledOnlyControlConfig{Enabled: boolPtrInit(true)}
+			}
+			if compSelected(st, compCheckoutPersist) {
+				gh.Controls.CheckoutMustNotPersistCredentials = &configuration.EnabledOnlyControlConfig{Enabled: boolPtrInit(true)}
 			}
 			if compSelected(st, compDeclarePermissions) {
 				gh.Controls.WorkflowsMustDeclarePermissions = &configuration.EnabledOnlyControlConfig{Enabled: boolPtrInit(true)}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -209,7 +209,7 @@ func starterWizardConfig() *configuration.PlumberConfig {
 		AuthorizedActionsUsePlumberList: true,
 		CompositionChoices: []string{
 			compHardcoded, compUpToDate, compForbidden, compRefCollision, compSecurity, compScripts, compJobVars, compDinD,
-			compActionPin, compAuthorizedActions, compDangerousTriggers, compPRTargetHead, compDeclarePermissions, compReusableSecrets, compOverprovSecrets, compTemplateInjection,
+			compActionPin, compAuthorizedActions, compDangerousTriggers, compPRTargetHead, compCheckoutPersist, compDeclarePermissions, compReusableSecrets, compOverprovSecrets, compTemplateInjection,
 			compEnvInjection, compWriteAllPerms, compRefConfusion, compArchivedActions, compKnownCVEs, compImpostorCommit, compMutableRemoteExec, compCachePoisoning, compDebugTraceGitHub,
 		},
 		ActionPinTrustedOwnersMultiline:        strings.Join(defaultGitHubTrustedActionOwners(), "\n"),

--- a/cmd/legacy_json_github.go
+++ b/cmd/legacy_json_github.go
@@ -47,6 +47,8 @@ func buildLegacyResultGitHub(e control.ControlEntry, result *control.AnalysisRes
 		return "overprovisionedSecretsResult", buildOverprovisionedSecretsBlock(common, result, findings)
 	case "workflowMustNotUseDangerousTriggers":
 		return "dangerousTriggersResult", buildDangerousTriggersBlock(common, result, findings)
+	case "checkoutMustNotPersistCredentials":
+		return "checkoutCredentialsResult", buildCheckoutCredentialsBlock(common, result, findings)
 	case "pullRequestTargetMustNotCheckoutHead":
 		return "pullRequestTargetHeadCheckoutResult", buildPullRequestTargetHeadCheckoutBlock(common, result, findings)
 	case "workflowsMustDeclarePermissions":
@@ -404,6 +406,40 @@ func buildCachePoisoningBlock(c legacyCommon, result *control.AnalysisResult, fi
 // buildDangerousTriggersBlock — ISSUE-802. Denominator is workflows
 // total; numerator is workflows whose trigger set intersects the
 // dangerous-triggers list.
+// buildCheckoutCredentialsBlock — ISSUE-307 / ISSUE-310. One control, two
+// codes graded by exploitability: the credential merely persisting (latent)
+// versus the credential also being packed into a downloadable artifact (a
+// demonstrable leak). The two are counted separately because a consumer
+// triaging this needs to know which of the two it has; a single total would
+// make a hygiene backlog and an exfiltrable token look alike.
+//
+// The counts come from the findings rather than from a stats field: nothing
+// in the collector counts checkout steps, and adding a stat to serve one
+// block would be plumbing for its own sake.
+func buildCheckoutCredentialsBlock(c legacyCommon, result *control.AnalysisResult, findings []opaengine.Finding) map[string]any {
+	latent, packed := 0, 0
+	for _, f := range findings {
+		switch f.Code {
+		case string(control.CodeArtipacked):
+			latent++
+		case string(control.CodeArtipackedExfiltrated):
+			packed++
+		}
+	}
+	return map[string]any{
+		"issues": projectFindings(findings, "job"),
+		"metrics": map[string]any{
+			"workflowsScanned":            statsOf(result).WorkflowsTotal,
+			"checkoutsPersistingLatent":   latent,
+			"checkoutsPackedIntoArtifact": packed,
+		},
+		"version":   "0.1.0",
+		"ciValid":   c.CiValid,
+		"ciMissing": c.CiMissing,
+		"skipped":   c.Skipped,
+	}
+}
+
 func buildDangerousTriggersBlock(c legacyCommon, result *control.AnalysisResult, findings []opaengine.Finding) map[string]any {
 	s := statsOf(result)
 	return map[string]any{

--- a/cmd/render_details.go
+++ b/cmd/render_details.go
@@ -634,6 +634,10 @@ func buildGitHubControlStats(controlName string, stats *control.GitHubAnalysisSt
 			{Label: "Workflows Scanned", Value: fmt.Sprintf("%d", stats.WorkflowsTotal)},
 			{Label: "Using Dangerous Triggers", Value: fmt.Sprintf("%d", stats.WorkflowsWithDangerousTrigger)},
 		}
+	case "checkoutMustNotPersistCredentials":
+		return []statLine{
+			{Label: "Workflows Scanned", Value: fmt.Sprintf("%d", stats.WorkflowsTotal)},
+		}
 	case "workflowsMustDeclarePermissions":
 		withPerms := stats.WorkflowsTotal - stats.WorkflowsMissingPermissions
 		if withPerms < 0 {

--- a/configuration/plumberconfig.go
+++ b/configuration/plumberconfig.go
@@ -119,6 +119,9 @@ var validControlSchema = map[string][]string{
 	"pullRequestTargetMustNotCheckoutHead": {
 		"enabled",
 	},
+	"checkoutMustNotPersistCredentials": {
+		"enabled",
+	},
 	"workflowsMustDeclarePermissions": {
 		"enabled",
 	},
@@ -394,6 +397,13 @@ type ControlsConfig struct {
 	// fork-controlled code in the same run (tj-actions / CVE-2025-30066).
 	// Config-free; toggle via `enabled`.
 	PullRequestTargetMustNotCheckoutHead *EnabledOnlyControlConfig `yaml:"pullRequestTargetMustNotCheckoutHead,omitempty"`
+
+	// CheckoutMustNotPersistCredentials control configuration (GitHub
+	// Actions only). Flags an `actions/checkout` step that omits
+	// `persist-credentials: false`, leaving the GITHUB_TOKEN in
+	// `.git/config` where a later step can exfiltrate it.
+	// Config-free; toggle via `enabled`.
+	CheckoutMustNotPersistCredentials *EnabledOnlyControlConfig `yaml:"checkoutMustNotPersistCredentials,omitempty"`
 
 	// WorkflowsMustDeclarePermissions control configuration (GitHub Actions only).
 	// Config-free; toggle via `enabled`.

--- a/configuration/plumberconfig_test.go
+++ b/configuration/plumberconfig_test.go
@@ -363,6 +363,7 @@ func TestValidControlNames(t *testing.T) {
 		"actionsMustNotCarryKnownCVEs",
 		"actionsMustNotExecuteMutableRemoteCode",
 		"branchMustBeProtected",
+		"checkoutMustNotPersistCredentials",
 		"cicdVariablesMustBeMasked",
 		"cicdVariablesMustBeProtected",
 		"containerImageMustComeFromAuthorizedSources",

--- a/configuration/registry.go
+++ b/configuration/registry.go
@@ -160,7 +160,6 @@ var benchedControls = map[string]map[string]struct{}{
 		"actionsMustNotDuplicateRunnerBuiltins": {},
 
 		// Repo-artifact / setup-side controls (need fixture coverage).
-		"checkoutMustNotPersistCredentials":                   {},
 		"containerCredentialsMustComeFromSecrets":             {},
 		"dependabotEcosystemsMustHaveCooldown":                {},
 		"dependabotMustNotAllowInsecureExternalCodeExecution": {},

--- a/control/catalog.go
+++ b/control/catalog.go
@@ -235,6 +235,11 @@ func GitHubControls(pc *configuration.PlumberConfig) []ControlEntry {
 		Skipped:     c.PullRequestTargetMustNotCheckoutHead == nil || !c.PullRequestTargetMustNotCheckoutHead.IsEnabled(),
 	})
 	entries = append(entries, ControlEntry{
+		DisplayName: "Checkout must not persist credentials",
+		ControlName: "checkoutMustNotPersistCredentials",
+		Skipped:     c.CheckoutMustNotPersistCredentials == nil || !c.CheckoutMustNotPersistCredentials.IsEnabled(),
+	})
+	entries = append(entries, ControlEntry{
 		DisplayName: "Workflows must declare permissions",
 		ControlName: "workflowsMustDeclarePermissions",
 		Skipped:     c.WorkflowsMustDeclarePermissions == nil || !c.WorkflowsMustDeclarePermissions.IsEnabled(),
@@ -427,6 +432,9 @@ func DisabledControlNames(c *configuration.ControlsConfig) map[string]bool {
 	}
 	if cfg := c.PullRequestTargetMustNotCheckoutHead; cfg == nil || !cfg.IsEnabled() {
 		out["pullRequestTargetMustNotCheckoutHead"] = true
+	}
+	if cfg := c.CheckoutMustNotPersistCredentials; cfg == nil || !cfg.IsEnabled() {
+		out["checkoutMustNotPersistCredentials"] = true
 	}
 	if cfg := c.WorkflowsMustDeclarePermissions; cfg == nil || !cfg.IsEnabled() {
 		out["workflowsMustDeclarePermissions"] = true

--- a/control/codes.go
+++ b/control/codes.go
@@ -107,7 +107,8 @@ const (
 	CodeSecretsOutsideEnv ErrorCode = "ISSUE-305"
 	// ISSUE-306: GitHub App token issued with revocation disabled
 	CodeGitHubAppSkipRevoke ErrorCode = "ISSUE-306"
-	// ISSUE-307: Checkout persists credentials in .git/config (artipacked)
+	// ISSUE-307: Checkout persists credentials in .git/config — latent
+	// hygiene (low). The demonstrable-leak escalation is ISSUE-310.
 	CodeArtipacked ErrorCode = "ISSUE-307"
 	// ISSUE-308: Workflow reads a secret via a dynamic index (secrets[expr])
 	CodeSecretsDynamicIndex ErrorCode = "ISSUE-308"
@@ -115,6 +116,9 @@ const (
 	// Moved from ISSUE-301 in the 301/309 swap so the leaked-secrets rule could
 	// take the slot already used by the downstream jobs platform.
 	CodeOverprovisionedSecrets ErrorCode = "ISSUE-309"
+	// ISSUE-310: Persisted checkout credentials are packed into an uploaded
+	// artifact (`.git` in the artifact) — the demonstrable ArtiPACKED leak.
+	CodeArtipackedExfiltrated ErrorCode = "ISSUE-310"
 )
 
 // Issue codes for pipeline composition controls (4xx)
@@ -723,11 +727,20 @@ var errorCodeRegistry = map[ErrorCode]ErrorCodeInfo{
 	},
 	CodeArtipacked: {
 		Code:        CodeArtipacked,
-		Severity:    SeverityHigh,
-		Title:       "Checkout persists credentials in .git/config",
-		Description: "A GitHub Actions job runs `actions/checkout` without disabling credential persistence. By default the action writes GITHUB_TOKEN into the cloned repository's .git/config. Any subsequent step that uploads `.git` as part of an artifact, or executes fork-controlled code, can exfiltrate the token.",
+		Severity:    SeverityLow,
+		Title:       "Checkout persists credentials in .git/config (latent)",
+		Description: "A GitHub Actions job runs `actions/checkout` without disabling credential persistence. By default the action writes GITHUB_TOKEN into the cloned repository's .git/config, where it survives for the lifetime of the job. On its own this is latent hygiene: the token is discarded when the job ends. It becomes a demonstrable leak only when a later step packs `.git` into an uploaded artifact (escalated to ISSUE-310) or when fork-controlled code runs in the job (covered by ISSUE-802 / ISSUE-804).",
 		Remediation: "Add `with: { persist-credentials: false }` on every `uses: actions/checkout@*` step unless the job legitimately needs to push back. When push is required, scope the token with an explicit `permissions:` block.",
 		DocURL:      docsBaseURL + string(CodeArtipacked),
+		ControlName: "checkoutMustNotPersistCredentials",
+	},
+	CodeArtipackedExfiltrated: {
+		Code:        CodeArtipackedExfiltrated,
+		Severity:    SeverityHigh,
+		Title:       "Persisted checkout credentials packed into an uploaded artifact",
+		Description: "A GitHub Actions job runs `actions/checkout` with credential persistence enabled and then a later `actions/upload-artifact` step uploads a `.git`-inclusive path (the workspace root, `.`, or a path naming `.git`). The GITHUB_TOKEN written into `.git/config` is packed into the artifact, which is downloadable (anonymously, on public repos), so the token is exfiltrable. This is the canonical, demonstrable ArtiPACKED leak.",
+		Remediation: "Add `with: { persist-credentials: false }` on the `actions/checkout@*` step, or upload a scoped path that excludes `.git` (e.g. `path: dist/` instead of `path: .`). When push is required, scope the token with an explicit `permissions:` block.",
+		DocURL:      docsBaseURL + string(CodeArtipackedExfiltrated),
 		ControlName: "checkoutMustNotPersistCredentials",
 	},
 	CodeUnredactedSecrets: {

--- a/defaultConfig/.plumber.yaml
+++ b/defaultConfig/.plumber.yaml
@@ -965,6 +965,19 @@ github:
       enabled: true
 
     # ===========================================
+    # Checkout must not persist credentials
+    # ===========================================
+    # By default `actions/checkout` writes the GITHUB_TOKEN into the
+    # cloned repository's `.git/config`, where it survives for the rest
+    # of the job. On its own that is latent (ISSUE-307, low): the token
+    # dies with the job. It becomes a demonstrable leak (ISSUE-310,
+    # high) when a later step uploads a `.git`-inclusive path as an
+    # artifact, which is downloadable. The fix is a one-liner for both:
+    # `with: persist-credentials: false`.
+    checkoutMustNotPersistCredentials:
+      enabled: true
+
+    # ===========================================
     # Workflow must not export the entire secrets context
     # ===========================================
     # Flags a job that serialises the whole `secrets` context with

--- a/docs/GITHUB_ISSUES.md
+++ b/docs/GITHUB_ISSUES.md
@@ -54,7 +54,8 @@ reading the upstream docs.
 | [ISSUE-801](#issue-801--undocumented-permissions) | `undocumented-permissions` | medium |
 | [ISSUE-305](#issue-305--secrets-outside-env) | `secrets-outside-env` | medium |
 | [ISSUE-306](#issue-306--github-app-skip-revoke) | `github-app-skip-revoke` | high |
-| [ISSUE-307](#issue-307--artipacked) | `artipacked` | high |
+| [ISSUE-307](#issue-307--artipacked) | `artipacked` | low |
+| [ISSUE-310](#issue-310--artipacked-exfiltrated) | `artipacked-exfiltrated` | high |
 | [ISSUE-308](#issue-308--secrets-dynamic-index) | `secrets-dynamic-index` | low |
 | [ISSUE-309](#issue-309--overprovisioned-secrets) | `overprovisioned-secrets` | **critical** |
 
@@ -1288,12 +1289,15 @@ stays exploitable instead of meeting a revoked token.
 
 ## ISSUE-307 — `artipacked`
 
-**Severity:** `high` • **Control:** `checkoutMustNotPersistCredentials`
+**Severity:** `low` • **Control:** `checkoutMustNotPersistCredentials`
 
 `actions/checkout` writes the GITHUB_TOKEN into the cloned repo's
-`.git/config` by default. Any later step that uploads `.git` as part
-of an artefact, or that runs fork-controlled code, can exfiltrate the
-token.
+`.git/config` by default. On its own that is latent hygiene: the token
+is discarded when the job ends. It becomes a demonstrable leak only
+when a later step packs `.git` into an uploaded artifact (escalated to
+[ISSUE-310](#issue-310--artipacked-exfiltrated)) or when fork-controlled
+code runs in the job (covered by ISSUE-802 / ISSUE-804). This low-tier
+finding is a heads-up to add the one-liner.
 
 ```yaml
 # ❌ before — token persisted
@@ -1305,6 +1309,38 @@ token.
 - uses: actions/checkout@v4
   with:
     persist-credentials: false
+```
+
+---
+
+## ISSUE-310 — `artipacked-exfiltrated`
+
+**Severity:** `high` • **Control:** `checkoutMustNotPersistCredentials`
+
+A checkout persists the GITHUB_TOKEN **and** a later
+`actions/upload-artifact` uploads a `.git`-inclusive path (the
+workspace root, `.`, or a path naming `.git`). The token is packed
+into the artifact, which is downloadable — anonymously, on public
+repos — so it is exfiltrable. This is the canonical, demonstrable
+ArtiPACKED leak, so it escalates from the latent
+[ISSUE-307](#issue-307--artipacked) hygiene tier to a real exposure.
+
+```yaml
+# ❌ before — persisted token packed into the artifact
+- uses: actions/checkout@v4
+- uses: actions/upload-artifact@v4
+  with:
+    path: .            # includes .git/, and .git/config holds the token
+```
+
+```yaml
+# ✅ after — disable persistence, or upload a scoped path
+- uses: actions/checkout@v4
+  with:
+    persist-credentials: false
+- uses: actions/upload-artifact@v4
+  with:
+    path: dist/        # excludes .git/
 ```
 
 ---

--- a/finding/identity/declarations.go
+++ b/finding/identity/declarations.go
@@ -117,12 +117,17 @@ var declarations = map[string][]string{
 	"ISSUE-305": {"file", "job"},
 	// App token issued without revocation: keyed on the token action ref (uses) (benched, not yet live: declaration provisional, revisit on unbench).
 	"ISSUE-306": {"file", "job", "uses"},
-	// Checkout persists credentials: keyed on the action ref (uses); step separates a reused action (benched, not yet live: declaration provisional, revisit on unbench).
+	// Checkout persists credentials, latent: keyed on the action ref (uses); step separates a reused action.
 	"ISSUE-307": {"file", "job", "uses", "step"},
 	// Secret accessed via a dynamic index: one per job, keyed on the job (benched, not yet live: declaration provisional, revisit on unbench).
 	"ISSUE-308": {"file", "job"},
 	// Whole secrets context exported: one per job, keyed on the job.
 	"ISSUE-309": {"file", "job"},
+	// Persisted checkout credentials packed into an uploaded artifact: same
+	// key as ISSUE-307, which it escalates from. A job can check out twice
+	// and pack both, so the action ref has to separate them; keying on the
+	// job alone would report one of the two and silently drop the other.
+	"ISSUE-310": {"file", "job", "uses", "step"},
 	// Hardcoded job: keyed on the hardcoded job name.
 	"ISSUE-401": {"file", "job", "hardcodedJob"},
 	// Ref collides with a tag and a branch: union of the GitHub `uses` and GitLab `includePath` surfaces (see note above).

--- a/finding/identity/identity_test.go
+++ b/finding/identity/identity_test.go
@@ -343,6 +343,7 @@ func TestDeclarations_EveryCodeFingerprintIsPinned(t *testing.T) {
 		"ISSUE-307": "05ed16253de98346",
 		"ISSUE-308": "de132d1493cadafe",
 		"ISSUE-309": "2e2c85d21a6492a6",
+		"ISSUE-310": "5ba5827fd01d3e4c",
 		"ISSUE-401": "468870372f32863b",
 		"ISSUE-402": "574564223df032be",
 		"ISSUE-403": "9c0211f37dbdd777",

--- a/policies/artipacked.rego
+++ b/policies/artipacked.rego
@@ -1,30 +1,61 @@
 # artipacked — detect jobs that check out the repository with
-# `actions/checkout` without disabling credential persistence. By
-# default, actions/checkout writes the GITHUB_TOKEN into the cloned
-# repository's .git/config, where it survives for the lifetime of the
-# job. Any later step that uploads `.git` as part of an artifact, or
-# that executes fork-controlled code, can exfiltrate the token. The
-# documented mitigation is a one-liner: `with: persist-credentials:
-# false`.
+# `actions/checkout` while credential persistence is enabled. By default
+# `actions/checkout` writes the GITHUB_TOKEN into the cloned repo's
+# `.git/config`, where it survives for the lifetime of the job.
 #
-# This check pairs with dangerous-triggers (ISSUE-802) and
-# template-injection (ISSUE-207): the persisted credential is
-# precisely what an attacker harvests once they escalate through the
-# trigger / injection path.
+# The severity is graded by whether the token is actually exfiltrated:
+#
+#   - ISSUE-307 (low) — the credential persists but nothing in the job
+#     packs `.git` into an artifact. This is latent hygiene: the token is
+#     discarded when the job ends, and the other exfiltration route
+#     (persisted credential harvested by fork-controlled code) is owned
+#     by dangerous-triggers (ISSUE-802) and pull-request-target-head-
+#     checkout (ISSUE-804). Flagged as a heads-up to add the one-liner.
+#
+#   - ISSUE-310 (high) — the same persisted credential AND a later
+#     `actions/upload-artifact` step that uploads a `.git`-inclusive path
+#     (`.`, `./`, the workspace root, or any path naming `.git`). The
+#     artifact is downloadable (anonymously, on public repos) and the
+#     token is harvested. This is the canonical, demonstrable "ArtiPACKED"
+#     leak, so it escalates from hygiene to a real exposure.
+#
+# The mitigation is a one-liner for both: `with: persist-credentials:
+# false` (and push with an explicit token if the job needs to write back).
 package artipacked
 
 import rego.v1
 
+# ISSUE-310 (high): credential persists AND `.git` is packed into an
+# uploaded artifact — a demonstrable token leak.
 deny contains finding if {
 	some i, j
 	job := input.pipeline.jobs[i]
 	action := job.uses[j]
 	startswith(action.uses, "actions/checkout@")
 	not _credentials_disabled(action)
+	upload := _git_packing_upload(job, object.get(action, "line", 0))
+	finding := {
+		"code":     "ISSUE-310",
+		"severity": "high",
+		"message":  sprintf("job %q runs %q with credential persistence, then %q uploads a `.git`-inclusive path (%q) — GITHUB_TOKEN is packed into a downloadable artifact and exfiltrable", [job.name, action.uses, upload.uses, _upload_path(upload)]),
+		"job":      job.name,
+		"line":     object.get(action, "line", 0),
+	}
+}
+
+# ISSUE-307 (low): credential persists but nothing packs `.git` into an
+# artifact — latent hygiene, not a demonstrated leak.
+deny contains finding if {
+	some i, j
+	job := input.pipeline.jobs[i]
+	action := job.uses[j]
+	startswith(action.uses, "actions/checkout@")
+	not _credentials_disabled(action)
+	not _git_packing_upload(job, object.get(action, "line", 0))
 	finding := {
 		"code":     "ISSUE-307",
-		"severity": "high",
-		"message":  sprintf("job %q runs %q without `persist-credentials: false` — GITHUB_TOKEN lingers in .git/config and is exfiltrable by later steps", [job.name, action.uses]),
+		"severity": "low",
+		"message":  sprintf("job %q runs %q without `persist-credentials: false` — GITHUB_TOKEN lingers in .git/config (latent; becomes a leak if a later step packs .git into an artifact or runs fork-controlled code)", [job.name, action.uses]),
 		"job":      job.name,
 		"uses":     action.uses,
 		"line":     object.get(action, "line", 0),
@@ -40,3 +71,42 @@ _credentials_disabled(action) if {
 _credentials_disabled(action) if {
 	action.with["persist-credentials"] == "false"
 }
+
+# _git_packing_upload returns an upload-artifact action from the same
+# job that (a) runs after the checkout at checkoutLine and (b) uploads
+# a path that would include the `.git` directory.
+_git_packing_upload(job, checkoutLine) := upload if {
+	some k
+	upload := job.uses[k]
+	startswith(upload.uses, "actions/upload-artifact@")
+	object.get(upload, "line", 0) > checkoutLine
+	_path_includes_git(_upload_path(upload))
+}
+
+_upload_path(upload) := path if {
+	path := upload.with.path
+}
+
+# The `path:` input may be a single scalar or a newline-separated block
+# (multiple paths). Flag if any line resolves to a `.git`-inclusive
+# location.
+_path_includes_git(path) if {
+	is_string(path)
+	_risky_path(trim_space(path))
+}
+
+_path_includes_git(path) if {
+	is_string(path)
+	some line in split(path, "\n")
+	_risky_path(trim_space(line))
+}
+
+# A path that packs the whole workspace (and therefore `.git`), or that
+# names `.git` directly.
+_risky_path(p) if p == "."
+
+_risky_path(p) if p == "./"
+
+_risky_path(p) if contains(p, "github.workspace")
+
+_risky_path(p) if contains(p, ".git")

--- a/policies/artipacked.rego
+++ b/policies/artipacked.rego
@@ -39,6 +39,11 @@ deny contains finding if {
 		"severity": "high",
 		"message":  sprintf("job %q runs %q with credential persistence, then %q uploads a `.git`-inclusive path (%q) — GITHUB_TOKEN is packed into a downloadable artifact and exfiltrable", [job.name, action.uses, upload.uses, _upload_path(upload)]),
 		"job":      job.name,
+		# The checkout ref, not the upload's: it is what identifies WHICH
+		# step persisted the credential. A job can check out twice (its own
+		# repo plus another) and both can pack; without this they collapse
+		# into one finding and the second checkout is never reported.
+		"uses": action.uses,
 		"line":     object.get(action, "line", 0),
 	}
 }

--- a/policies/rules_test.go
+++ b/policies/rules_test.go
@@ -716,9 +716,10 @@ func TestIssue208_InsecureCommands(t *testing.T) {
 	}
 }
 
-// TestIssue307_Artipacked drives the artipacked policy against a
-// default actions/checkout (violation) and one explicitly passing
-// `persist-credentials: false` (clean).
+// TestIssue307_Artipacked drives the artipacked policy against both
+// violation forms (a default actions/checkout and an explicit
+// `persist-credentials: true`) and both clean forms (the boolean
+// `false` and the quoted string `"false"`).
 func TestIssue307_Artipacked(t *testing.T) {
 	cases := []struct {
 		fixture      string
@@ -729,7 +730,15 @@ func TestIssue307_Artipacked(t *testing.T) {
 			expectedHits: []string{"violation_default_checkout/clone"},
 		},
 		{
+			fixture:      "violation_persist_true.yml",
+			expectedHits: []string{"violation_persist_true/clone"},
+		},
+		{
 			fixture:      "clean_credentials_disabled.yml",
+			expectedHits: nil,
+		},
+		{
+			fixture:      "clean_credentials_disabled_quoted.yml",
 			expectedHits: nil,
 		},
 	}

--- a/policies/rules_test.go
+++ b/policies/rules_test.go
@@ -716,30 +716,41 @@ func TestIssue208_InsecureCommands(t *testing.T) {
 	}
 }
 
-// TestIssue307_Artipacked drives the artipacked policy against both
-// violation forms (a default actions/checkout and an explicit
-// `persist-credentials: true`) and both clean forms (the boolean
-// `false` and the quoted string `"false"`).
+// TestIssue307_Artipacked drives the artipacked policy under the graded
+// model. A persisted-credential checkout (A) always fires, but the
+// severity depends on whether `.git` is packed into an artifact (B):
+//   - A ∧ B  → ISSUE-310 (high): the demonstrable ArtiPACKED leak.
+//   - A ∧ ¬B → ISSUE-307 (low): latent hygiene.
+//   - ¬A     → nothing (credentials disabled).
+// expectedCodes lists the ISSUE codes each fixture must produce.
 func TestIssue307_Artipacked(t *testing.T) {
 	cases := []struct {
-		fixture      string
-		expectedHits []string
+		fixture       string
+		expectedCodes []string
 	}{
 		{
-			fixture:      "violation_default_checkout.yml",
-			expectedHits: []string{"violation_default_checkout/clone"},
+			fixture:       "violation_default_checkout.yml",
+			expectedCodes: []string{"ISSUE-310"},
 		},
 		{
-			fixture:      "violation_persist_true.yml",
-			expectedHits: []string{"violation_persist_true/clone"},
+			fixture:       "violation_persist_true.yml",
+			expectedCodes: []string{"ISSUE-310"},
 		},
 		{
-			fixture:      "clean_credentials_disabled.yml",
-			expectedHits: nil,
+			fixture:       "low_persisted_no_upload.yml",
+			expectedCodes: []string{"ISSUE-307"},
 		},
 		{
-			fixture:      "clean_credentials_disabled_quoted.yml",
-			expectedHits: nil,
+			fixture:       "low_upload_scoped_path.yml",
+			expectedCodes: []string{"ISSUE-307"},
+		},
+		{
+			fixture:       "clean_credentials_disabled.yml",
+			expectedCodes: nil,
+		},
+		{
+			fixture:       "clean_credentials_disabled_quoted.yml",
+			expectedCodes: nil,
 		},
 	}
 
@@ -774,18 +785,17 @@ func TestIssue307_Artipacked(t *testing.T) {
 				t.Fatalf("evaluate: %v", err)
 			}
 
-			hits := make([]string, 0, len(findings))
+			codes := make([]string, 0, len(findings))
 			for _, f := range findings {
-				if f.Code != "ISSUE-307" {
-					continue
+				if f.Code == "ISSUE-307" || f.Code == "ISSUE-310" {
+					codes = append(codes, f.Code)
 				}
-				hits = append(hits, f.Job)
 			}
-			sort.Strings(hits)
-			expected := append([]string(nil), tc.expectedHits...)
+			sort.Strings(codes)
+			expected := append([]string(nil), tc.expectedCodes...)
 			sort.Strings(expected)
-			if !stringSlicesEqual(hits, expected) {
-				t.Fatalf("%s: expected %v, got %v", tc.fixture, expected, hits)
+			if !stringSlicesEqual(codes, expected) {
+				t.Fatalf("%s: expected %v, got %v", tc.fixture, expected, codes)
 			}
 		})
 	}

--- a/policies/testdata/ISSUE-307/github/clean_credentials_disabled_quoted.yml
+++ b/policies/testdata/ISSUE-307/github/clean_credentials_disabled_quoted.yml
@@ -1,0 +1,14 @@
+# Checkout disables credential persistence using the quoted string
+# form `persist-credentials: "false"`. The rule accepts both the YAML
+# boolean and the quoted string. Expected: 0 findings.
+name: Safe checkout quoted
+on: push
+
+jobs:
+  safe-clone:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: "false"
+      - run: echo "built"

--- a/policies/testdata/ISSUE-307/github/low_persisted_no_upload.yml
+++ b/policies/testdata/ISSUE-307/github/low_persisted_no_upload.yml
@@ -1,0 +1,14 @@
+# A default actions/checkout persists GITHUB_TOKEN in .git/config, but
+# nothing packs `.git` into an artifact. This is latent hygiene, not a
+# demonstrated leak, so it is the low-severity ISSUE-307 tier (the
+# persisted-credential-plus-fork-code route is owned by the dangerous-
+# triggers / PR-head-checkout controls). Expected: 1 ISSUE-307 (low).
+name: Persisted credential, no artifact upload
+on: push
+
+jobs:
+  clone:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "built"

--- a/policies/testdata/ISSUE-307/github/low_upload_scoped_path.yml
+++ b/policies/testdata/ISSUE-307/github/low_upload_scoped_path.yml
@@ -1,0 +1,18 @@
+# A default actions/checkout persists GITHUB_TOKEN, and a later
+# upload-artifact runs — but it uploads a scoped build output (`dist/`),
+# not the workspace root or `.git`. The token is never packed, so it does
+# not escalate: it stays the low-severity ISSUE-307 tier, not ISSUE-310.
+# Expected: 1 ISSUE-307 (low), no ISSUE-310.
+name: Persisted credential, scoped artifact path
+on: push
+
+jobs:
+  clone:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/

--- a/policies/testdata/ISSUE-307/github/violation_default_checkout.yml
+++ b/policies/testdata/ISSUE-307/github/violation_default_checkout.yml
@@ -9,7 +9,11 @@ jobs:
   clone:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # Named on purpose: `step` is part of this code's identity key, and
+      # the harness requires at least one emission to carry it. Two
+      # checkouts of the same ref in one job are told apart by it.
+      - name: Checkout sources
+        uses: actions/checkout@v4
       - run: echo "built"
       - uses: actions/upload-artifact@v4
         with:

--- a/policies/testdata/ISSUE-307/github/violation_default_checkout.yml
+++ b/policies/testdata/ISSUE-307/github/violation_default_checkout.yml
@@ -1,6 +1,8 @@
-# Default actions/checkout persists GITHUB_TOKEN in .git/config.
-# Expected: 1 finding on clone.
-name: Default checkout
+# A default actions/checkout persists GITHUB_TOKEN in .git/config, and a
+# later upload-artifact packs the whole workspace (path: `.`) — which
+# includes `.git`. The token is shipped inside a downloadable artifact.
+# Expected: 1 finding on clone (A: persisted credential AND B: .git packed).
+name: Default checkout then pack workspace
 on: push
 
 jobs:
@@ -9,3 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: echo "built"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: workspace
+          path: .

--- a/policies/testdata/ISSUE-307/github/violation_persist_true.yml
+++ b/policies/testdata/ISSUE-307/github/violation_persist_true.yml
@@ -1,7 +1,8 @@
 # Checkout explicitly re-enables credential persistence with
-# `persist-credentials: true`. Same exposure as the default: the
-# GITHUB_TOKEN lingers in .git/config. Expected: 1 finding on clone.
-name: Explicit persist true
+# `persist-credentials: true`, then a later upload-artifact uploads a
+# `.git`-inclusive path. Same exposure as the default: GITHUB_TOKEN is
+# packed into a downloadable artifact. Expected: 1 finding on clone.
+name: Explicit persist true then pack .git
 on: push
 
 jobs:
@@ -12,3 +13,9 @@ jobs:
         with:
           persist-credentials: true
       - run: echo "built"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: repo
+          path: |
+            dist/
+            .git

--- a/policies/testdata/ISSUE-307/github/violation_persist_true.yml
+++ b/policies/testdata/ISSUE-307/github/violation_persist_true.yml
@@ -1,0 +1,14 @@
+# Checkout explicitly re-enables credential persistence with
+# `persist-credentials: true`. Same exposure as the default: the
+# GITHUB_TOKEN lingers in .git/config. Expected: 1 finding on clone.
+name: Explicit persist true
+on: push
+
+jobs:
+  clone:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+      - run: echo "built"


### PR DESCRIPTION
Closes #187.

## Summary

`artipacked` was implemented but benched. This ships it, and grades it by
exploitability rather than shipping one blanket `high`.

#187 asked for a single `high` control. That is not what this delivers, and the
difference is deliberate:

- **ISSUE-307 (low)** — `actions/checkout` runs without `persist-credentials:
  false`, and nothing in the job packs `.git` into an artifact. The
  `GITHUB_TOKEN` sits in `.git/config` but dies with the job. Latent hygiene:
  worth the one-line fix, not worth a `high`.
- **ISSUE-310 (high)** — the same persisted credential **plus** a later
  `actions/upload-artifact` step uploading a `.git`-inclusive path (`.`, the
  workspace root, or any path naming `.git`). The artifact is downloadable,
  anonymously on public repos, so the token is exfiltrable. This is the
  canonical ArtiPACKED leak.

The other exfiltration route — a persisted credential harvested by
fork-controlled code — is already owned by ISSUE-802 (dangerous triggers) and
ISSUE-804 (pull_request_target head checkout), so it is not duplicated here.

**Why not one `high`.** A run over a large real workflow set produced 88
findings. Reporting all of them as `high` would drown the handful that are
actually exfiltrable, which is the failure mode ISSUE-207 already refuses in
this codebase: fields that cannot carry the payload are deliberately not
matched, because flagging them buries the real signal.

## Wiring

The control turned out to be benched for more than missing fixtures: it had no
config plumbing at all. `enabled: false` was silently ignored and it never
appeared in `config view`. That is now complete, and ISSUE-310 is wired the same
way as its 20 shipping GitHub peers:

- `benchedControls[ProviderGitHub]` entry removed.
- Config: `EnabledOnlyControlConfig` field, valid-key entry, `control/catalog.go`
  entry, `DisabledControlNames` gate.
- Both configs: the shipped default (`defaultConfig/.plumber.yaml`, which is what
  `make embed` reads) and the self-scan (`.plumber.yaml`).
- `config init` wizard: menu item, emit logic, and the starter selection.
- Output: `checkoutCredentialsResult` JSON block and the terminal stat block.
  Without these the control ran and produced findings that never surfaced in
  either report.
- Identity: an `ISSUE-310` declaration keyed like ISSUE-307
  (`file`, `job`, `uses`, `step`), with the golden fingerprint regenerated.
  ISSUE-307's own declaration carried a "provisional, revisit on unbench" note;
  unbenching is that revisit, so the note is gone.

`ISSUE-310` also emits `uses`. Both rules iterate a job's actions, so a job that
checks out twice and packs both would otherwise report one finding and silently
drop the other.

## Tests

Five fixtures covering the grading: default checkout with a workspace upload
(310), explicit `persist-credentials: true` (310), persisted with no upload
(307), persisted with a scoped upload path that excludes `.git` (307), and the
quoted `"false"` clean form. `make build && make test && make lint && make
deadcode` green, rebased on `main`.

## Not done here

`ISSUE-310` needs an entry in the website catalogue
(`getplumber.io/src/data/issues.ts`). Nothing in this repo's CI guards that, and
until it lands the `docs/cli/issues/ISSUE-310` link on every finding 404s.
