### PR TITLE
test(platform): pin the review-flagged guards from the platform-mode audit

### DIFF
--- a/cmd/platform_push_test.go
+++ b/cmd/platform_push_test.go
@@ -1040,3 +1040,52 @@ func keysOf(m map[string]json.RawMessage) []string {
 	}
 	return out
 }
+
+// notEvaluableReasonData carries the machine-readable reason onto the
+// pushed finding; dropping it would leave the platform unable to tell "the
+// resolution was unavailable" from "this lane is not switched over" without
+// parsing prose (re-raised #431 review thread).
+func TestNotEvaluableReasonData(t *testing.T) {
+	r := &control.AnalysisResult{}
+	r.MarkNotEvaluable("includesMustBeUpToDate", "resolution_unavailable")
+
+	raw := notEvaluableReasonData(r, "includesMustBeUpToDate")
+	var got map[string]string
+	if err := json.Unmarshal(raw, &got); err != nil || got["reason"] != "resolution_unavailable" {
+		t.Fatalf("want {reason: resolution_unavailable}, got %s (err %v)", raw, err)
+	}
+	if data := notEvaluableReasonData(r, "someOtherControl"); data != nil {
+		t.Fatalf("an unmarked control must carry no reason data, got %s", data)
+	}
+	if data := notEvaluableReasonData(nil, "includesMustBeUpToDate"); data != nil {
+		t.Fatalf("a nil result must yield nil, got %s", data)
+	}
+}
+
+// Platform mode runs tokenless by design: the OIDC id-token replaces the
+// personal token, so resolveGitLabToken must permit an empty GITLAB_TOKEN
+// when --platform is configured and still refuse it otherwise (re-raised
+// #431 review thread; the core of #368's tokenless CI).
+func TestResolveGitLabToken_PlatformModeBypass(t *testing.T) {
+	orig := platformURL
+	defer func() { platformURL = orig }()
+	t.Setenv("GITLAB_TOKEN", "")
+
+	platformURL = "https://app.example.com"
+	token, err := resolveGitLabToken(analyzeFlags{})
+	if err != nil || token != "" {
+		t.Fatalf("platform mode must continue tokenless: got (%q, %v)", token, err)
+	}
+
+	platformURL = ""
+	if _, err := resolveGitLabToken(analyzeFlags{}); err == nil {
+		t.Fatal("without --platform a missing GITLAB_TOKEN must stay an informative error")
+	}
+
+	platformURL = "https://app.example.com"
+	t.Setenv("GITLAB_TOKEN", "glpat-real")
+	token, err = resolveGitLabToken(analyzeFlags{})
+	if err != nil || token != "glpat-real" {
+		t.Fatalf("a supplied token must always win: got (%q, %v)", token, err)
+	}
+}

--- a/control/lanes_test.go
+++ b/control/lanes_test.go
@@ -667,3 +667,62 @@ func TestOwnCollectionGapsStaySilentWhenNothingFailed(t *testing.T) {
 		t.Errorf("a clean collection must mark nothing, got %v", result.NotEvaluable)
 	}
 }
