### PR TITLE
fix(ci): treat a review that completes without structured output as zero findings

### DIFF
--- a/.github/workflows/claude-pr-checks.yml
+++ b/.github/workflows/claude-pr-checks.yml
@@ -77,6 +77,13 @@ jobs:
 
       - name: Claude review
         id: review
+        # continue-on-error hands the pass/fail decision to the
+        # zero-findings fallback step below, which can tell a review that
+        # completed with nothing to report apart from one that really
+        # failed. The action alone cannot: it hard-fails whenever the model
+        # finishes without calling the structured-output tool, and a review
+        # with zero findings reliably ends exactly that way.
+        continue-on-error: true
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -173,6 +180,37 @@ jobs:
             --allowedTools "Read,Grep,Glob"
             --disallowedTools "Read(/proc/**),Read(//proc/**),Read(/sys/**),Read(//sys/**),Read(/etc/**),Read(//etc/**),Read(/home/runner/work/_temp/**),Read(//home/runner/work/_temp/**),Grep(/proc/**),Grep(//proc/**),Grep(/sys/**),Grep(//sys/**),Grep(/etc/**),Grep(//etc/**),Grep(/home/runner/work/_temp/**),Grep(//home/runner/work/_temp/**)"
             --json-schema '{"type":"object","properties":{"has_findings":{"type":"boolean"},"findings":{"type":"array","items":{"type":"object","properties":{"summary":{"type":"string"},"severity":{"type":"string"},"file":{"type":"string"},"line":{"type":"integer"},"details":{"type":"string"}},"required":["summary","file","details"]}}},"required":["has_findings","findings"]}'
+
+      # The verdict for a failed review step. The action exports the
+      # execution transcript even when it fails (both its entrypoints set
+      # execution_file in their catch), and the transcript's final result
+      # message tells the two failure classes apart:
+      #
+      #   - subtype "success" without is_error: the review COMPLETED and
+      #     the model simply never called the structured-output tool - the
+      #     reliable shape of a review with nothing to report. Treat as no
+      #     findings: exit 0, no artifact, and the comment job already
+      #     reads a missing report as "control did not complete".
+      #   - anything else (no transcript, is_error, a non-success subtype):
+      #     a real failure - API error, timeout, refusal - that must stay
+      #     red rather than read as a clean review.
+      - name: Zero-findings fallback
+        if: steps.review.outcome == 'failure'
+        env:
+          EXECUTION_FILE: ${{ steps.review.outputs.execution_file }}
+        run: |
+          if [ -z "$EXECUTION_FILE" ] || [ ! -s "$EXECUTION_FILE" ]; then
+            echo "review failed before producing a transcript"
+            exit 1
+          fi
+          subtype=$(jq -r '[.[] | select(.type == "result")] | last | .subtype // empty' "$EXECUTION_FILE")
+          is_error=$(jq -r '[.[] | select(.type == "result")] | last | .is_error // false' "$EXECUTION_FILE")
+          if [ "$subtype" = "success" ] && [ "$is_error" != "true" ]; then
+            echo "review completed without structured output; treating as a review with no findings"
+          else
+            echo "review failed (subtype=${subtype:-none} is_error=${is_error})"
+            exit 1
+          fi
 
       # Review jobs never post; they hand their report to the comment job
       # below via an artifact.


### PR DESCRIPTION
The pinned claude-code-action hard-fails whenever the model finishes without calling the structured-output tool, and a review control with nothing to report reliably ends exactly that way: three consecutive identical failures on PR #431's current head (`subtype: success`, no findings, no structured output), one per rerun. Every future PR that a review control finds clean will hit the same red check.

**How the fix distinguishes the two failure classes.** The action exports its execution transcript (`execution_file` output) even when it fails; both of its entrypoints set it in their catch path. The transcript's final `result` message carries `subtype` and `is_error`:

- `subtype: "success"` without `is_error`: the review COMPLETED and the model simply never emitted structured output, the zero-findings shape. The new fallback step treats it as a clean review: exit 0, no report artifact, and the comment job already reads a missing report as "control did not complete".
- Anything else (no transcript, `is_error`, non-success subtype): a real failure (API error, timeout, refusal) and the job stays red exactly as today.

The review step gains `continue-on-error: true` so the fallback step owns the verdict; a step that succeeds normally skips the fallback entirely and nothing else in the job changes.

**Verified:** YAML parses; the repo's own Plumber self-scan on the modified tree stays at 100 raw points with zero failed controls (no new `uses:` entries, so no new pinning).

Once merged, rerunning `claude-review (bug-risks)` on #431 should turn its deterministic red check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzQcbUy6pBGj3sgVaXV5jo