### PR TITLE
fix(ci): build release binaries with Go 1.26.6 (unbreak release after #446)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.25.11'
+          # Must be >= the go.mod `go` directive (1.26.0, raised by
+          # golang.org/x/crypto v0.56.0). setup-go pins GOTOOLCHAIN=local, so a
+          # pin below the directive fails the build. Kept on the 1.26.6 toolchain
+          # so the release binaries carry the same stdlib as the Docker image.
+          go-version: '1.26.6'
 
       - name: Build binary
         env:


### PR DESCRIPTION
## Fixes the release build broken by #446

#446 bumped `golang.org/x/crypto` to v0.56.0 (to clear the `x/crypto/ssh` image CVEs), which requires Go 1.26 and raised the go.mod `go` directive to **1.26.0**. I updated the `ci.yml` build matrix but **missed the release binary job**, which pinned **Go 1.25.11** with `GOTOOLCHAIN=local` - so it can no longer build the module:

```
go.mod requires go >= 1.26.0 (running go 1.25.11; GOTOOLCHAIN=local)
```

Every `Build Binaries` leg failed on the `0.4.53` release run.

## Fix

Raise `release.yml`'s Go pin `1.25.11 -> 1.26.6`, matching the go.mod toolchain and the Docker builder (so the release binaries carry the same stdlib as the published image).

Verified: the exact release cross-compile (`GOOS=linux GOARCH=arm64 ... go build -ldflags=...`) succeeds under Go 1.26.6 with `GOTOOLCHAIN=local`. Other pins are fine: ci.yml is already on 1.26.x; codeql and plumber-action pin 1.26.4 (>= the 1.26.0 directive).

## Release recovery

`0.4.53` was version-bumped by semantic-release but its binaries never built. Merging this triggers a fresh release that builds cleanly and supersedes it. The orphan `v0.4.53` tag (if created) can be deleted - your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
