### PR TITLE
feat(platform): export the score band and push final_points

### DIFF
--- a/cmd/platform_push.go
+++ b/cmd/platform_push.go
@@ -177,26 +177,32 @@ const (
 	platformStatusNotEvaluable = "not_evaluable"
 )
 
-// platformScore is the entry's Plumber Score. Points is
-// PlumberScoreResult.RawPointsUnclamped rounded to the nearest int — see
+// platformScore is the entry's Plumber Score. Points is RawPointsUnclamped
+// (signed, no floor); FinalPoints is the malus-capped final figure the
+// banner shows (platform contract 2026-09-10, additive). See
 // platformScoreFrom.
 type platformScore struct {
-	Letter string `json:"letter,omitempty"`
-	Points int    `json:"points"`
+	Letter      string `json:"letter,omitempty"`
+	Points      int    `json:"points"`
+	FinalPoints *int   `json:"final_points,omitempty"`
 }
 
 // platformScoreFrom converts the already-computed Plumber Score to the wire
 // shape. Points is RawPointsUnclamped — the SIGNED deficit with no floor at
 // zero (the contract stores it unclamped; the gate/badge's floored-at-zero
 // RawPoints is display-only) — rounded to the nearest int, matching what the
-// contract's Score.Points type actually is. Tolerates a nil score (no
-// production caller passes one today, but a best-effort push should never
-// panic a run over a nil pointer) by sending the zero value.
+// contract's Score.Points type actually is. FinalPoints carries the
+// malus-capped final figure (floored at 0, capped at 30 while any Critical
+// exists) so the platform can cross-check its own recompute against the
+// CLI's exact formula. Tolerates a nil score (no production caller passes
+// one today, but a best-effort push should never panic a run over a nil
+// pointer) by sending the zero value, with FinalPoints left nil.
 func platformScoreFrom(score *control.PlumberScoreResult) platformScore {
 	if score == nil {
 		return platformScore{}
 	}
-	return platformScore{Letter: score.Score, Points: int(math.Round(score.RawPointsUnclamped))}
+	final := int(math.Round(score.FinalPoints))
+	return platformScore{Letter: score.Score, Points: int(math.Round(score.RawPointsUnclamped)), FinalPoints: &final}
 }
 
 // policyNameFor derives a stable, human-meaningful policy name from the config

--- a/cmd/platform_push_test.go
+++ b/cmd/platform_push_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -243,6 +244,116 @@ func TestBuildPlatformPush_ScorePointsRoundToSignedInt(t *testing.T) {
 				t.Errorf("score = %+v, want letter=E points=%d", got, tc.want)
 			}
 		})