+
+// TestMarkFailedCollections pins the branch-protection collection-failure
+// path (re-raised #431 review thread): an unreadable protection listing is
+// indistinguishable from a project that protects nothing, which is the
+// exact violation branchMustBeProtected reports, so the control must
+// abstain and its findings must be dropped rather than fire the loudest
+// possible false positive.
+func TestMarkFailedCollections(t *testing.T) {
+	entries := []ControlEntry{{ControlName: controlBranchMustBeProtected}}
+
+	t.Run("unread listing marks the control and drops its findings", func(t *testing.T) {
+		r := &AnalysisResult{
+			ProtectionData: &gitlab.GitlabProtectionAnalysisData{BranchProtectionsKnown: false},
+			Findings: []opaengine.Finding{
+				{Code: "ISSUE-501", Message: "branch main unprotected"},
+				{Code: "ISSUE-401", Message: "unrelated finding survives"},
+			},
+		}
+		r.MarkFailedCollections(entries)
+		reason, marked := r.NotEvaluableReason(controlBranchMustBeProtected)
+		if !marked || reason != ReasonCollectionFailed {
+			t.Fatalf("want collection_failed mark, got (%q, %v)", reason, marked)
+		}
+		codes := map[string]bool{}
+		for _, f := range r.Findings {
+			codes[f.Code] = true
+		}
+		if codes["ISSUE-501"] {
+			t.Fatal("the branch-protection finding must be dropped: it was computed over data never read")
+		}
+		if !codes["ISSUE-401"] {
+			t.Fatal("unrelated findings must survive the drop")
+		}
+	})
+
+	t.Run("a read listing marks nothing", func(t *testing.T) {
+		r := &AnalysisResult{ProtectionData: &gitlab.GitlabProtectionAnalysisData{BranchProtectionsKnown: true}}
+		r.MarkFailedCollections(entries)
+		if _, marked := r.NotEvaluableReason(controlBranchMustBeProtected); marked {
+			t.Fatal("a successfully read listing must not be marked")
+		}
+	})
+
+	t.Run("a disabled control is skipped, not marked", func(t *testing.T) {
+		r := &AnalysisResult{ProtectionData: &gitlab.GitlabProtectionAnalysisData{BranchProtectionsKnown: false}}
+		r.MarkFailedCollections([]ControlEntry{{ControlName: controlBranchMustBeProtected, Skipped: true}})
+		if _, marked := r.NotEvaluableReason(controlBranchMustBeProtected); marked {
+			t.Fatal("a control the operator disabled was not unevaluated, it was turned off")
+		}
+	})
+
+	t.Run("no protection data at all marks nothing here", func(t *testing.T) {
+		r := &AnalysisResult{}
+		r.MarkFailedCollections(entries)
+		if _, marked := r.NotEvaluableReason(controlBranchMustBeProtected); marked {
+			t.Fatal("a collection that never ran is the other markers' concern, not this one's")
+		}
+	})
+}

--- a/control/mrcomment_test.go
+++ b/control/mrcomment_test.go
@@ -150,3 +150,26 @@ func TestMRCommentOrderCoversEveryGitLabControl(t *testing.T) {
 		}
 	}
 }
+
+// TestGenerateMRComment_NotEvaluableRow pins the MR-comment table's third
+// state (re-raised #431 review thread): a control whose data lane supplied
+// nothing renders as "not evaluated" with a grey question mark, never as a
+// green check a reviewer would take for a pass.
+func TestGenerateMRComment_NotEvaluableRow(t *testing.T) {
+	enabled := true
+	pc := &configuration.PlumberConfig{GitLab: &configuration.ProviderConfig{
+		Controls: configuration.ControlsConfig{
+			BranchMustBeProtected: &configuration.BranchProtectionControlConfig{Enabled: &enabled},
+		},
+	}}
+	result := &AnalysisResult{CiValid: true}
+	result.MarkNotEvaluable("branchMustBeProtected", ReasonCollectionFailed)
+
+	body := generateMRComment(result, pc, true, "", nil, false, false, nil, nil)
+	if !strings.Contains(body, ":grey_question:") || !strings.Contains(body, "_not evaluated_") {
+		t.Fatalf("a not_evaluable control must render its own row, got:\n%s", body)
+	}
+	if strings.Contains(body, ":white_check_mark: Branch must be protected") {
+		t.Fatalf("a not_evaluable control must never render as a green check:\n%s", body)
+	}
+}

--- a/gitlab/ci_environment_ref_test.go
+++ b/gitlab/ci_environment_ref_test.go
@@ -49,3 +49,45 @@ func TestCIConfigPathIsExternal(t *testing.T) {
 		}
 	}
 }
