### PR TITLE
test(cli): pin that --no-controls keeps collected include versions

### DIFF
--- a/cmd/no_controls_outputs_test.go
+++ b/cmd/no_controls_outputs_test.go
@@ -227,7 +227,11 @@ func gitHubPBOMFixture() *control.AnalysisResult {
 			Jobs: []ir.Job{{
 				Name:  "build",
 				Image: &ir.Image{Name: "alpine", Tag: "latest", Registry: "docker.io"},
-				Uses:  []ir.Action{{Uses: "actions/checkout@v4"}},
+				// Comment carries the human-readable version annotation
+				// ("@sha # v4.1.0"); the GitHub generator stashes it as the
+				// include's latestVersion, which is collected data and must
+				// survive --no-controls just like the GitLab equivalent.
+				Uses: []ir.Action{{Uses: "actions/checkout@v4", Comment: "v4.1.0"}},
 			}},
 		},
 		Findings: []opaengine.Finding{
@@ -365,6 +369,30 @@ func assertPBOMClaimsNothing(t *testing.T, raw []byte) {
 			if v, ok := entry[k]; ok {
 				t.Errorf("%v asserts %s=%v for a control that never ran", entry["image"], k, v)
 			}
+		}
+	}
+
+	// The other half of the contract, and the one the assertions above
+	// cannot express: suppression is scoped to VERDICTS, and the collected
+	// data has to survive. `latestVersion` is the upstream version the
+	// origin collector read; it states a fact, not a conclusion, so the
+	// artifact keeps it.
+	//
+	// It is worth pinning separately because in processIncludes the
+	// LatestVersion assignment sits one line above the suppressVerdicts
+	// guard, in both the FromPlumber and FromGitlabCatalog branches. A
+	// refactor that widened the guard by one line would silently strip
+	// upstream versions from every --no-controls PBOM, which is the very
+	// artifact the flag exists to produce, and nothing else here would
+	// fail: the checks above only assert that verdict fields are ABSENT.
+	// EVERY include, not just one: processIncludes has two branches that
+	// each set LatestVersion next to the guard (FromPlumber and
+	// FromGitlabCatalog), and the fixture exercises both. An "at least one"
+	// check would be satisfied by the healthy branch while the other
+	// silently lost its version.
+	for _, inc := range bom.Includes {
+		if v, _ := inc["latestVersion"].(string); v == "" {
+			t.Errorf("include %v lost its collected latestVersion; --no-controls must suppress verdicts, not the inventory", inc["location"])
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to a review finding on #435 that arrived about four minutes after the merge, so it could not be addressed in that PR.

## The gap

`--no-controls` suppresses per-control **verdicts**; it must not suppress the **collected inventory**. The PBOM tests asserted only the first half: that no verdict field (`upToDate`, `authorized`, `forbiddenTag`, ...) is stamped on any entry. Nothing asserted the non-verdict data survives.

That matters because of where the line sits. In `processIncludes`, `LatestVersion` is assigned immediately above the `suppressVerdicts` guard, in both branches:

```go
inc.LatestVersion = origin.PlumberOrigin.LatestVersion
if !g.suppressVerdicts {
    upToDate := origin.UpToDate
    inc.UpToDate = &upToDate
}
```

Widening that guard by one line is an easy refactor mistake, and it would silently strip upstream versions from every `--no-controls` PBOM, the exact artifact the flag exists to produce, with the suite staying green. The README and the `NoControls` doc comment both promise the PBOM records "images, includes, upstream versions".

## The fix

`assertPBOMClaimsNothing` now requires **every** include to keep a non-empty `latestVersion`.

"At least one" is not enough, and I checked that rather than assumed it: my first attempt used exactly that, and the mutation below **passed**. The GitLab fixture carries two includes that reach the field through different branches (`FromPlumber` and `FromGitlabCatalog`), so a single-branch regression hid behind the healthy one. Requiring all of them is what closes it.

The GitHub action fixture also gains a version comment (`Comment: "v4.1.0"`), which is where that provider's generator sources the same field, so both providers are covered rather than just GitLab.

## Verification

Mutation-tested on each of the three sites that set `LatestVersion`, each in isolation:

| Mutation | Result |
|---|---|
| `FromPlumber` branch: guard widened over `LatestVersion` | `FAIL gitlab/pbom` |
| `FromGitlabCatalog` branch: same | `FAIL gitlab/pbom` |
| GitHub generator: `inc.LatestVersion` dropped | `FAIL github/pbom` |

Test-only change. Full `go test ./...` green, `go vet` clean, and the pinned `golangci-lint` reports `0 issues`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDkbDA2xTxKsn6wv5f8fPx