### PR TITLE
feat(catalog): export human-readable control names and categories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       - name: deadcode
         run: |
           raw=$(go run golang.org/x/tools/cmd/deadcode@09747cdf594a7924dcecb506312be3bd6e437962 ./...) # v0.30.0
-          out=$(printf '%s\n' "$raw" | grep -v '^finding/identity/' || true)
+          out=$(printf '%s\n' "$raw" | grep -v '^finding/identity/' | grep -v 'unreachable func: ControlsCatalog' || true)
           if [ -n "$out" ]; then echo "$out"; echo "dead code detected"; exit 1; fi
 
   govulncheck:

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ lint:
 deadcode:
 	@set -e; \
 	raw=$$(go run golang.org/x/tools/cmd/deadcode@09747cdf594a7924dcecb506312be3bd6e437962 ./...); \
-	out=$$(printf '%s\n' "$$raw" | grep -v '^finding/identity/' || true); \
+	out=$$(printf '%s\n' "$$raw" | grep -v '^finding/identity/' | grep -v 'unreachable func: ControlsCatalog' || true); \
 	if [ -n "$$out" ]; then echo "$$out"; echo "deadcode: unreachable functions found"; exit 1; fi
 
 # Vulnerability scan. First run mirrors CI (reachability: what our code can

--- a/cmd/legacy_json.go
+++ b/cmd/legacy_json.go
@@ -108,6 +108,13 @@ func legacyResultsByName(result *control.AnalysisResult, pc *configuration.Plumb
 func _withControlMeta(block any, e control.ControlEntry, result *control.AnalysisResult, findingCount int) any {
 	if m, ok := block.(map[string]any); ok {
 		m["controlName"] = e.ControlName
+		// Display metadata next to the stable technical id (#440): the
+		// docs-catalog wording and grouping, so no consumer has to maintain
+		// a technicalName -> human-name map that drifts on every release.
+		if meta, ok := configuration.ControlMetaFor(e.ControlName); ok {
+			m["name"] = meta.DisplayName
+			m["category"] = meta.Category
+		}
 		m["status"] = control.StatusFor(e, result, findingCount)
 		if result != nil && result.ApprovalRulesTierCaveat && isApprovalRuleControl(e.ControlName) {
 			// Structured so a consumer can key on it: the approvals API returned
@@ -398,6 +405,12 @@ func projectFinding(f opaengine.Finding, jobKey string) map[string]any {
 	out := map[string]any{
 		"code":   f.Code,
 		"docUrl": "https://getplumber.io/docs/cli/issues/" + f.Code,
+	}
+	// The issue TYPE's display name (#440), the docs wording from the code
+	// registry, so grouping findings by code needs no hand-made code map.
+	// The technical code above stays the stable key.
+	if info := control.LookupCode(control.ErrorCode(f.Code)); info != nil && info.Title != "" {
+		out["title"] = info.Title
 	}
 	if f.Job != "" && jobKey != "" {
 		out[jobKey] = f.Job

--- a/cmd/platform_push.go
+++ b/cmd/platform_push.go
@@ -147,6 +147,25 @@ type platformFinding struct {
 	Requirement string          `json:"requirement,omitempty"`
 	Status      string          `json:"status"`
 	Data        json.RawMessage `json:"data,omitempty"`
+
+	// Name and Category are the control's display metadata (#440), the
+	// docs-catalog wording next to the stable technical id in Control.
+	// Additive: the platform ignores unknown fields, and consumers that
+	// keyed on Control keep working unchanged.
+	Name     string `json:"name,omitempty"`
+	Category string `json:"category,omitempty"`
+}
+
+// decoratedPlatformFinding builds a push finding entry with the control's
+// display metadata attached (#440), so every construction site stays in
+// step with the exported catalog.
+func decoratedPlatformFinding(controlName, status string, data json.RawMessage) platformFinding {
+	f := platformFinding{Control: controlName, Status: status, Data: data}
+	if meta, ok := configuration.ControlMetaFor(controlName); ok {
+		f.Name = meta.DisplayName
+		f.Category = meta.Category
+	}
+	return f
 }
 
 // Finding-status vocabulary the platform's contract defines.
@@ -395,20 +414,12 @@ func platformFindingsFor(p providerPkg.Provider, result *control.AnalysisResult,
 			continue
 		case control.StatusFailed:
 			for _, f := range fs {
-				out = append(out, platformFinding{
-					Control: platformFindingControlName(f),
-					Status:  platformStatusFail,
-					Data:    platformFindingDataRaw(f),
-				})
+				out = append(out, decoratedPlatformFinding(platformFindingControlName(f), platformStatusFail, platformFindingDataRaw(f)))
 			}
 		case control.StatusError:
-			out = append(out, platformFinding{
-				Control: e.ControlName,
-				Status:  platformStatusNotEvaluable,
-				Data:    notEvaluableReasonData(result, e.ControlName),
-			})
+			out = append(out, decoratedPlatformFinding(e.ControlName, platformStatusNotEvaluable, notEvaluableReasonData(result, e.ControlName)))
 		default: // control.StatusPassed
-			out = append(out, platformFinding{Control: e.ControlName, Status: platformStatusPass})
+			out = append(out, decoratedPlatformFinding(e.ControlName, platformStatusPass, nil))
 		}
 	}
 	return out

--- a/cmd/platform_push_test.go
+++ b/cmd/platform_push_test.go
@@ -1089,3 +1089,46 @@ func TestResolveGitLabToken_PlatformModeBypass(t *testing.T) {
 		t.Fatalf("a supplied token must always win: got (%q, %v)", token, err)
 	}
 }
+
+// The report's control blocks and issue rows carry display metadata next
+// to their technical ids (#440): name + category per control, title per
+// issue code, all sourced from the exported tables so no consumer keeps a
+// hand map.
+func TestReportCarriesDisplayMetadata(t *testing.T) {
+	entry := control.ControlEntry{ControlName: "branchMustBeProtected"}
+	block := _withControlMeta(map[string]any{}, entry, &control.AnalysisResult{CiValid: true}, 0)
+	m := block.(map[string]any)
+	if m["controlName"] != "branchMustBeProtected" {
+		t.Fatalf("technical id must stay: %v", m)
+	}
+	if m["name"] != "Branch must be protected" {
+		t.Errorf("display name missing or wrong: %v", m["name"])
+	}
+	if m["category"] != configuration.CategoryAccessAndAuthorization {
+		t.Errorf("category missing or wrong: %v", m["category"])
+	}
+
+	issue := projectFinding(opaengine.Finding{Code: "ISSUE-501", Message: "x"}, "job")
+	if issue["code"] != "ISSUE-501" {
+		t.Fatalf("technical code must stay: %v", issue)
+	}
+	title, _ := issue["title"].(string)
+	if title == "" {
+		t.Errorf("issue title missing: %v", issue)
+	}
+}
+
+// The push findings carry the same display metadata additively (#440): the
+// platform and any consumer of the raw artifact see the docs wording next
+// to the stable technical control name.
+func TestPlatformFindingsCarryDisplayMetadata(t *testing.T) {
+	f := decoratedPlatformFinding("branchMustBeProtected", platformStatusPass, nil)
+	if f.Control != "branchMustBeProtected" || f.Name != "Branch must be protected" ||
+		f.Category != configuration.CategoryAccessAndAuthorization {
+		t.Fatalf("decorated finding mismatch: %+v", f)
+	}
+	unknown := decoratedPlatformFinding("noSuchControl", platformStatusPass, nil)
+	if unknown.Name != "" || unknown.Category != "" {
+		t.Fatalf("an unknown control must not invent metadata: %+v", unknown)
+	}
+}

--- a/cmd/platform_push_test.go
+++ b/cmd/platform_push_test.go
@@ -446,6 +446,26 @@ func TestMaybePushPlatform_FindingsCoverPassFailAndNotEvaluable(t *testing.T) {
 	if !ok || pass.Status != platformStatusPass || len(pass.Data) != 0 {
 		t.Errorf("pipelineMustNotEnableDebugTrace = %+v (present=%v), want status=pass with no data", pass, ok)
 	}
+
+	// Every branch carries the display metadata (#440), asserted on the
+	// DECODED BODY so the real platformFindingsFor wiring is what is
+	// pinned, not the helper in isolation. The fail branch matters most:
+	// it resolves its control name through LookupCode(f.Code) rather than
+	// e.ControlName, so its metadata lookup goes through a distinct path.
+	for name, f := range map[string]platformFinding{
+		"containerImageMustComeFromAuthorizedSources": fail,
+		"branchMustBeProtected":                       notEval,
+		"pipelineMustNotEnableDebugTrace":             pass,
+	} {
+		meta, ok := configuration.ControlMetaFor(name)
+		if !ok {
+			t.Fatalf("%s: no exported catalog row", name)
+		}
+		if f.Name != meta.DisplayName || f.Category != meta.Category {
+			t.Errorf("%s: pushed (name=%q, category=%q), want (%q, %q) from the exported catalog",
+				name, f.Name, f.Category, meta.DisplayName, meta.Category)
+		}
+	}
 }
 
 // A control excluded via --skip-controls (the same e.Skipped flag a control

--- a/configuration/catalog_export_test.go
+++ b/configuration/catalog_export_test.go
@@ -1,0 +1,46 @@
+package configuration
+
+import "testing"
+
+// The exported control catalog (#440) is the single source for display
+// metadata: every control the engine knows about must carry a non-empty
+// docs-catalog name and one of the closed category set, or a consumer
+// falls back to the raw camelCase identifier - the exact drift this table
+// exists to end.
+func TestControlsCatalogIsComplete(t *testing.T) {
+	valid := map[string]bool{
+		CategoryContainerImages: true, CategoryCICDVariables: true,
+		CategoryCICDSecrets: true, CategoryPipelineComposition: true,
+		CategoryAccessAndAuthorization: true, CategorySecuritySource: true,
+		CategoryThirdPartyActions: true, CategoryWorkflowTriggersAndPermissions: true,
+		CategoryRepositoryHygiene: true,
+	}
+	cat := ControlsCatalog()
+	if len(cat) != len(controlsMeta) {
+		t.Fatalf("catalog has %d entries, registry %d", len(cat), len(controlsMeta))
+	}
+	for _, e := range cat {
+		if e.DisplayName == "" {
+			t.Errorf("%s: empty DisplayName", e.Name)
+		}
+		if !valid[e.Category] {
+			t.Errorf("%s: category %q is not one of the docs-catalog headings", e.Name, e.Category)
+		}
+		if len(e.Providers) == 0 {
+			t.Errorf("%s: no providers", e.Name)
+		}
+	}
+	// Sorted, and consistent with the single-name accessor.
+	for i := 1; i < len(cat); i++ {
+		if cat[i-1].Name >= cat[i].Name {
+			t.Fatalf("catalog not sorted at %q", cat[i].Name)
+		}
+	}
+	meta, ok := ControlMetaFor("branchMustBeProtected")
+	if !ok || meta.DisplayName != "Branch must be protected" || meta.Category != CategoryAccessAndAuthorization {
+		t.Fatalf("ControlMetaFor(branchMustBeProtected) = (%+v, %v)", meta, ok)
+	}
+	if _, ok := ControlMetaFor("noSuchControl"); ok {
+		t.Fatal("an unknown control must not resolve")
+	}
+}

--- a/configuration/registry.go
+++ b/configuration/registry.go
@@ -1,5 +1,7 @@
 package configuration
 
+import "sort"
+
 // ControlMeta describes a control's static properties: which providers
 // it applies to and whether it is currently considered production-
 // ready (i.e. NOT benched). Toggle semantics for individual users
@@ -10,6 +12,17 @@ type ControlMeta struct {
 	// "gitlab", "github", or both. Used by ValidateKnownKeys to warn
 	// when a control is placed under the wrong provider section.
 	Providers []string
+
+	// DisplayName is the human-readable control name, the docs catalog
+	// wording (#440). Display only: the technical control name stays the
+	// stable key everywhere.
+	DisplayName string
+
+	// Category is the docs catalog grouping this control belongs to, one
+	// of the Category* constants below. It follows the control's issue-code
+	// block (1xx container images, 2xx variables, ... 9xx repository
+	// hygiene), which TestControlCategoriesFollowTheCodeBlocks pins.
+	Category string
 }
 
 // providerGitLab and providerGitHub are exported as constants so call
@@ -17,6 +30,21 @@ type ControlMeta struct {
 const (
 	ProviderGitLab = "gitlab"
 	ProviderGitHub = "github"
+)
+
+// The docs catalog categories (https://getplumber.io/docs/cli/controls),
+// verbatim, plus one heading for the benched 9xx repository-hygiene block
+// the site does not document yet. Every control belongs to exactly one.
+const (
+	CategoryContainerImages                = "CI/CD Container Images"
+	CategoryCICDVariables                  = "CI/CD Variables"
+	CategoryCICDSecrets                    = "CI/CD Secrets"
+	CategoryPipelineComposition            = "Pipeline Composition"
+	CategoryAccessAndAuthorization         = "Access and Authorization"
+	CategorySecuritySource                 = "Security Source"
+	CategoryThirdPartyActions              = "Third-party Actions"
+	CategoryWorkflowTriggersAndPermissions = "Workflow Triggers and Permissions"
+	CategoryRepositoryHygiene              = "Repository Hygiene"
 )
 
 // controlsMeta is the canonical registry of every control name the
@@ -30,74 +58,338 @@ const (
 // GitHub-only control gets {ProviderGitHub}.
 var controlsMeta = map[string]ControlMeta{
 	// Cross-provider (same control name + rego logic, provider-specific values).
-	"branchMustBeProtected":                                  {Providers: []string{ProviderGitLab, ProviderGitHub}},
-	"mergeRequestApprovalRulesMustRequireMinimumApprovals":   {Providers: []string{ProviderGitLab}},
-	"mergeRequestApprovalRulesMustCoverAllProtectedBranches": {Providers: []string{ProviderGitLab}},
-	"mergeRequestApprovalSettingsMustBeCompliant":            {Providers: []string{ProviderGitLab}},
-	"mergeRequestSettingsMustBeCompliant":                    {Providers: []string{ProviderGitLab}},
-	"cicdVariablesMustBeProtected":                           {Providers: []string{ProviderGitLab}},
-	"cicdVariablesMustBeMasked":                              {Providers: []string{ProviderGitLab}},
-	"projectMustHaveSecurityPolicySource":                    {Providers: []string{ProviderGitLab}},
-	"containerImageMustComeFromAuthorizedSources":            {Providers: []string{ProviderGitLab, ProviderGitHub}},
-	"containerImageMustNotUseForbiddenTags":                  {Providers: []string{ProviderGitLab, ProviderGitHub}},
-	"externalRefsMustNotCollide":                             {Providers: []string{ProviderGitLab, ProviderGitHub}},
-	"includesMustBeUpToDate":                                 {Providers: []string{ProviderGitLab, ProviderGitHub}},
-	"includesMustNotUseForbiddenVersions":                    {Providers: []string{ProviderGitLab, ProviderGitHub}},
-	"pipelineMustIncludeComponent":                           {Providers: []string{ProviderGitLab, ProviderGitHub}},
-	"pipelineMustIncludeTemplate":                            {Providers: []string{ProviderGitLab, ProviderGitHub}},
-	"pipelineMustNotEnableDebugTrace":                        {Providers: []string{ProviderGitLab, ProviderGitHub}},
-	"pipelineMustNotExecuteUnverifiedScripts":                {Providers: []string{ProviderGitLab, ProviderGitHub}},
-	"pipelineMustNotIncludeHardcodedJobs":                    {Providers: []string{ProviderGitLab, ProviderGitHub}},
-	"pipelineMustNotOverrideJobVariables":                    {Providers: []string{ProviderGitLab, ProviderGitHub}},
-	"pipelineMustNotUseDockerInDocker":                       {Providers: []string{ProviderGitLab, ProviderGitHub}},
-	"pipelineMustNotUseUnsafeVariableExpansion":              {Providers: []string{ProviderGitLab, ProviderGitHub}},
-	"securityJobsMustNotBeWeakened":                          {Providers: []string{ProviderGitLab, ProviderGitHub}},
+	"branchMustBeProtected": {
+		Providers:   []string{ProviderGitLab, ProviderGitHub},
+		DisplayName: "Branch must be protected",
+		Category:    CategoryAccessAndAuthorization,
+	},
+	"mergeRequestApprovalRulesMustRequireMinimumApprovals": {
+		Providers:   []string{ProviderGitLab},
+		DisplayName: "MR approval rules must require a minimum number of approvals",
+		Category:    CategoryAccessAndAuthorization,
+	},
+	"mergeRequestApprovalRulesMustCoverAllProtectedBranches": {
+		Providers:   []string{ProviderGitLab},
+		DisplayName: "MR approval rules must cover all protected branches",
+		Category:    CategoryAccessAndAuthorization,
+	},
+	"mergeRequestApprovalSettingsMustBeCompliant": {
+		Providers:   []string{ProviderGitLab},
+		DisplayName: "MR approval settings must be compliant",
+		Category:    CategoryAccessAndAuthorization,
+	},
+	"mergeRequestSettingsMustBeCompliant": {
+		Providers:   []string{ProviderGitLab},
+		DisplayName: "MR settings must be compliant",
+		Category:    CategoryAccessAndAuthorization,
+	},
+	"cicdVariablesMustBeProtected": {
+		Providers:   []string{ProviderGitLab},
+		DisplayName: "CI/CD variables must be protected",
+		Category:    CategoryCICDVariables,
+	},
+	"cicdVariablesMustBeMasked": {
+		Providers:   []string{ProviderGitLab},
+		DisplayName: "CI/CD variables must be masked",
+		Category:    CategoryCICDVariables,
+	},
+	"projectMustHaveSecurityPolicySource": {
+		Providers:   []string{ProviderGitLab},
+		DisplayName: "Project must have a security policy source",
+		Category:    CategorySecuritySource,
+	},
+	"containerImageMustComeFromAuthorizedSources": {
+		Providers:   []string{ProviderGitLab, ProviderGitHub},
+		DisplayName: "Container images must come from authorized sources",
+		Category:    CategoryContainerImages,
+	},
+	"containerImageMustNotUseForbiddenTags": {
+		Providers:   []string{ProviderGitLab, ProviderGitHub},
+		DisplayName: "Container images must not use forbidden tags",
+		Category:    CategoryContainerImages,
+	},
+	"externalRefsMustNotCollide": {
+		Providers:   []string{ProviderGitLab, ProviderGitHub},
+		DisplayName: "Includes must not use ambiguous tag/branch refs",
+		Category:    CategoryPipelineComposition,
+	},
+	"includesMustBeUpToDate": {
+		Providers:   []string{ProviderGitLab, ProviderGitHub},
+		DisplayName: "Includes must be up to date",
+		Category:    CategoryPipelineComposition,
+	},
+	"includesMustNotUseForbiddenVersions": {
+		Providers:   []string{ProviderGitLab, ProviderGitHub},
+		DisplayName: "Includes must not use forbidden versions",
+		Category:    CategoryPipelineComposition,
+	},
+	"pipelineMustIncludeComponent": {
+		Providers:   []string{ProviderGitLab, ProviderGitHub},
+		DisplayName: "Pipeline must include required components",
+		Category:    CategoryPipelineComposition,
+	},
+	"pipelineMustIncludeTemplate": {
+		Providers:   []string{ProviderGitLab, ProviderGitHub},
+		DisplayName: "Pipeline must include required templates",
+		Category:    CategoryPipelineComposition,
+	},
+	"pipelineMustNotEnableDebugTrace": {
+		Providers:   []string{ProviderGitLab, ProviderGitHub},
+		DisplayName: "Pipeline must not enable debug trace",
+		Category:    CategoryCICDVariables,
+	},
+	"pipelineMustNotExecuteUnverifiedScripts": {
+		Providers:   []string{ProviderGitLab, ProviderGitHub},
+		DisplayName: "Pipeline must not execute unverified scripts",
+		Category:    CategoryPipelineComposition,
+	},
+	"pipelineMustNotIncludeHardcodedJobs": {
+		Providers:   []string{ProviderGitLab, ProviderGitHub},
+		DisplayName: "Pipeline must not include hardcoded jobs",
+		Category:    CategoryPipelineComposition,
+	},
+	"pipelineMustNotOverrideJobVariables": {
+		Providers:   []string{ProviderGitLab, ProviderGitHub},
+		DisplayName: "Pipeline must not override job variables",
+		Category:    CategoryCICDVariables,
+	},
+	"pipelineMustNotUseDockerInDocker": {
+		Providers:   []string{ProviderGitLab, ProviderGitHub},
+		DisplayName: "Pipeline must not use Docker-in-Docker",
+		Category:    CategoryPipelineComposition,
+	},
+	"pipelineMustNotUseUnsafeVariableExpansion": {
+		Providers:   []string{ProviderGitLab, ProviderGitHub},
+		DisplayName: "Pipeline must not use unsafe variable expansion",
+		Category:    CategoryCICDVariables,
+	},
+	"securityJobsMustNotBeWeakened": {
+		Providers:   []string{ProviderGitLab, ProviderGitHub},
+		DisplayName: "Security jobs must not be weakened",
+		Category:    CategoryPipelineComposition,
+	},
 
 	// GitHub-only.
-	"actionPinCommentsMustMatchSha":                       {Providers: []string{ProviderGitHub}},
-	"actionPinsMustNotBeStale":                            {Providers: []string{ProviderGitHub}},
-	"actionRefsMustExistUpstream":                         {Providers: []string{ProviderGitHub}},
-	"actionsMustBePinnedByCommitSha":                      {Providers: []string{ProviderGitHub}},
-	"actionsMustNotBeArchived":                            {Providers: []string{ProviderGitHub}},
-	"actionsMustNotCarryKnownCVEs":                        {Providers: []string{ProviderGitHub}},
-	"actionsMustNotDuplicateRunnerBuiltins":               {Providers: []string{ProviderGitHub}},
-	"actionsMustNotExecuteMutableRemoteCode":              {Providers: []string{ProviderGitHub}},
-	"checkoutMustNotPersistCredentials":                   {Providers: []string{ProviderGitHub}},
-	"containerCredentialsMustComeFromSecrets":             {Providers: []string{ProviderGitHub}},
-	"dependabotEcosystemsMustHaveCooldown":                {Providers: []string{ProviderGitHub}},
-	"dependabotMustNotAllowInsecureExternalCodeExecution": {Providers: []string{ProviderGitHub}},
-	"deployJobsMustUseEnvironmentGate":                    {Providers: []string{ProviderGitHub}},
-	"dockerfilesMustPinBaseImageByDigest":                 {Providers: []string{ProviderGitHub}},
-	"githubActionMustComeFromAuthorizedSources":           {Providers: []string{ProviderGitHub}},
-	"githubAppTokensMustBeRevokedOnExit":                  {Providers: []string{ProviderGitHub}},
-	"publishWorkflowsMustUseOidcTrustedPublishing":        {Providers: []string{ProviderGitHub}},
-	"pullRequestTargetMustNotCheckoutHead":                {Providers: []string{ProviderGitHub}},
-	"releaseWorkflowsMustNotRestoreUntrustedCache":        {Providers: []string{ProviderGitHub}},
-	"releaseWorkflowsMustSignArtefacts":                   {Providers: []string{ProviderGitHub}},
-	"repositoriesMustConfigureDependencyUpdates":          {Providers: []string{ProviderGitHub}},
-	"repositoriesMustPublishSecurityPolicy":               {Providers: []string{ProviderGitHub}},
-	"repositoriesMustRunSAST":                             {Providers: []string{ProviderGitHub}},
-	"reusableWorkflowsMustNotInheritSecrets":              {Providers: []string{ProviderGitHub}},
-	"workflowConditionsMustBeSound":                       {Providers: []string{ProviderGitHub}},
-	"workflowContainsCallsMustBeSound":                    {Providers: []string{ProviderGitHub}},
-	"workflowMustNotContainObfuscation":                   {Providers: []string{ProviderGitHub}},
-	"workflowMustNotExportEntireGitHubContext":            {Providers: []string{ProviderGitHub}},
-	"workflowMustNotExportEntireSecretsContext":           {Providers: []string{ProviderGitHub}},
-	"workflowMustNotGrantPermissionsWriteAll":             {Providers: []string{ProviderGitHub}},
-	"workflowMustNotIndexSecretsDynamically":              {Providers: []string{ProviderGitHub}},
-	"workflowMustNotInjectUserInputInScripts":             {Providers: []string{ProviderGitHub}},
-	"workflowMustNotInjectVarsInScripts":                  {Providers: []string{ProviderGitHub}},
-	"workflowMustNotReEnableInsecureCommands":             {Providers: []string{ProviderGitHub}},
-	"workflowMustNotTrustSpoofableActorChecks":            {Providers: []string{ProviderGitHub}},
-	"workflowMustNotUnredactSecretsViaFromJSON":           {Providers: []string{ProviderGitHub}},
-	"workflowMustNotUseDangerousTriggers":                 {Providers: []string{ProviderGitHub}},
-	"workflowMustNotUseKnownMisfeatures":                  {Providers: []string{ProviderGitHub}},
-	"workflowMustNotWriteUntrustedContentToGitHubEnv":     {Providers: []string{ProviderGitHub}},
-	"workflowMustIncludeRequiredActions":                  {Providers: []string{ProviderGitHub}},
-	"workflowMustPinPackageInstalls":                      {Providers: []string{ProviderGitHub}},
-	"workflowsMustDeclareConcurrency":                     {Providers: []string{ProviderGitHub}},
-	"workflowsMustDeclarePermissions":                     {Providers: []string{ProviderGitHub}},
-	"workflowsMustHaveExplicitName":                       {Providers: []string{ProviderGitHub}},
+	"actionPinCommentsMustMatchSha": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Action pin comments must match the pinned SHA",
+		Category:    CategoryThirdPartyActions,
+	},
+	"actionPinsMustNotBeStale": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Action pins must not be stale",
+		Category:    CategoryThirdPartyActions,
+	},
+	"actionRefsMustExistUpstream": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Actions must pin commits that exist upstream",
+		Category:    CategoryThirdPartyActions,
+	},
+	"actionsMustBePinnedByCommitSha": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Third-party actions must be pinned by commit SHA",
+		Category:    CategoryThirdPartyActions,
+	},
+	"actionsMustNotBeArchived": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Actions must not reference archived repositories",
+		Category:    CategoryThirdPartyActions,
+	},
+	"actionsMustNotCarryKnownCVEs": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Actions must not carry known CVEs",
+		Category:    CategoryThirdPartyActions,
+	},
+	"actionsMustNotDuplicateRunnerBuiltins": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Actions must not duplicate runner builtins",
+		Category:    CategoryThirdPartyActions,
+	},
+	"actionsMustNotExecuteMutableRemoteCode": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Actions must not execute mutable remote code",
+		Category:    CategoryThirdPartyActions,
+	},
+	"checkoutMustNotPersistCredentials": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Checkout must not persist credentials",
+		Category:    CategoryCICDSecrets,
+	},
+	"containerCredentialsMustComeFromSecrets": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Container credentials must come from secrets",
+		Category:    CategoryThirdPartyActions,
+	},
+	"dependabotEcosystemsMustHaveCooldown": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Dependabot ecosystems must have a cooldown",
+		Category:    CategoryRepositoryHygiene,
+	},
+	"dependabotMustNotAllowInsecureExternalCodeExecution": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Dependabot must not allow insecure external code execution",
+		Category:    CategoryRepositoryHygiene,
+	},
+	"deployJobsMustUseEnvironmentGate": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Deploy jobs must use an environment gate",
+		Category:    CategoryCICDSecrets,
+	},
+	"dockerfilesMustPinBaseImageByDigest": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Dockerfiles must pin base images by digest",
+		Category:    CategoryThirdPartyActions,
+	},
+	"githubActionMustComeFromAuthorizedSources": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Actions must come from authorized sources",
+		Category:    CategoryThirdPartyActions,
+	},
+	"githubAppTokensMustBeRevokedOnExit": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "GitHub App tokens must be revoked on exit",
+		Category:    CategoryCICDSecrets,
+	},
+	"publishWorkflowsMustUseOidcTrustedPublishing": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Publish workflows must use OIDC trusted publishing",
+		Category:    CategoryPipelineComposition,
+	},
+	"pullRequestTargetMustNotCheckoutHead": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "pull_request_target workflows must not check out the PR head",
+		Category:    CategoryWorkflowTriggersAndPermissions,
+	},
+	"releaseWorkflowsMustNotRestoreUntrustedCache": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Release workflows must not restore an untrusted cache",
+		Category:    CategoryThirdPartyActions,
+	},
+	"releaseWorkflowsMustSignArtefacts": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Release workflows must sign artefacts",
+		Category:    CategoryThirdPartyActions,
+	},
+	"repositoriesMustConfigureDependencyUpdates": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Repositories must configure dependency updates",
+		Category:    CategoryRepositoryHygiene,
+	},
+	"repositoriesMustPublishSecurityPolicy": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Repositories must publish a security policy",
+		Category:    CategoryRepositoryHygiene,
+	},
+	"repositoriesMustRunSAST": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Repositories must run SAST",
+		Category:    CategoryRepositoryHygiene,
+	},
+	"reusableWorkflowsMustNotInheritSecrets": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Reusable workflows must not inherit secrets",
+		Category:    CategoryCICDSecrets,
+	},
+	"workflowConditionsMustBeSound": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflow conditions must be sound",
+		Category:    CategoryCICDVariables,
+	},
+	"workflowContainsCallsMustBeSound": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflow contains() calls must be sound",
+		Category:    CategoryCICDVariables,
+	},
+	"workflowMustNotContainObfuscation": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must not contain obfuscation",
+		Category:    CategoryPipelineComposition,
+	},
+	"workflowMustNotExportEntireGitHubContext": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must not export the entire GitHub context",
+		Category:    CategoryCICDVariables,
+	},
+	"workflowMustNotExportEntireSecretsContext": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must not expose all secrets at once",
+		Category:    CategoryCICDSecrets,
+	},
+	"workflowMustNotGrantPermissionsWriteAll": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflow must not grant write-all permissions",
+		Category:    CategoryWorkflowTriggersAndPermissions,
+	},
+	"workflowMustNotIndexSecretsDynamically": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must not index secrets dynamically",
+		Category:    CategoryCICDSecrets,
+	},
+	"workflowMustNotInjectUserInputInScripts": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must not inject user input in scripts",
+		Category:    CategoryCICDVariables,
+	},
+	"workflowMustNotInjectVarsInScripts": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must not inject vars in scripts",
+		Category:    CategoryCICDVariables,
+	},
+	"workflowMustNotReEnableInsecureCommands": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must not re-enable insecure commands",
+		Category:    CategoryCICDVariables,
+	},
+	"workflowMustNotTrustSpoofableActorChecks": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must not trust spoofable actor checks",
+		Category:    CategoryCICDVariables,
+	},
+	"workflowMustNotUnredactSecretsViaFromJSON": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must not unredact secrets via fromJSON",
+		Category:    CategoryCICDSecrets,
+	},
+	"workflowMustNotUseDangerousTriggers": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must not use dangerous triggers",
+		Category:    CategoryWorkflowTriggersAndPermissions,
+	},
+	"workflowMustNotUseKnownMisfeatures": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must not use known misfeatures",
+		Category:    CategoryPipelineComposition,
+	},
+	"workflowMustNotWriteUntrustedContentToGitHubEnv": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must not write untrusted content to $GITHUB_ENV",
+		Category:    CategoryCICDVariables,
+	},
+	"workflowMustIncludeRequiredActions": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must include required actions",
+		Category:    CategoryPipelineComposition,
+	},
+	"workflowMustPinPackageInstalls": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must pin package installs",
+		Category:    CategoryCICDVariables,
+	},
+	"workflowsMustDeclareConcurrency": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must declare concurrency",
+		Category:    CategoryPipelineComposition,
+	},
+	"workflowsMustDeclarePermissions": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must declare permissions",
+		Category:    CategoryWorkflowTriggersAndPermissions,
+	},
+	"workflowsMustHaveExplicitName": {
+		Providers:   []string{ProviderGitHub},
+		DisplayName: "Workflows must have an explicit name",
+		Category:    CategoryPipelineComposition,
+	},
 }
 
 // removedControls maps control names that shipped in earlier releases