+
+// CheckoutIsAtRef gates whether the analyzed project's CI file is read from
+// the checkout instead of fetched: reading one branch's file while
+// reporting on another parses cleanly and is silently wrong, which is why
+// every branch of this guard needs pinning (re-raised #431 review thread).
+func TestCheckoutIsAtRef(t *testing.T) {
+	t.Run("outside CI is never at the ref", func(t *testing.T) {
+		t.Setenv("CI", "")
+		t.Setenv("CI_COMMIT_REF_NAME", "main")
+		if CheckoutIsAtRef("main") {
+			t.Fatal("outside CI there is no checked-out ref to be at")
+		}
+	})
+	t.Run("empty branch means the analyzed ref by definition", func(t *testing.T) {
+		t.Setenv("CI", "true")
+		t.Setenv("CI_COMMIT_REF_NAME", "feature/x")
+		if !CheckoutIsAtRef("") {
+			t.Fatal("a run that names no branch analyses what it stands in")
+		}
+	})
+	t.Run("matching ref", func(t *testing.T) {
+		t.Setenv("CI", "true")
+		t.Setenv("CI_COMMIT_REF_NAME", "release/2.0")
+		if !CheckoutIsAtRef("release/2.0") {
+			t.Fatal("the job checked out exactly this ref")
+		}
+	})
+	t.Run("differing ref refuses the checkout", func(t *testing.T) {
+		t.Setenv("CI", "true")
+		t.Setenv("CI_COMMIT_REF_NAME", "main")
+		if CheckoutIsAtRef("release/2.0") {
+			t.Fatal("analyzing release/2.0 from a job building main must not read main's tree")
+		}
+	})
+	t.Run("no checked-out ref recorded refuses", func(t *testing.T) {
+		t.Setenv("CI", "true")
+		t.Setenv("CI_COMMIT_REF_NAME", "")
+		if CheckoutIsAtRef("main") {
+			t.Fatal("an absent $CI_COMMIT_REF_NAME cannot confirm the ref")
+		}
+	})
+}

--- a/gitlab/ci_project_test.go
+++ b/gitlab/ci_project_test.go
@@ -1,0 +1,97 @@
+package gitlab
+
+import "testing"
+
+// The re-raised #431 review threads: ProjectFromCIEnvironment substitutes
+// the two project-lookup API calls in platform mode, and its refusal guard
+// is what keeps `plumber analyze --project other/repo` from filing a whole
+// report about the runner's own repository. These tests pin the identity
+// mapping and every refusal branch.
+
+func ciJobEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CI", "true")
+	t.Setenv("CI_PROJECT_PATH", "grp/proj")
+	t.Setenv("CI_PROJECT_ID", "42")
+	t.Setenv("CI_PROJECT_NAME", "proj")
+	t.Setenv("CI_DEFAULT_BRANCH", "main")
+	t.Setenv("CI_COMMIT_SHA", "abc123def")
+	t.Setenv("CI_CONFIG_PATH", "ci/pipeline.yml")
+}
+
+func TestProjectFromCIEnvironment_MapsThePredefinedVariables(t *testing.T) {
+	ciJobEnv(t)
+	p, ok := ProjectFromCIEnvironment("grp/proj", "")
+	if !ok {
+		t.Fatal("a complete CI environment for the analyzed project must be accepted")
+	}
+	if p.IdOnPlatform != 42 || p.Path != "grp/proj" || p.Name != "proj" ||
+		p.DefaultBranch != "main" || p.LatestHeadCommitSha != "abc123def" {
+		t.Fatalf("identity mapping mismatch: %+v", p)
+	}
+	// $CI_COMMIT_SHA is the analyzed commit, NOT the default branch's head
+	// (the API's answer): pinned via LatestHeadCommitSha above.
+	if p.CiConfPath != "ci/pipeline.yml" {
+		t.Fatalf("CiConfPath = %q, want the job's $CI_CONFIG_PATH", p.CiConfPath)
+	}
+}
+
+// The wrong-repository guard: analyzing a DIFFERENT project from inside a CI
+// job must refuse the environment, or branch protections, variables and the
+// CI config of the runner's project would be filed under the other
+// project's name with nothing downstream able to notice.
+func TestProjectFromCIEnvironment_RefusesADifferentAnalyzedProject(t *testing.T) {
+	ciJobEnv(t)
+	if _, ok := ProjectFromCIEnvironment("other/repo", ""); ok {
+		t.Fatal("the environment describes grp/proj; it must not be accepted for other/repo")
+	}
+}
+
+func TestProjectFromCIEnvironment_RefusalBranches(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(t *testing.T)
+	}{
+		{"outside CI", func(t *testing.T) {
+			ciJobEnv(t)
+			t.Setenv("CI", "")
+		}},
+		{"missing project path", func(t *testing.T) {
+			ciJobEnv(t)
+			t.Setenv("CI_PROJECT_PATH", "")
+		}},
+		{"missing commit sha", func(t *testing.T) {
+			ciJobEnv(t)
+			t.Setenv("CI_COMMIT_SHA", "")
+		}},
+		{"non-numeric project id", func(t *testing.T) {
+			ciJobEnv(t)
+			t.Setenv("CI_PROJECT_ID", "not-a-number")
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setup(t)
+			if _, ok := ProjectFromCIEnvironment("grp/proj", ""); ok {
+				t.Fatal("an environment that cannot answer completely must be refused, never a partial identity")
+			}
+		})
+	}
+}
+
+// resolveCIConfigPath precedence: the platform snapshot's value wins (the
+// anchor digest was computed against it), then the job's $CI_CONFIG_PATH,
+// then GitLab's default.
+func TestResolveCIConfigPath_Precedence(t *testing.T) {
+	ciJobEnv(t)
+	if got := resolveCIConfigPath("custom/from-snapshot.yml"); got != "custom/from-snapshot.yml" {
+		t.Fatalf("snapshot value must win, got %q", got)
+	}
+	if got := resolveCIConfigPath(""); got != "ci/pipeline.yml" {
+		t.Fatalf("without a snapshot value the job's $CI_CONFIG_PATH must win, got %q", got)
+	}
+	t.Setenv("CI_CONFIG_PATH", "")
+	if got := resolveCIConfigPath(""); got != ".gitlab-ci.yml" {
+		t.Fatalf("with neither, the GitLab default must apply, got %q", got)
+	}
+}