+	}
+}
+
+// End to end: score.final_points must survive the full build -> marshal ->
+// unmarshal round trip, and a zero final_points (the Critical malus floor)
+// must be present on the wire as "final_points": 0, not omitted, since a
+// present-but-zero and a genuinely-absent field mean different things to a
+// platform doing a recompute cross-check.
+func TestBuildPlatformPush_ScoreFinalPointsOnWire(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		score *control.PlumberScoreResult
+		want  int
+	}{
+		{"nonzero final_points", &control.PlumberScoreResult{Score: "C", RawPointsUnclamped: 55, FinalPoints: 55}, 55},
+		{"zero final_points (malus floor)", &control.PlumberScoreResult{Score: "E", RawPointsUnclamped: -5, FinalPoints: 0}, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := buildPlatformPush(testProvider(t), nil, &control.AnalysisResult{}, tc.score, ".plumber.yaml")
+			if err != nil {
+				t.Fatalf("buildPlatformPush: %v", err)
+			}
+
+			var raw map[string]json.RawMessage
+			if err := json.Unmarshal(body, &raw); err != nil {
+				t.Fatal(err)
+			}
+			var rawResults []map[string]json.RawMessage
+			if err := json.Unmarshal(raw["results"], &rawResults); err != nil {
+				t.Fatal(err)
+			}
+			var rawScore map[string]json.RawMessage
+			if err := json.Unmarshal(rawResults[0]["score"], &rawScore); err != nil {
+				t.Fatal(err)
+			}
+			finalRaw, present := rawScore["final_points"]
+			if !present {
+				t.Fatalf("final_points key is absent from the wire body, want it present (even when the value is 0): %s", rawResults[0]["score"])
+			}
+			if string(finalRaw) != strconv.Itoa(tc.want) {
+				t.Errorf("wire final_points = %s, want %d", finalRaw, tc.want)
+			}
+
+			var push platformPush
+			if err := json.Unmarshal(body, &push); err != nil {
+				t.Fatal(err)
+			}
+			got := push.Results[0].Score.FinalPoints
+			if got == nil || *got != tc.want {
+				t.Errorf("push.Results[0].Score.FinalPoints = %v, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// Row 40 (platform): the push carries final_points beside the existing signed
+// points, so the platform can cross-check its own recompute against the
+// CLI's exact formula (malus included).
+func TestPlatformScoreFrom_CarriesFinalPoints(t *testing.T) {
+	s := &control.PlumberScoreResult{Score: "E", RawPointsUnclamped: 75, FinalPoints: 30}
+	got := platformScoreFrom(s)
+	if got.Letter != "E" || got.Points != 75 || got.FinalPoints == nil || *got.FinalPoints != 30 {
+		t.Fatalf("want E, points 75 (raw), final_points 30, got %+v", got)
+	}
+}
+
+// The Critical malus floors FinalPoints at zero even when the raw deficit is
+// negative (RawPointsUnclamped survives unclamped, per its own doc comment);
+// FinalPoints must still be a present, non-nil zero, not treated as absent.
+func TestPlatformScoreFrom_FinalPointsFloorAtZero(t *testing.T) {
+	s := &control.PlumberScoreResult{Score: "E", RawPointsUnclamped: -5, FinalPoints: 0}
+	got := platformScoreFrom(s)
+	if got.FinalPoints == nil || *got.FinalPoints != 0 {
+		t.Fatalf("final_points = %v, want a non-nil 0 (the malus floor, not an absent field)", got.FinalPoints)
+	}
+	if got.Points != -5 {
+		t.Fatalf("points = %d, want -5 (RawPointsUnclamped stays signed and unclamped)", got.Points)
+	}
+}
+
+// FinalPoints rounds half away from zero (math.Round), matching Points'
+// rounding rule.
+func TestPlatformScoreFrom_FinalPointsRounds(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		final float64
+		want  int
+	}{
+		{"half rounds up away from zero", 30.5, 31},
+		{"below half rounds down", 29.4, 29},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &control.PlumberScoreResult{Score: "C", RawPointsUnclamped: tc.final, FinalPoints: tc.final}
+			got := platformScoreFrom(s)
+			if got.FinalPoints == nil || *got.FinalPoints != tc.want {
+				t.Fatalf("final_points = %v, want %d", got.FinalPoints, tc.want)
+			}
+		})
+	}
+}
+
+// A nil score must not panic and must leave FinalPoints nil (genuinely
+// absent), alongside the existing zero-value Letter/Points behaviour.
+func TestPlatformScoreFrom_NilScore(t *testing.T) {
+	got := platformScoreFrom(nil)
+	if got.FinalPoints != nil {
+		t.Fatalf("final_points = %v, want nil for a nil score", got.FinalPoints)
+	}
+	if got.Letter != "" || got.Points != 0 {
+		t.Fatalf("want zero-value Letter/Points for a nil score, got %+v", got)
 	}
 }
 

--- a/control/scoring.go
+++ b/control/scoring.go
@@ -171,7 +171,7 @@ func scoreSeveritySpecs() map[IssueSeverity]severitySpec {
 // Raw points are 100 minus the sum of capped per-code losses. When at least
 // one Critical issue is present, final points are capped at 30 (Critical
 // malus), forcing the letter score into the E band. The A–E letter is read
-// from final points using the thresholds in scoreLetterFromPoints.
+// from final points using the thresholds in ScoreLetterFromPoints.
 func ComputePlumberScore(codeCounts map[ErrorCode]int) PlumberScoreResult {
 	specs := scoreSeveritySpecs()
 
@@ -271,7 +271,7 @@ func ComputePlumberScore(codeCounts map[ErrorCode]int) PlumberScoreResult {
 		final = math.Min(raw, maxPointsWithCritical)
 	}
 	out.FinalPoints = final
-	out.Score = scoreLetterFromPoints(out.FinalPoints)
+	out.Score = ScoreLetterFromPoints(out.FinalPoints)
 
 	return out
 }
@@ -295,7 +295,8 @@ func ScoreLetterRank(letter string) int {
 	}
 }
 
-func scoreLetterFromPoints(finalPoints float64) string {
+// ScoreLetterFromPoints is the scoring-v3 letter band (A>=90, B>=71, C>=51, D>=31, else E) over FINAL points. Exported for the platform, which derives an aggregate's letter through this one table.
+func ScoreLetterFromPoints(finalPoints float64) string {
 	switch {
 	case finalPoints >= 90:
 		return "A"

--- a/control/scoring_test.go
+++ b/control/scoring_test.go
@@ -150,8 +150,18 @@ func TestScoreLetterFromPoints_boundaries(t *testing.T) {
 		{30.9, "E"},
 	}
 	for _, tc := range cases {
-		if g := scoreLetterFromPoints(tc.final); g != tc.want {
+		if g := ScoreLetterFromPoints(tc.final); g != tc.want {
 			t.Fatalf("points %f: want letter %s, got %s", tc.final, tc.want, g)
+		}
+	}
+}
+
+// Row 40 (platform): the band is the CLI's, exported so the platform derives an aggregate's
+// letter through this function instead of a local copy.
+func TestScoreLetterFromPoints_Bands(t *testing.T) {
+	for pts, want := range map[float64]string{100: "A", 90: "A", 89.9: "B", 71: "B", 70.9: "C", 51: "C", 50.9: "D", 31: "D", 30.9: "E", 0: "E"} {
+		if got := ScoreLetterFromPoints(pts); got != want {
+			t.Fatalf("ScoreLetterFromPoints(%v): want %s, got %s", pts, want, got)
 		}
 	}
 }


### PR DESCRIPTION
## What / why

The platform now displays exactly what `control.ComputePlumberScore` produces (letter and FINAL points, Critical malus included). Two additive CLI changes support this platform ruling: the platform derives an aggregate's letter through the CLI's own band and cross-checks its recompute against the CLI's exact formula, instead of keeping a local copy that could drift.

## Changes

1. `control/scoring.go`: renamed the unexported `scoreLetterFromPoints` to exported `ScoreLetterFromPoints` (the scoring-v3 letter band: A>=90, B>=71, C>=51, D>=31, else E, over final points). The one caller in `ComputePlumberScore` and the existing test that referenced the unexported name were updated. Behaviour is byte-identical, this is a rename only.
2. `cmd/platform_push.go`: `platformScore` gains `FinalPoints *int json:"final_points,omitempty"`. `platformScoreFrom` sets it to `round(FinalPoints)` for a non-nil score and leaves it `nil` for a nil score. The existing `Points` field is untouched (still the signed, unclamped raw deficit).

Both changes are additive: the platform contract (`docs/contracts/openapi.yaml` `Score.final_points`, integer, push-only, "the formula's final points, floored at 0, capped at 30 while any Critical exists") already accepts pushes with or without `final_points`.

Platform contracts CHANGELOG 2026-09-10, QUESTIONS row 40.

## Test evidence

TDD, red before green:

- `go test ./control/ -run TestScoreLetterFromPoints -v` before the rename: build failure (`undefined: ScoreLetterFromPoints`). After the rename: PASS (`TestScoreLetterFromPoints_boundaries`, `TestScoreLetterFromPoints_Bands`).
- `go test ./cmd/... -run TestPlatformScoreFrom_CarriesFinalPoints -v` before the field: build failure (`got.FinalPoints undefined`). After the field: PASS.
- `go test ./control/... ./cmd/...`: PASS.
- `go test ./...`: PASS (all packages).
- `golangci-lint run` (pinned v2.10.1, matches `.github/workflows/ci.yml`): 0 issues, both scoped to the changed packages and repo-wide.
- `go run golang.org/x/tools/cmd/deadcode@09747cdf594a7924dcecb506312be3bd6e437962 ./...` (same pin as CI): no new findings.

Do NOT merge, Thomas will review and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRHuGuptmc9Rd147CsC2se