@@ -261,4 +553,38 @@ func IsControlApplicableTo(controlName, provider string) bool {
 		}
 	}
 	return false
+}
+
+// ControlCatalogEntry is one row of the exported control catalog: the
+// stable technical name plus its display metadata (#440).
+type ControlCatalogEntry struct {
+	// Name is the technical control name, the stable key used in
+	// .plumber.yaml, reports and the score push.
+	Name string
+	ControlMeta
+}
+
+// ControlsCatalog returns every control the engine knows about with its
+// display metadata, sorted by technical name. The slice and its entries are
+// copies: mutating them cannot corrupt the registry.
+func ControlsCatalog() []ControlCatalogEntry {
+	out := make([]ControlCatalogEntry, 0, len(controlsMeta))
+	for name, meta := range controlsMeta {
+		m := meta
+		m.Providers = append([]string(nil), meta.Providers...)
+		out = append(out, ControlCatalogEntry{Name: name, ControlMeta: m})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// ControlMetaFor returns the display metadata for one technical control
+// name, and whether the control is known at all.
+func ControlMetaFor(name string) (ControlMeta, bool) {
+	meta, ok := controlsMeta[name]
+	if !ok {
+		return ControlMeta{}, false
+	}
+	meta.Providers = append([]string(nil), meta.Providers...)
+	return meta, true
 }

--- a/control/catalog_export_test.go
+++ b/control/catalog_export_test.go
@@ -1,0 +1,86 @@
+package control
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+)
+
+// The site's catalog (https://getplumber.io/docs/cli/controls) groups
+// controls by their issue-code block, so a control's Category must follow
+// the block its registered codes live in. Pinning the derivation keeps a
+// new control from landing in the wrong docs grouping silently (#440).
+func TestControlCategoriesFollowTheCodeBlocks(t *testing.T) {
+	blockCategory := map[byte]string{
+		'1': configuration.CategoryContainerImages,
+		'2': configuration.CategoryCICDVariables,
+		'3': configuration.CategoryCICDSecrets,
+		'4': configuration.CategoryPipelineComposition,
+		'5': configuration.CategoryAccessAndAuthorization,
+		'6': configuration.CategorySecuritySource,
+		'7': configuration.CategoryThirdPartyActions,
+		'8': configuration.CategoryWorkflowTriggersAndPermissions,
+		'9': configuration.CategoryRepositoryHygiene,
+	}
+	for _, entry := range configuration.ControlsCatalog() {
+		codes := CodesForControl(entry.Name)
+		if len(codes) == 0 {
+			continue
+		}
+		blocks := map[byte]bool{}
+		for _, c := range codes {
+			blocks[strings.TrimPrefix(string(c), "ISSUE-")[0]] = true
+		}
+		if len(blocks) != 1 {
+			t.Errorf("%s: codes span more than one block (%v); the category derivation assumes one", entry.Name, codes)
+			continue
+		}
+		for b := range blocks {
+			if want := blockCategory[b]; entry.Category != want {
+				t.Errorf("%s: category %q, want %q (its codes live in the %cxx block)", entry.Name, entry.Category, want, b)
+			}
+		}
+	}
+}
+
+// The catalog's terminal display names and the exported table must agree:
+// the table is what reports and embedders see, the ControlEntry name is
+// what the terminal prints, and the two describing one control differently
+// would be exactly the drift #440 exists to end.
+//
+// Two tolerated divergences, each deliberate: the forbidden-tags entry
+// computes its terminal name per run from the configured tags, and a
+// cross-provider control may word its terminal name per provider
+// ("Pipeline must not ..." on GitLab, "Workflows must not ..." on GitHub)
+// while the exported table carries ONE canonical name - which must then be
+// one of the observed wordings, never a third.
+func TestCatalogDisplayNamesMatchTheExportedTable(t *testing.T) {
+	pc := &configuration.PlumberConfig{}
+	glEntries := GitLabControls(pc)
+	ghEntries := GitHubControls(pc)
+	if len(glEntries) == 0 || len(ghEntries) == 0 {
+		t.Fatalf("catalog built no entries (gitlab %d, github %d); the comparison would be vacuous", len(glEntries), len(ghEntries))
+	}
+	dynamic := map[string]bool{"containerImageMustNotUseForbiddenTags": true}
+	observed := map[string]map[string]bool{}
+	for _, e := range append(append([]ControlEntry{}, glEntries...), ghEntries...) {
+		if _, ok := configuration.ControlMetaFor(e.ControlName); !ok {
+			t.Errorf("%s: catalog entry has no exported table row", e.ControlName)
+			continue
+		}
+		if observed[e.ControlName] == nil {
+			observed[e.ControlName] = map[string]bool{}
+		}
+		observed[e.ControlName][e.DisplayName] = true
+	}
+	for name, wordings := range observed {
+		if dynamic[name] {
+			continue
+		}
+		meta, _ := configuration.ControlMetaFor(name)
+		if !wordings[meta.DisplayName] {
+			t.Errorf("%s: exported name %q matches none of the terminal wordings %v", name, meta.DisplayName, wordings)
+		}
+	}
+}


### PR DESCRIPTION
Closes #440.

Every surface identified controls and issue types only by their technical name, so every consumer hand-built a `technicalName -> "Branch must be protected"` map that silently drifted on each release. The display metadata now ships with the results, from one exported table. **Technical ids stay the stable keys everywhere; the new fields are additive and display-only** (per Thomas's ruling on the issue).

**The exported table** (`configuration`):
- `ControlMeta` gains `DisplayName` and `Category`, filled for all 66 controls.
- Categories are the docs catalog's own headings ([getplumber.io/docs/cli/controls](https://getplumber.io/docs/cli/controls)), verbatim: `CI/CD Container Images`, `CI/CD Variables`, `CI/CD Secrets`, `Pipeline Composition`, `Access and Authorization`, `Security Source`, `Third-party Actions`, `Workflow Triggers and Permissions`. Each control's category follows its issue-code block (1xx images ... 8xx triggers), pinned by `TestControlCategoriesFollowTheCodeBlocks`. One addition the site does not document yet: `Repository Hygiene` for the benched 9xx block (rename the one constant if the site later chooses another heading).
- New embedder accessors: `configuration.ControlsCatalog()` (sorted, defensively copied, includes the per-control provider applicability that was previously unexported) and `configuration.ControlMetaFor(name)`. Issue-type display names were already programmatically reachable via `control.LookupCode(...).Title`; the outputs now carry them too.

**Outputs**, verified e2e on real runs against the mock GitLab/platform:
- `plumber-report.json` control blocks: `{"controlName": "cicdVariablesMustBeProtected", "name": "CI/CD variables must be protected", "category": "CI/CD Variables", ...}`.
- Issue rows: `{"code": "ISSUE-201", "title": "CI/CD settings variable is not protected", ...}` next to the existing `docUrl`.
- Platform push findings: `{"control": "...", "name": "...", "category": "..."}`, additive (the platform ignores unknown fields).
- PBOM/CycloneDX name no controls today (their compliance sections key on issue codes as booleans), so there is nothing to decorate there; the day one grows a control listing, `ControlMetaFor` is the source.

**Guards:** completeness test (every control has a non-empty name and a closed-set category), the code-block derivation test, and a drift test pinning that a control's exported name matches its terminal catalog wording (the per-run computed forbidden-tags name and the per-provider Pipeline-vs-Workflows wordings are the two documented tolerances, and the test fails loudly if the catalogs ever build zero entries so it can never go vacuous). `ControlsCatalog` carries a named deadcode-gate exemption in the Makefile + ci.yml, same reasoning as the existing `finding/identity/` exemption: an embedder surface with no in-repo caller by design, pinned by tests.

**Verified:** full `go test ./...` green, golangci-lint 0 issues, the exact CI deadcode step reproduced clean, and both e2e modes show the fields on the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzQcbUy6pBGj3sgVaXV5jo