--- a/gitlab/image_unresolved_test.go
+++ b/gitlab/image_unresolved_test.go
@@ -1,0 +1,31 @@
+package gitlab
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+// parseImageReference's Unresolved flag is what makes the image rules
+// abstain instead of judging a placeholder (re-raised #431 review threads):
+// a reference still holding a $VARIABLE parses into registry/name/tag
+// fields that are present and WRONG, so the flag, not field emptiness, is
+// the only honest signal.
+func TestParseImageReference_SetsUnresolvedOnVariables(t *testing.T) {
+	l := logrus.NewEntry(logrus.New())
+
+	unresolved := &GitlabPipelineImageInfo{Link: "$CI_REGISTRY/app:latest"}
+	unresolved.parseImageReference(l)
+	if !unresolved.Unresolved {
+		t.Fatal("a reference still holding a $VARIABLE must be flagged unresolved")
+	}
+
+	resolved := &GitlabPipelineImageInfo{Link: "registry.example.com/team/app:1.2.3"}
+	resolved.parseImageReference(l)
+	if resolved.Unresolved {
+		t.Fatal("a fully literal reference is resolved")
+	}
+	if resolved.Registry != "registry.example.com" || resolved.Name != "team/app" || resolved.Tag != "1.2.3" {
+		t.Fatalf("literal reference parsed wrong: %+v", resolved)
+	}
+}

--- a/gitlab/utilsCI_replacevariable_test.go
+++ b/gitlab/utilsCI_replacevariable_test.go
@@ -1,0 +1,23 @@
+package gitlab
+
+import "testing"
+
+// TestReplaceVariable_EmptyValueIsNotASubstitution pins the empty-value
+// guard (re-raised #431 review thread): substituting an empty value renders
+// `$PREFIX/semgrep:5` as `/semgrep:5` - a reference that looks resolved,
+// carries no `$` for anyone to notice, and names an image that does not
+// exist. The placeholder must stay so parseImageReference marks the ref
+// unresolved and the image rules abstain.
+func TestReplaceVariable_EmptyValueIsNotASubstitution(t *testing.T) {
+	projectVars := map[string]string{"PREFIX": "", "REG": "registry.example.com"}
+
+	got := ReplaceVariable("$PREFIX/semgrep:5", projectVars, nil, nil, nil, nil, nil)
+	if got != "$PREFIX/semgrep:5" {
+		t.Fatalf("an empty value substituted: got %q, want the placeholder kept", got)
+	}
+
+	got = ReplaceVariable("$REG/app:1", projectVars, nil, nil, nil, nil, nil)
+	if got != "registry.example.com/app:1" {
+		t.Fatalf("a non-empty value must substitute: got %q", got)
+	}
+}

--- a/policies/rules_test.go
+++ b/policies/rules_test.go
@@ -722,6 +722,7 @@ func TestIssue208_InsecureCommands(t *testing.T) {
 //   - A ∧ B  → ISSUE-310 (high): the demonstrable ArtiPACKED leak.
 //   - A ∧ ¬B → ISSUE-307 (low): latent hygiene.
 //   - ¬A     → nothing (credentials disabled).
+//
 // expectedCodes lists the ISSUE codes each fixture must produce.
 func TestIssue307_Artipacked(t *testing.T) {
 	cases := []struct {
@@ -6014,4 +6015,56 @@ func TestIssue402_AmbiguousIncludeIdentifiesOnTheIncludePath(t *testing.T) {
 	assertSubjectKey(t, findings, "ISSUE-402", "includePath",
 		[]string{"gitlab.example.com/components/sast/sast"})
 	assertNoJob(t, findings, "ISSUE-402")
+}
+
+// TestUnresolvedImageGuardAbstains pins the `not job.image.unresolved`
+// guard the image rules gained in platform mode's audit (the re-raised
+// review debate): an image reference that still held a $VARIABLE parses
+// into registry/name/tag fields that are present and WRONG, so ISSUE-101
+// and ISSUE-102 must abstain on it - and the SAME literal reference without
+// the flag must still fire both, which is what keeps the guard from being
+// an evasion route for fully-literal violations.
+func TestUnresolvedImageGuardAbstains(t *testing.T) {
+	engine := opaengine.New()
+	if err := engine.LoadFromFSFiltered(policies.FS, nil); err != nil {
+		t.Fatalf("load embedded policies: %v", err)
+	}
+	cfg := map[string]any{
+		"imageMutableTag":        map[string]any{"forbiddenTags": []string{"latest"}},
+		"imageAuthorizedSources": map[string]any{"trustedUrls": []string{"registry.corp.example/"}},
+	}
+	job := func(unresolved bool) *ir.NormalizedPipeline {
+		return &ir.NormalizedPipeline{
+			Provider: ir.ProviderGitLab,
+			Jobs: []ir.Job{{
+				Name: "deploy",
+				Image: &ir.Image{
+					Registry:   "evil.example.com",
+					Name:       "app",
+					Tag:        "latest",
+					Unresolved: unresolved,
+				},
+			}},
+		}
+	}
+
+	unresolvedFindings, err := engine.Evaluate(context.Background(), job(true), cfg)
+	if err != nil {
+		t.Fatalf("evaluate unresolved: %v", err)
+	}
+	for _, code := range []string{"ISSUE-101", "ISSUE-102"} {
+		if got := countCode(unresolvedFindings, code); got != 0 {
+			t.Errorf("%s fired %d time(s) on an UNRESOLVED reference: the parsed fields describe a placeholder, not an image", code, got)
+		}
+	}
+
+	resolvedFindings, err := engine.Evaluate(context.Background(), job(false), cfg)
+	if err != nil {
+		t.Fatalf("evaluate resolved: %v", err)
+	}
+	for _, code := range []string{"ISSUE-101", "ISSUE-102"} {
+		if got := countCode(resolvedFindings, code); got == 0 {
+			t.Errorf("%s did not fire on the identical RESOLVED violation: the guard must never shield a literal reference", code)
+		}
+	}
 }

--- a/provider/compliance_test.go
+++ b/provider/compliance_test.go
@@ -184,3 +184,35 @@ func TestGitHubProvider_ComputeCompliance(t *testing.T) {
 		}
 	})
 }
+
+// A control marked not_evaluable leaves the compliance ratio entirely: it
+// is neither a pass (its empty findings list proves nothing) nor a fail.
+// Counting it as passed would report 100% on a run that evaluated nothing,
+// the exact false green the status exists to prevent (re-raised #431
+// review thread; the exclusion keys on result.NotEvaluable, not StatusFor,
+// so run-wide degradation signals keep their standalone semantics).
+func TestGitLabProvider_ComputeCompliance_NotEvaluableLeavesTheRatio(t *testing.T) {
+	p := &GitLabProvider{}
+	conf := &configuration.Configuration{PlumberConfig: gitLabPC(t)} // enables 2 controls
+
+	result := &control.AnalysisResult{CiValid: true}
+	result.MarkNotEvaluable("containerImageMustNotUseForbiddenTags", "resolution_unavailable")
+
+	pct, n := p.ComputeCompliance(result, conf)
+	if n != 1 {
+		t.Fatalf("denominator = %d, want 1: the not_evaluable control must leave the ratio", n)
+	}
+	if pct != 100.0 {
+		t.Fatalf("pct = %v, want 100 from the one control that really evaluated", pct)
+	}
+
+	// Both controls unevaluable: nothing evaluated, and the honest answer
+	// is 0 of 0, never 100 of 0.
+	both := &control.AnalysisResult{CiValid: true}
+	both.MarkNotEvaluable("containerImageMustNotUseForbiddenTags", "resolution_unavailable")
+	both.MarkNotEvaluable("branchMustBeProtected", "resolution_unavailable")
+	pct, n = p.ComputeCompliance(both, conf)
+	if pct != 0.0 || n != 0 {
+		t.Fatalf("all not_evaluable: got (%v, %d), want (0, 0)", pct, n)
+	}
+}


### PR DESCRIPTION
The follow-up the #431 review deferred. The claude-review threads re-raised on #431's later heads named real untested guards; none was blocking, all are worth pinning before they regress. Test-only: nine test files touched, zero production changes.

**What each addition forecloses:**

- **`ProjectFromCIEnvironment`** (2 threads): the identity mapping from the predefined variables, every refusal branch (outside CI, missing path/sha, non-numeric id), and the wrong-repository guard: `plumber analyze --project other/repo` from inside a CI job must not file the runner's own project's settings under the other project's name.
- **`resolveCIConfigPath`**: snapshot value over `$CI_CONFIG_PATH` over the GitLab default; the platform's anchor digest can only ever match if both sides hash the same root.
- **`CheckoutIsAtRef`**: all five branches of the guard that keeps a job building `main` from reading `main`'s tree while reporting on `release/2.0`.
- **`ComputeCompliance`**: a `not_evaluable` control leaves the ratio entirely (neither pass nor fail), and an all-unevaluable run reports 0 of 0, never 100 of 0.
- **`MarkFailedCollections`**: an unread protection listing abstains `branchMustBeProtected` and drops its findings (the loudest possible false positive otherwise); a disabled control and a never-run collection are not marked.
- **MR comment**: a `not_evaluable` control renders its own `:grey_question: _not evaluated_` row, never a green check.
- **`parseImageReference` + the rego guard** (3 threads, the High debate): a `$VARIABLE` reference is flagged unresolved and ISSUE-101/ISSUE-102 abstain on it, while the byte-identical literal violation still fires both, proving the guard cannot shield a fully-literal violation.
- **`ReplaceVariable`**: an empty value is not a substitution; the placeholder survives so the image rules abstain rather than judging `/semgrep:5`.
- **`notEvaluableReasonData`**: the machine-readable reason round-trips; unmarked controls and nil results yield nil.
- **`resolveGitLabToken`**: tokenless continues only under `--platform` (the core of #368's tokenless CI); a supplied token always wins; standalone keeps its informative error.

**Consciously deferred** (each Low/Medium and heavier to stage): `setupPlatformMode`'s engaged/error branches, `GetFullGitlabCI`'s platform-mode fetch branches, and the renderers' unresolved-image arithmetic.

**Verified:** full `go test ./...` green, golangci-lint 0 issues, gofmt clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)