### PR TITLE
fix(platform): safe checkout on root-owned clones, honest unconfigured controls, dismissal propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,29 @@ it to decide what to collect and what to report:
   on. A run prints which configuration it used and why, with no `--verbose`
   needed.
 
+- **The checkout is trusted for git regardless of who cloned it.** Plumber
+  declares the analysed directory `safe.directory` for git before reading it,
+  so a runner clone owned by another uid (the default GitLab Docker executor
+  clones as root) is still read instead of failing detection silently. The
+  declaration is per invocation and names that one directory, never `*`: no
+  global git config is written, so nothing is trusted beyond the run.
+- **An enabled control with none of its configuration set reports
+  `not_evaluable`, never a silent pass.** A `RequiresConfig` control turned on
+  with none of its substantive fields set asserts nothing, so it is marked
+  `not_evaluable` with reason `config_required` and excluded from the score,
+  rather than counted as passing.
+- **Findings the platform has dismissed are marked and excluded from the
+  score.** A finding matching a dismissal served in the project context is
+  excluded from the score and still pushed to the platform with a
+  `dismissed: true` marker (a control never reports a pass just because its
+  findings were dismissed). It is marked in every output that has a place to
+  mark it: the terminal report tags it `[dismissed on the platform]`, the CSV
+  export carries a `dismissed` column and the OCSF export a `dismissed: true`
+  key. The `--output` JSON report carries no marker, deliberately: its finding
+  objects are the same bytes the platform hashes into a finding's identity, so
+  adding a field to them would change what the CLI and the platform agree a
+  finding is.
+
 Platform mode reports *less* when data is missing, never something different:
 a run that cannot evaluate a control says so.
 
@@ -456,6 +479,12 @@ More details:
 | `1` | The Plumber Score is below the gate (or the deprecated `--threshold` is not met) |
 | `2` | Invalid usage, configuration, or a runtime / provider / auth / network failure |
 | `3` | A check could not be verified and `--fail-warnings` is set (e.g. an action version that could not be resolved) |
+
+The deprecated `--threshold` gate is computed from each control's own
+pass/fail rather than the Plumber Score, so a control whose only findings are
+dismissed on the platform still counts as failing there, unlike the score
+gate (`--min-points` / `--min-score`), which excludes dismissed findings;
+prefer `--min-points`.
 
 ## Self-Hosted GitLab
 

--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -1588,6 +1588,7 @@ func findingsToItems(findings []opaengine.Finding) ([]control.ErrorCode, []detai
 			DocURL:      code.DocURL(),
 			Location:    formatFindingLocation(f),
 			DetailLines: detailLinesFromFinding(f),
+			Dismissed:   f.Dismissed,
 		})
 	}
 	return codes, items

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -34,11 +34,7 @@ func runWithProvider(p provider.Provider, cmd *cobra.Command, conf *configuratio
 		return err
 	}
 
-	newLocationLinker(conf, result, p.Name()).Annotate(result.Findings)
-	opaengine.StampFingerprints(result.Findings, conf.GitRepoRoot)
-	markPlatformDismissedFindings(conf, result)
-
-	summary := buildComplianceSummary(p, result, conf)
+	summary := finalizeFindings(p, conf, result)
 
 	if printOutput {
 		if err := outputTextWithProvider(p, result, conf, summary, controlsFilterList, skipControlsList); err != nil {
@@ -51,6 +47,25 @@ func runWithProvider(p provider.Provider, cmd *cobra.Command, conf *configuratio
 	}
 
 	return publishAndFinalize(p, cmd, result, conf, summary)
+}
+
+// finalizeFindings turns a raw analysis result into the summary the rest of the
+// pipeline reports on, and is deliberately the ONLY place that sequence lives:
+// annotate source locations, stamp fingerprints, mark what the platform served
+// as dismissed, then compute the summary.
+//
+// The order is load bearing twice over. The dismissed match hashes the fields
+// fingerprinting canonicalizes, so marking before the stamp would match
+// nothing; and the summary scores the run, so marking after it would push a
+// score that still counts a dismissed finding. Both entry points go through
+// here - runWithProvider for GitLab, presentResultWithProvider for the GitHub
+// paths - rather than repeating the sequence, because a copy is a copy that can
+// silently lose a step (the ONE thing #447's wiring is exposed to).
+func finalizeFindings(p provider.Provider, conf *configuration.Configuration, result *control.AnalysisResult) complianceSummary {
+	newLocationLinker(conf, result, p.Name()).Annotate(result.Findings)
+	opaengine.StampFingerprints(result.Findings, conf.GitRepoRoot)
+	markPlatformDismissedFindings(conf, result)
+	return buildComplianceSummary(p, result, conf)
 }
 
 // markPlatformDismissedFindings marks the findings the platform already
@@ -486,10 +501,7 @@ func presentResultWithProvider(p provider.Provider, cmd *cobra.Command, result *
 		reportPlatformMode(conf.PlatformRun)
 	}
 
-	newLocationLinker(conf, result, p.Name()).Annotate(result.Findings)
-	opaengine.StampFingerprints(result.Findings, conf.GitRepoRoot)
-	markPlatformDismissedFindings(conf, result)
-	summary := buildComplianceSummary(p, result, conf)
+	summary := finalizeFindings(p, conf, result)
 	if printOutput {
 		if err := outputTextWithProvider(p, result, conf, summary, conf.ControlsFilter, conf.SkipControlsFilter); err != nil {
 			return err

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -8,6 +8,7 @@ import (
 	"github.com/getplumber/plumber/control"
 	opaengine "github.com/getplumber/plumber/internal/engine/opa"
 	"github.com/getplumber/plumber/provider"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -35,6 +36,7 @@ func runWithProvider(p provider.Provider, cmd *cobra.Command, conf *configuratio
 
 	newLocationLinker(conf, result, p.Name()).Annotate(result.Findings)
 	opaengine.StampFingerprints(result.Findings, conf.GitRepoRoot)
+	markPlatformDismissedFindings(conf, result)
 
 	summary := buildComplianceSummary(p, result, conf)
 
@@ -49,6 +51,23 @@ func runWithProvider(p provider.Provider, cmd *cobra.Command, conf *configuratio
 	}
 
 	return publishAndFinalize(p, cmd, result, conf, summary)
+}
+
+// markPlatformDismissedFindings marks the findings the platform already
+// served as dismissed (#447), right after fingerprints are stamped: the
+// platform identity a dismissed entry matches against depends on the same
+// canonical fields fingerprinting reads, so this must run after that stamp,
+// not before it. No-op outside platform mode, or when the /context fetch
+// itself never produced a context (a failed or skipped fetch leaves
+// conf.PlatformRun.Context nil, and there is nothing served to mark
+// against).
+func markPlatformDismissedFindings(conf *configuration.Configuration, result *control.AnalysisResult) {
+	if conf == nil || result == nil || conf.PlatformRun == nil || conf.PlatformRun.Context == nil {
+		return
+	}
+	if n := control.MarkDismissed(result.Findings, conf.PlatformRun.Context.DismissedIssues); n > 0 {
+		logrus.Debugf("dismissed_issues: marked %d finding(s) as platform-dismissed", n)
+	}
 }
 
 // publishAndFinalize is the tail both analyze entry points share: publish the
@@ -333,6 +352,12 @@ func buildProviderControlSummariesAndGroups(p provider.Provider, result *control
 			sortBranchProtectionFindingsForDisplay(findings)
 		}
 		codes, items := findingsToItems(findings)
+		dismissed := 0
+		for _, item := range items {
+			if item.Dismissed {
+				dismissed++
+			}
+		}
 		skipped := e.Skipped || dataCollectionFailed
 		stats := provider.BuildControlStats(p.Name(), e.ControlName, result, conf.PlumberConfig, findings)
 		// A control whose lane supplied nothing must not render as passed.
@@ -345,6 +370,15 @@ func buildProviderControlSummariesAndGroups(p provider.Provider, result *control
 		if !skipped && result != nil {
 			reason, notEvaluable = result.NotEvaluable[e.ControlName]
 		}
+		// #447: the Controls table's issue count and per-severity tally
+		// deliberately count EVERY finding, dismissed ones included. This is
+		// not an oversight next to renderFailedControl's "N issues, M
+		// dismissed" header: a dismissed finding still exists in this run's
+		// output (it is never dropped, only excluded from the score, per
+		// forEachIssueCode in control/scoring.go), and this table is a
+		// per-control inventory, not the live verdict. Collapsing the row
+		// count when every finding of a control happens to be dismissed
+		// would make the control's row look emptier than what actually ran.
 		controls = append(controls, controlSummary{
 			name:       e.DisplayName,
 			issues:     len(items),
@@ -360,6 +394,7 @@ func buildProviderControlSummariesAndGroups(p provider.Provider, result *control
 			NotEvaluableReason: reason,
 			Stats:              stats,
 			Findings:           items,
+			Dismissed:          dismissed,
 		})
 	}
 	return controls, groups
@@ -453,6 +488,7 @@ func presentResultWithProvider(p provider.Provider, cmd *cobra.Command, result *
 
 	newLocationLinker(conf, result, p.Name()).Annotate(result.Findings)
 	opaengine.StampFingerprints(result.Findings, conf.GitRepoRoot)
+	markPlatformDismissedFindings(conf, result)
 	summary := buildComplianceSummary(p, result, conf)
 	if printOutput {
 		if err := outputTextWithProvider(p, result, conf, summary, conf.ControlsFilter, conf.SkipControlsFilter); err != nil {

--- a/cmd/csv.go
+++ b/cmd/csv.go
@@ -43,7 +43,11 @@ import (
 // template, component or action). Those findings carry what they are about in
 // their structured payload and in the identity block of the JSON report.
 func buildCSV(entries []control.ControlEntry, result *control.AnalysisResult) [][]string {
-	header := []string{"code", "fingerprint", "controlName", "status", "severity", "message", "context", "file", "line", "url", "docUrl"}
+	// dismissed carries the platform's #447 marker: "true"/"false" on a
+	// finding row, empty on a non-failing control's summary row (there is
+	// no finding to have an opinion about), the same emptiness convention
+	// code and fingerprint already use on that row shape.
+	header := []string{"code", "fingerprint", "controlName", "status", "severity", "message", "context", "file", "line", "url", "docUrl", "dismissed"}
 	byControl := control.FindingsByControl(result.Findings)
 
 	var nonFailing [][]string // passed / error / skipped: one row per control, at the top
@@ -66,6 +70,7 @@ func buildCSV(entries []control.ControlEntry, result *control.AnalysisResult) []
 				"",                                 // line
 				"",                                 // url
 				"",                                 // docUrl
+				"",                                 // dismissed (no finding)
 			}))
 			continue
 		}
@@ -100,6 +105,7 @@ func buildCSV(entries []control.ControlEntry, result *control.AnalysisResult) []
 				line,
 				f.URL,
 				"https://getplumber.io/docs/cli/issues/" + f.Code,
+				strconv.FormatBool(f.Dismissed),
 			}))
 		}
 	}

--- a/cmd/csv_test.go
+++ b/cmd/csv_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Column layout: 0 code, 1 fingerprint, 2 controlName, 3 status, 4 severity,
-// 5 message, 6 context, 7 file, 8 line, 9 url, 10 docUrl.
+// 5 message, 6 context, 7 file, 8 line, 9 url, 10 docUrl, 11 dismissed.
 //
 // ISSUE-701 maps to actionsMustBePinnedByCommitSha in the codes registry, so a
 // finding with that code is associated with that control by FindingsByControl.
@@ -28,7 +28,7 @@ func TestBuildCSV_ShapeColumnsAndOrdering(t *testing.T) {
 
 	records := buildCSV(entries, result)
 
-	wantHeader := []string{"code", "fingerprint", "controlName", "status", "severity", "message", "context", "file", "line", "url", "docUrl"}
+	wantHeader := []string{"code", "fingerprint", "controlName", "status", "severity", "message", "context", "file", "line", "url", "docUrl", "dismissed"}
 	if len(records) != 4 { // header + cleanControl(passed) + disabledControl(skipped) + actions(failed)
 		t.Fatalf("records = %d, want 4", len(records))
 	}
@@ -48,6 +48,9 @@ func TestBuildCSV_ShapeColumnsAndOrdering(t *testing.T) {
 	}
 	if records[1][0] != "" || records[1][1] != "" {
 		t.Errorf("passed row code/fingerprint = %q/%q, want empty", records[1][0], records[1][1])
+	}
+	if records[1][11] != "" {
+		t.Errorf("passed row dismissed = %q, want empty (no finding to have an opinion about)", records[1][11])
 	}
 	if records[2][2] != "disabledControl" || records[2][3] != "skipped" {
 		t.Errorf("row2 = %v, want disabledControl/skipped", records[2][:4])
@@ -71,6 +74,7 @@ func TestBuildCSV_ShapeColumnsAndOrdering(t *testing.T) {
 		8:  "28",
 		9:  "https://example.com/blob/ci.yml#L28",
 		10: "https://getplumber.io/docs/cli/issues/ISSUE-701",
+		11: "false",
 	}
 	for i, w := range want {
 		if failRow[i] != w {
@@ -258,6 +262,43 @@ func TestCSVSafeCell_CoversEveryKnownVector(t *testing.T) {
 		if got := csvSafeCell(s); got != s {
 			t.Errorf("ordinary value was modified: %q -> %q", s, got)
 		}
+	}
+}
+
+// TestBuildCSV_DismissedColumnFollowsTheFinding pins #447's CSV export: the
+// dismissed column carries each failing finding's own marker independently,
+// "true" or "false" as a literal string (encoding/csv writes everything as
+// text; a reader must not have to parse a bool from an ambiguous empty cell).
+func TestBuildCSV_DismissedColumnFollowsTheFinding(t *testing.T) {
+	entries := []control.ControlEntry{{ControlName: "actionsMustBePinnedByCommitSha", DisplayName: "Pin"}}
+	result := &control.AnalysisResult{
+		CiValid: true,
+		Findings: []opaengine.Finding{
+			{Code: "ISSUE-701", Message: "live one", Dismissed: false},
+			{Code: "ISSUE-701", Message: "dismissed one", Dismissed: true},
+		},
+	}
+	records := buildCSV(entries, result)
+	if len(records) != 3 { // header + 2 finding rows
+		t.Fatalf("records = %d, want 3 (header + 2 finding rows)", len(records))
+	}
+	var live, dismissed []string
+	for _, row := range records[1:] {
+		switch row[5] { // message
+		case "live one":
+			live = row
+		case "dismissed one":
+			dismissed = row
+		}
+	}
+	if live == nil || dismissed == nil {
+		t.Fatalf("expected both rows among %v", records[1:])
+	}
+	if live[11] != "false" {
+		t.Errorf("live row dismissed = %q, want \"false\"", live[11])
+	}
+	if dismissed[11] != "true" {
+		t.Errorf("dismissed row dismissed = %q, want \"true\"", dismissed[11])
 	}
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getplumber/plumber/configuration"
 	defaultconfig "github.com/getplumber/plumber/defaultConfig"
 	"github.com/getplumber/plumber/internal/ir"
+	"github.com/getplumber/plumber/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -758,9 +759,14 @@ func providersFromProviderChoice(choice string) []string {
 // preserves historical behaviour for the (still common) GitLab-only
 // case.
 func autoDetectProviderForInit() []string {
-	out, err := exec.Command("git", "config", "--get", "remote.origin.url").Output()
+	// Through utils.GitOutput, not exec.Command: the wizard runs in the same kind of checkout
+	// `plumber analyze` does, and a raw invocation is refused on one owned by another uid without
+	// saying why (#464). The helper declares the inspected directory safe and logs git's own
+	// first stderr line, so a wizard that silently falls back to GitLab is at least diagnosable.
+	dir, _ := os.Getwd()
+	out, err := utils.GitOutput(dir, "config", "--get", "remote.origin.url")
 	if err == nil {
-		url := strings.ToLower(strings.TrimSpace(string(out)))
+		url := strings.ToLower(out)
 		switch {
 		case strings.Contains(url, "github.com"):
 			return []string{provGitHub}

--- a/cmd/ocsf.go
+++ b/cmd/ocsf.go
@@ -338,6 +338,12 @@ func ocsfFailUnmapped(findings []opaengine.Finding) map[string]any {
 		if f.Fingerprint != "" {
 			rec["fingerprint"] = f.Fingerprint
 		}
+		if f.Dismissed {
+			// #447: same presence-is-the-claim convention as the platform
+			// push's own dismissed field (cmd/platform_push.go) - omitted
+			// entirely rather than sent as false for every ordinary finding.
+			rec["dismissed"] = true
+		}
 		if f.File != "" {
 			rec["file"] = reportFilePath(f.File)
 		}

--- a/cmd/ocsf_test.go
+++ b/cmd/ocsf_test.go
@@ -34,6 +34,44 @@ func TestBuildOCSF_FindingFingerprint(t *testing.T) {
 	}
 }
 
+// TestBuildOCSF_DismissedMarkerFollowsTheFinding pins #447's OCSF export,
+// mirroring how TestBuildOCSF_FindingFingerprint pins fingerprint: a
+// dismissed finding's record carries dismissed:true; an ordinary finding's
+// record carries no "dismissed" key at all (never a literal false).
+func TestBuildOCSF_DismissedMarkerFollowsTheFinding(t *testing.T) {
+	entries := []control.ControlEntry{{ControlName: "actionsMustBePinnedByCommitSha", DisplayName: "Pin"}}
+	result := &control.AnalysisResult{
+		CiValid: true,
+		Findings: []opaengine.Finding{
+			{Code: "ISSUE-701", Message: "live one", Dismissed: false},
+			{Code: "ISSUE-701", Message: "dismissed one", Dismissed: true},
+		},
+	}
+	events := buildOCSF(entries, result, "github", 1, "s")
+	recs, ok := events[0].Unmapped["plumber_findings"].([]map[string]any)
+	if !ok || len(recs) != 2 {
+		t.Fatalf("plumber_findings = %v, want 2 records", events[0].Unmapped["plumber_findings"])
+	}
+	var live, dismissed map[string]any
+	for _, r := range recs {
+		switch r["message"] {
+		case "live one":
+			live = r
+		case "dismissed one":
+			dismissed = r
+		}
+	}
+	if live == nil || dismissed == nil {
+		t.Fatalf("expected both records among %v", recs)
+	}
+	if _, has := live["dismissed"]; has {
+		t.Errorf("live finding record = %v, want no \"dismissed\" key at all", live)
+	}
+	if v, ok := dismissed["dismissed"].(bool); !ok || !v {
+		t.Errorf("dismissed finding record = %v, want dismissed:true", dismissed)
+	}
+}
+
 func TestBuildOCSF_FailingControl(t *testing.T) {
 	entries := []control.ControlEntry{
 		{ControlName: "actionsMustBePinnedByCommitSha", DisplayName: "Pin actions to SHA"},

--- a/cmd/platform_push.go
+++ b/cmd/platform_push.go
@@ -148,6 +148,13 @@ type platformFinding struct {
 	Status      string          `json:"status"`
 	Data        json.RawMessage `json:"data,omitempty"`
 
+	// Dismissed carries the finding's own control.Finding.Dismissed bit
+	// (#447): a finding the platform already served back as dismissed via
+	// /context, matched by control.MarkDismissed before the push is built.
+	// Omitted (never sent as false) on every finding that is not: the
+	// platform reads its presence as the claim, not its value.
+	Dismissed bool `json:"dismissed,omitempty"`
+
 	// Name and Category are the control's display metadata (#440), the
 	// docs-catalog wording next to the stable technical id in Control.
 	// Additive: the platform ignores unknown fields, and consumers that
@@ -420,7 +427,9 @@ func platformFindingsFor(p providerPkg.Provider, result *control.AnalysisResult,
 			continue
 		case control.StatusFailed:
 			for _, f := range fs {
-				out = append(out, decoratedPlatformFinding(platformFindingControlName(f), platformStatusFail, platformFindingDataRaw(f)))
+				pf := decoratedPlatformFinding(platformFindingControlName(f), platformStatusFail, platformFindingDataRaw(f))
+				pf.Dismissed = f.Dismissed
+				out = append(out, pf)
 			}
 		case control.StatusError:
 			out = append(out, decoratedPlatformFinding(e.ControlName, platformStatusNotEvaluable, notEvaluableReasonData(result, e.ControlName)))
@@ -455,17 +464,21 @@ func notEvaluableReasonData(result *control.AnalysisResult, controlName string) 
 	return raw
 }
 
-// platformFindingControlName names a failed finding's control via the same
-// registry lookup FindingsByControl itself buckets by (control.LookupCode),
-// re-derived per finding rather than reused from the enclosing ControlEntry.
-// Falls back to the raw code string when the code has no registry entry —
-// never to the enclosing control's name, which would misattribute an
-// unclassified finding as belonging to it.
+// platformFindingControlName names a failed finding's control via
+// control.ControlKeyFor, the same registry lookup FindingsByControl itself
+// buckets by (control.LookupCode), falling back to the raw code string when
+// the code has no registry entry, never to the enclosing control's name,
+// which would misattribute an unclassified finding as belonging to it.
+//
+// This calls the EXACT SAME helper control.MarkDismissed uses to bucket a
+// served dismissed entry by control (#447): a second, independently
+// maintained copy of "look up the code, else use it raw" here could drift
+// from that one, and a finding whose code the registry cannot classify is
+// exactly the case where the two sides most need to agree: it is pushed
+// under its raw code, and the platform can only ever serve a dismissal for
+// it back under that same raw code.
 func platformFindingControlName(f opaengine.Finding) string {
-	if info := control.LookupCode(control.ErrorCode(f.Code)); info != nil {
-		return info.ControlName
-	}
-	return f.Code
+	return control.ControlKeyFor(f.Code)
 }
 
 // platformFindingDataRaw serializes f exactly as opaengine.Finding.MarshalJSON

--- a/cmd/platform_push_test.go
+++ b/cmd/platform_push_test.go
@@ -17,7 +17,9 @@ import (
 	"github.com/getplumber/plumber/configuration"
 	"github.com/getplumber/plumber/control"
 	defaultconfig "github.com/getplumber/plumber/defaultConfig"
+	"github.com/getplumber/plumber/finding/identity"
 	opaengine "github.com/getplumber/plumber/internal/engine/opa"
+	"github.com/getplumber/plumber/internal/platform"
 	providerPkg "github.com/getplumber/plumber/provider"
 )
 
@@ -684,6 +686,184 @@ func TestMaybePushPlatform_DismissedFindingWireShape(t *testing.T) {
 	}
 	if !sawEntryWithNoDismissedKey {
 		t.Fatal("fixture must include at least one non-dismissed control to prove the key is truly absent elsewhere")
+	}
+}
+
+// stubRunProvider is the real GitLab provider with Run replaced by a canned result, so a test can
+// drive runWithProvider - the GitLab entry point, and the only path where platform mode actually
+// operates - without a live collection. Every other method is the real provider's, so the catalog,
+// the compliance computation and the CI mapping behave exactly as they do in production.
+type stubRunProvider struct {
+	providerPkg.Provider
+	result *control.AnalysisResult
+}
+
+func (s stubRunProvider) Run(*configuration.Configuration) (*control.AnalysisResult, error) {
+	return s.result, nil
+}
+
+// TestSharedPipeline_ServedDismissalMarksThePushAndLeavesTheScore pins the run-level half of #447,
+// which the wire-shape test above does not reach: nothing on the shared pipeline marks a finding
+// except the single markPlatformDismissedFindings call inside finalizeFindings, between
+// StampFingerprints and buildComplianceSummary. Drop it and a run pushes a served dismissal as a
+// live finding and scores it, with every unit test still green.
+//
+// Both production entry points are driven, because platform mode is not symmetric between them:
+// presentResultWithProvider serves the GitHub paths, while runWithProvider is GitLab's and is the
+// one path where platform mode actually operates. They share finalizeFindings, and this test is
+// what says so - a copy of the sequence in either of them, minus a step, fails here.
+//
+// The served entry is built the way the platform builds it: the identity hash of the finding as it
+// exists AFTER fingerprint stamping, under the current recipe version, keyed by the finding's
+// control. Both halves of the claim are asserted on the SAME run: the captured push body carries
+// "dismissed":true on that entry, and the score the run computed is the score of a run with no
+// such finding at all.
+func TestSharedPipeline_ServedDismissalMarksThePushAndLeavesTheScore(t *testing.T) {
+	origPrint := printOutput
+	printOutput = false // the terminal report is not under test
+	defer func() { printOutput = origPrint }()
+	newGateFlagsCmd(t) // reset gate globals: default points gate (min-points 100)
+
+	// The same fixture the wire-shape test uses: ISSUE-101 belongs to
+	// containerImageMustComeFromAuthorizedSources, which the shipped default config enables, so
+	// this is a fail finding a real run of that config produces, and it costs the score real
+	// points.
+	failFinding := func() opaengine.Finding {
+		return opaengine.Finding{Code: "ISSUE-101", Severity: "high", Message: "untrusted registry", Job: "build", File: ".gitlab-ci.yml", Line: 4}
+	}
+
+	stamped := []opaengine.Finding{failFinding()}
+	opaengine.StampFingerprints(stamped, "")
+	hash, _, ok := identity.PlatformHash(stamped[0].IdentityInput())
+	if !ok {
+		t.Fatal("the fixture finding has no platform identity, so no served dismissal could ever match it")
+	}
+	served := platform.DismissedIssue{
+		IdentityHash:  hash,
+		RecipeVersion: identity.RecipeVersion,
+		ControlType:   control.ControlKeyFor(stamped[0].Code),
+	}
+
+	// dismissedKeyFor reads the marker off the raw wire bytes rather than through platformFinding,
+	// for the reason docs/platform-push-testing.md gives: decoding into the struct cannot tell an
+	// absent key from a false.
+	dismissedKeyFor := func(t *testing.T, body []byte, controlName string) (val any, present, found bool) {
+		t.Helper()
+		var raw map[string]any
+		if err := json.Unmarshal(body, &raw); err != nil {
+			t.Fatalf("body does not decode as JSON: %v", err)
+		}
+		results, _ := raw["results"].([]any)
+		if len(results) == 0 {
+			t.Fatal("results = empty")
+		}
+		entry, _ := results[0].(map[string]any)
+		rawFindings, _ := entry["findings"].([]any)
+		for _, rf := range rawFindings {
+			f, _ := rf.(map[string]any)
+			if name, _ := f["control"].(string); name != controlName {
+				continue
+			}
+			v, has := f["dismissed"]
+			return v, has, true
+		}
+		return nil, false, false
+	}
+
+	const dismissedControl = "containerImageMustComeFromAuthorizedSources"
+
+	entries := []struct {
+		name  string
+		drive func(t *testing.T, p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult)
+	}{
+		{
+			// The GitHub paths: the result is already in hand.
+			name: "presentResultWithProvider",
+			drive: func(t *testing.T, p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult) {
+				t.Helper()
+				_ = presentResultWithProvider(p, nil, result, conf)
+			},
+		},
+		{
+			// The GitLab entry point (cmd/analyze_gitlab.go), with p.Run stubbed out: everything
+			// after collection is the production path, spinner and publish included.
+			name: "runWithProvider",
+			drive: func(t *testing.T, p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult) {
+				t.Helper()
+				_ = runWithProvider(stubRunProvider{Provider: p, result: result}, nil, conf, nil, nil)
+			},
+		},
+	}
+
+	for _, entry := range entries {
+		t.Run(entry.name, func(t *testing.T) {
+			// run drives the production pipeline once and returns the raw pushed body plus the
+			// score that same run computed. A context with no policies pushes the single
+			// locally-named entry, so the assertions read one result rather than one per policy;
+			// the served dismissed list is the only variable.
+			run := func(t *testing.T, findings []opaengine.Finding, dismissed []platform.DismissedIssue) ([]byte, int) {
+				t.Helper()
+				var gotBody []byte
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					gotBody, _ = io.ReadAll(r.Body)
+					w.WriteHeader(http.StatusAccepted)
+				}))
+				defer srv.Close()
+				restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+				defer restore()
+
+				conf := configuration.NewDefaultConfiguration()
+				conf.ConfigFilePath = ".plumber.yaml"
+				conf.PlumberConfig = testDefaultPlumberConfig(t)
+				conf.PlatformRun = &platform.RunContext{
+					Endpoint: srv.URL,
+					Context:  &platform.ProjectContext{DismissedIssues: dismissed},
+				}
+
+				// The returned error is the gate verdict, which is not what this test reads: a
+				// live high finding fails the default points gate and the same finding dismissed
+				// does not. That difference is asserted on the pushed score below, which is the
+				// score itself rather than a proxy for it.
+				_ = captureStderr(t, func() {
+					entry.drive(t, testProvider(t), conf, &control.AnalysisResult{CiValid: true, Findings: findings})
+				})
+
+				if len(gotBody) == 0 {
+					t.Fatal("nothing was POSTed: the run-level pipeline never reached the platform push")
+				}
+				var push platformPush
+				if err := json.Unmarshal(gotBody, &push); err != nil {
+					t.Fatalf("pushed body does not decode: %v", err)
+				}
+				if len(push.Results) != 1 {
+					t.Fatalf("results = %d, want exactly 1 entry", len(push.Results))
+				}
+				return gotBody, push.Results[0].Score.Points
+			}
+
+			servedBody, servedPoints := run(t, []opaengine.Finding{failFinding()}, []platform.DismissedIssue{served})
+			liveBody, livePoints := run(t, []opaengine.Finding{failFinding()}, nil)
+			_, cleanPoints := run(t, nil, nil)
+
+			val, present, found := dismissedKeyFor(t, servedBody, dismissedControl)
+			if !found {
+				t.Fatalf("control %q is absent from the pushed findings: the served dismissal must be pushed, not withheld", dismissedControl)
+			}
+			if b, ok := val.(bool); !present || !ok || !b {
+				t.Errorf("dismissed = %v (present=%v), want \"dismissed\":true: markPlatformDismissedFindings must run on this entry point's pipeline", val, present)
+			}
+
+			if _, present, found := dismissedKeyFor(t, liveBody, dismissedControl); !found || present {
+				t.Errorf("without a served entry, control %q carried dismissed=%v: the marker must come from the served list alone", dismissedControl, present)
+			}
+
+			if servedPoints <= livePoints {
+				t.Errorf("score points = %d dismissed vs %d live, want the dismissed finding to cost nothing (#447: out of the score like not_evaluable)", servedPoints, livePoints)
+			}
+			if servedPoints != cleanPoints {
+				t.Errorf("score points = %d with the finding dismissed, %d with no such finding at all: the two must agree, or the exclusion is partial", servedPoints, cleanPoints)
+			}
+		})
 	}
 }
 

--- a/cmd/platform_push_test.go
+++ b/cmd/platform_push_test.go
@@ -579,6 +579,114 @@ func TestMaybePushPlatform_FindingsCoverPassFailAndNotEvaluable(t *testing.T) {
 	}
 }
 
+// TestPlatformFindingsFor_DismissedMarkerFollowsTheFinding pins #447 part 2
+// on the build side: platformFindingsFor's fail branch must carry each
+// finding's own Dismissed bit onto the pushed entry, not the same value for
+// every finding of a control. Two findings under the same failing control,
+// one dismissed and one not, must come out tagged independently.
+func TestPlatformFindingsFor_DismissedMarkerFollowsTheFinding(t *testing.T) {
+	pc := testDefaultPlumberConfig(t)
+	result := &control.AnalysisResult{
+		CiValid: true,
+		Findings: []opaengine.Finding{
+			{Code: "ISSUE-101", Severity: "high", Message: "live", Job: "build", File: ".gitlab-ci.yml", Line: 1},
+			{Code: "ISSUE-101", Severity: "high", Message: "dismissed one", Job: "deploy", File: ".gitlab-ci.yml", Line: 2, Dismissed: true},
+		},
+	}
+	findings := platformFindingsFor(testProvider(t), result, pc, nil, nil)
+
+	var live, dismissed *platformFinding
+	for i := range findings {
+		if findings[i].Control != "containerImageMustComeFromAuthorizedSources" {
+			continue
+		}
+		var data map[string]any
+		if err := json.Unmarshal(findings[i].Data, &data); err != nil {
+			t.Fatalf("finding data does not parse: %v", err)
+		}
+		switch data["message"] {
+		case "live":
+			live = &findings[i]
+		case "dismissed one":
+			dismissed = &findings[i]
+		}
+	}
+	if live == nil || dismissed == nil {
+		t.Fatalf("expected both the live and the dismissed finding among %+v", findings)
+	}
+	if live.Status != platformStatusFail || live.Dismissed {
+		t.Errorf("live finding = %+v, want status=fail, dismissed=false", live)
+	}
+	if dismissed.Status != platformStatusFail || !dismissed.Dismissed {
+		t.Errorf("dismissed finding = %+v, want status=fail, dismissed=true", dismissed)
+	}
+}
+
+// TestMaybePushPlatform_DismissedFindingWireShape checks the marker on the
+// raw wire bytes, the same way the rest of this file distrusts decoding
+// into platformFinding alone (see docs/platform-push-testing.md): a
+// dismissed finding's pushed entry must carry `"dismissed":true`, and an
+// ordinary finding's entry must carry no `dismissed` key at all
+// (omitempty), not a `false`.
+func TestMaybePushPlatform_DismissedFindingWireShape(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	conf := &configuration.Configuration{ConfigFilePath: ".plumber.yaml", PlumberConfig: testDefaultPlumberConfig(t)}
+	result := &control.AnalysisResult{
+		CiValid: true,
+		Findings: []opaengine.Finding{
+			{Code: "ISSUE-101", Severity: "high", Message: "untrusted registry", Job: "build", File: ".gitlab-ci.yml", Line: 4, Dismissed: true},
+		},
+	}
+	if err := maybePushPlatform(testProvider(t), conf, result, &control.PlumberScoreResult{Score: "C"}); err != nil {
+		t.Fatalf("maybePushPlatform: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(gotBody, &raw); err != nil {
+		t.Fatalf("body does not decode as JSON: %v", err)
+	}
+	results, _ := raw["results"].([]any)
+	if len(results) != 1 {
+		t.Fatalf("results = %v, want exactly 1 entry", results)
+	}
+	entry, _ := results[0].(map[string]any)
+	rawFindings, _ := entry["findings"].([]any)
+
+	var sawDismissedTrue, sawEntryWithNoDismissedKey bool
+	for _, rf := range rawFindings {
+		f, _ := rf.(map[string]any)
+		controlName, _ := f["control"].(string)
+		val, hasKey := f["dismissed"]
+		if controlName == "containerImageMustComeFromAuthorizedSources" {
+			b, ok := val.(bool)
+			if !hasKey || !ok || !b {
+				t.Errorf("dismissed finding's wire entry = %v, want \"dismissed\":true", f)
+			}
+			sawDismissedTrue = true
+			continue
+		}
+		if hasKey {
+			t.Errorf("control %q must carry no \"dismissed\" key at all (omitempty): %v", controlName, f)
+		} else {
+			sawEntryWithNoDismissedKey = true
+		}
+	}
+	if !sawDismissedTrue {
+		t.Fatal("the dismissed finding's control must appear in the pushed findings with dismissed:true")
+	}
+	if !sawEntryWithNoDismissedKey {
+		t.Fatal("fixture must include at least one non-dismissed control to prove the key is truly absent elsewhere")
+	}
+}
+
 // A control excluded via --skip-controls (the same e.Skipped flag a control
 // disabled in .plumber.yaml sets) is OMITTED from findings entirely: it is
 // still visible in effective_config, but "not evaluated by choice" is a

--- a/cmd/render_details.go
+++ b/cmd/render_details.go
@@ -45,6 +45,11 @@ type detailedFinding struct {
 	Location string
 	// DetailLines is optional (e.g. ISSUE-505: one headline, several sub-reasons).
 	DetailLines []string
+	// Dismissed mirrors opaengine.Finding.Dismissed (#447): the platform
+	// already has this finding filed as dismissed. Still rendered, never
+	// dropped (see renderFailedControl for the tag and the count it
+	// changes).
+	Dismissed bool
 }
 
 // findingGroup collects everything needed to render one per-rule
@@ -67,6 +72,11 @@ type findingGroup struct {
 	NotEvaluableReason string
 	Stats              []statLine
 	Findings           []detailedFinding
+	// Dismissed is how many of Findings are platform-dismissed (#447):
+	// still present in Findings (never dropped), counted here so
+	// renderFailedControl can show the live count separately from the
+	// dismissed one.
+	Dismissed int
 }
 
 // renderWarnings prints the run's non-fatal "could not verify" messages,
@@ -380,10 +390,16 @@ func renderFailedControlsSection(groups []findingGroup) {
 // code, message and doc URL. All content is indented one level under the
 // control title.
 func renderFailedControl(g findingGroup) {
-	n := len(g.Findings)
+	// The count excludes dismissed findings: they are still listed below
+	// (never silently dropped), but they are not part of the live verdict,
+	// so "1 issue" must not read as two when one of the two is dismissed.
+	n := len(g.Findings) - g.Dismissed
 	count := fmt.Sprintf("%d issues", n)
 	if n == 1 {
 		count = "1 issue"
+	}
+	if g.Dismissed > 0 {
+		count = fmt.Sprintf("%s, %d dismissed", count, g.Dismissed)
 	}
 	fmt.Printf("  %s✗%s %s%s%s %s(%s)%s\n", colorRed, colorReset, colorBold, g.Title, colorReset, colorRed, count, colorReset)
 	for _, s := range g.Stats {
@@ -392,7 +408,11 @@ func renderFailedControl(g findingGroup) {
 	fmt.Printf("\n      %sIssues Found:%s\n", colorYellow, colorReset)
 	for _, f := range g.Findings {
 		tag := severityTag(f.Code)
-		fmt.Printf("        %s [%s] %s\n", tag, f.Code, sanitizeTerminal(f.Message))
+		message := sanitizeTerminal(f.Message)
+		if f.Dismissed {
+			message += " [dismissed on the platform]"
+		}
+		fmt.Printf("        %s [%s] %s\n", tag, f.Code, message)
 		for _, line := range f.DetailLines {
 			fmt.Printf("         └─ %s\n", sanitizeTerminal(line))
 		}

--- a/cmd/render_details_test.go
+++ b/cmd/render_details_test.go
@@ -61,3 +61,40 @@ func TestRenderFindingGroups_NotEvaluableBeatsFindings(t *testing.T) {
 		t.Fatalf("stale findings from a dead lane must not render as a failure:\n%s", out)
 	}
 }
+
+// TestRenderFindingGroups_DismissedFindingTaggedAndExcludedFromCount pins
+// #447 part 2's terminal presentation: a finding the platform dismissed is
+// still shown (never silently dropped), tagged so the reader knows it is
+// not part of the live verdict, and left out of the issue count so "1
+// issue" does not read as two.
+func TestRenderFindingGroups_DismissedFindingTaggedAndExcludedFromCount(t *testing.T) {
+	out := captureStdout(t, func() {
+		renderFindingGroups([]findingGroup{
+			{
+				Title:     "Some Control",
+				Dismissed: 1,
+				Findings: []detailedFinding{
+					{Code: "ISSUE-101", Message: "live one"},
+					{Code: "ISSUE-101", Message: "dismissed one", Dismissed: true},
+				},
+			},
+		})
+	})
+	if !strings.Contains(out, "1 issue, 1 dismissed") {
+		t.Fatalf("want the header to read '1 issue, 1 dismissed', the live count excluding the dismissed finding:\n%s", out)
+	}
+	if !strings.Contains(out, "dismissed one") {
+		t.Fatalf("the dismissed finding must still be shown, never silently dropped:\n%s", out)
+	}
+	dismissedLine := out[strings.Index(out, "dismissed one"):]
+	if idx := strings.Index(dismissedLine, "\n"); idx >= 0 {
+		dismissedLine = dismissedLine[:idx]
+	}
+	if !strings.Contains(dismissedLine, "[dismissed on the platform]") {
+		t.Fatalf("the dismissed finding's own line must carry the platform tag:\n%s", out)
+	}
+	liveLine := out[strings.Index(out, "live one"):strings.Index(out, "dismissed one")]
+	if strings.Contains(liveLine, "[dismissed on the platform]") {
+		t.Fatalf("the live finding must not carry the dismissed tag:\n%s", out)
+	}
+}

--- a/configuration/default_config_unconfigured_test.go
+++ b/configuration/default_config_unconfigured_test.go
@@ -1,0 +1,32 @@
+package configuration
+
+import (
+	"testing"
+
+	defaultconfig "github.com/getplumber/plumber/defaultConfig"
+)
+
+// TestEmbeddedDefaultConfig_EnablesNoUnconfiguredControl pins #459 against the shipped default:
+// the embedded .plumber.yaml (defaultConfig/.plumber.yaml, what a zero-config run and this repo's
+// own dogfooding both extend) must never enable a RequiresConfig control without also setting one
+// of its substantive fields. If it did, the control would silently turn not_evaluable on every
+// default run and on Plumber's own 100/100 self-scan, exactly the vacuous-pass shape #459 exists
+// to catch, just moved from "enabled but empty" to "enabled by the shipped baseline but empty".
+func TestEmbeddedDefaultConfig_EnablesNoUnconfiguredControl(t *testing.T) {
+	pc, _, _, err := LoadPlumberConfigFromBytes(defaultconfig.Get(), "default")
+	if err != nil {
+		t.Fatalf("loading the embedded default config: %v", err)
+	}
+	for _, e := range ControlsCatalog() {
+		if !e.RequiresConfig {
+			continue
+		}
+		for _, provider := range e.Providers {
+			if IsUnconfigured(pc, provider, e.Name) {
+				t.Errorf("#459: the embedded default config enables %s (%s) with no substantive field set; "+
+					"a default run (and this repo's own 100/100 dogfooding) would silently report it not_evaluable",
+					e.Name, provider)
+			}
+		}
+	}
+}

--- a/configuration/schema.go
+++ b/configuration/schema.go
@@ -149,3 +149,93 @@ func ConfigSchemas() []ControlConfigSchema {
 	sort.Slice(out, func(i, j int) bool { return out[i].Control < out[j].Control })
 	return out
 }
+
+// IsUnconfigured reports whether controlName is enabled in pc but asserts nothing because none of
+// its substantive fields is set (#459): the control is RequiresConfig in the catalog, applicable
+// to provider, its block is present and enabled, and every field other than `enabled` is at its
+// zero value (nil pointer, empty slice or map, "", 0, false; a nested struct is zero when all of
+// its fields are). The field enumeration is the SAME reflection the catalog exports
+// (reflectControlSchemas), so a field the schema shows is a field this check reads. False for a
+// control that is not RequiresConfig, does not apply to provider, is disabled, or has no block:
+// those are "asserts something" or "skipped", never "unconfigured".
+func IsUnconfigured(pc *PlumberConfig, provider, controlName string) bool {
+	if pc == nil {
+		return false
+	}
+	meta, ok := ControlMetaFor(controlName)
+	if !ok || !meta.RequiresConfig || !IsControlApplicableTo(controlName, provider) {
+		return false
+	}
+	block := controlBlock(pc, provider, controlName)
+	if !block.IsValid() || block.IsNil() {
+		return false
+	}
+	en, ok := block.Interface().(interface{ IsEnabled() bool })
+	if !ok || !en.IsEnabled() {
+		return false
+	}
+	return substantiveFieldsAreZero(block.Elem())
+}
+
+// controlBlock returns the reflect.Value of controlName's config-struct pointer field on
+// provider's ControlsConfig, or an invalid Value if the control is not one of ControlsConfig's
+// fields, or that field is not pointer-typed (every control block is a pointer today; the guard
+// is here so a future value-typed field returns "no block" instead of panicking the IsNil() check
+// IsUnconfigured makes on the result). Walks the same yamlName-keyed fields reflectControlSchemas
+// does, so the two can never disagree about which field is which control's.
+func controlBlock(pc *PlumberConfig, provider, controlName string) reflect.Value {
+	cc := pc.ControlsFor(provider)
+	v := reflect.ValueOf(cc)
+	if !v.IsValid() || v.IsNil() {
+		return reflect.Value{}
+	}
+	v = v.Elem()
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		if yamlName(t.Field(i)) != controlName {
+			continue
+		}
+		fv := v.Field(i)
+		if fv.Kind() != reflect.Ptr {
+			return reflect.Value{}
+		}
+		return fv
+	}
+	return reflect.Value{}
+}
+
+// substantiveFieldsAreZero reports whether every field of the config struct v, other than the one
+// yaml-named `enabled`, is at its zero value. A field that is itself a pointer-to-struct (a nested
+// config block, e.g. SecurityJobsSubControlToggle) is walked with the SAME rule rather than judged
+// by pointer-nilness alone: a non-nil pointer to a struct whose own fields are all zero once ITS
+// `enabled` is excluded is zero here too. That matters because a nested block that sets nothing but
+// its own `enabled` toggles nothing substantive: e.g.
+// securityJobsMustNotBeWeakened: {enabled: true, allowFailureMustBeFalse: {enabled: false}} sets no
+// SecurityJobPatterns and turns no sub-check on, so the control is still unconfigured, matching the
+// same reading `enabled: true` alone gets at the top level.
+func substantiveFieldsAreZero(v reflect.Value) bool {
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		name := yamlName(f)
+		if name == "" || name == "enabled" {
+			continue
+		}
+		fv := v.Field(i)
+		switch {
+		case fv.Kind() == reflect.Ptr && fv.Type().Elem().Kind() == reflect.Struct:
+			if !fv.IsNil() && !substantiveFieldsAreZero(fv.Elem()) {
+				return false
+			}
+		case fv.Kind() == reflect.Struct:
+			if !substantiveFieldsAreZero(fv) {
+				return false
+			}
+		default:
+			if !fv.IsZero() {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/configuration/schema.go
+++ b/configuration/schema.go
@@ -178,25 +178,33 @@ func IsUnconfigured(pc *PlumberConfig, provider, controlName string) bool {
 }
 
 // controlBlock returns the reflect.Value of controlName's config-struct pointer field on
-// provider's ControlsConfig, or an invalid Value if the control is not one of ControlsConfig's
-// fields, or that field is not pointer-typed (every control block is a pointer today; the guard
-// is here so a future value-typed field returns "no block" instead of panicking the IsNil() check
-// IsUnconfigured makes on the result). Walks the same yamlName-keyed fields reflectControlSchemas
-// does, so the two can never disagree about which field is which control's.
+// provider's ControlsConfig, or an invalid Value if there is no such field or it does not have
+// the shape a control block has. Walks the same yamlName-keyed fields reflectControlSchemas does,
+// so the two can never disagree about which field is which control's.
 func controlBlock(pc *PlumberConfig, provider, controlName string) reflect.Value {
 	cc := pc.ControlsFor(provider)
 	v := reflect.ValueOf(cc)
 	if !v.IsValid() || v.IsNil() {
 		return reflect.Value{}
 	}
-	v = v.Elem()
+	return structPointerField(v.Elem(), controlName)
+}
+
+// structPointerField returns the field of struct value v whose yaml name is name, provided it is
+// a POINTER TO A STRUCT, and an invalid Value otherwise. Both halves of that condition are load
+// bearing: the caller dereferences the result and walks it with NumField (substantiveFieldsAreZero),
+// which panics on a pointer to anything else, and calls IsNil on it, which panics on a
+// non-pointer. Every control block is a pointer to a struct today, so this only ever fires on a
+// future field of a different shape - which then reads as "no block", the honest answer, instead
+// of taking the process down.
+func structPointerField(v reflect.Value, name string) reflect.Value {
 	t := v.Type()
 	for i := 0; i < t.NumField(); i++ {
-		if yamlName(t.Field(i)) != controlName {
+		if yamlName(t.Field(i)) != name {
 			continue
 		}
 		fv := v.Field(i)
-		if fv.Kind() != reflect.Ptr {
+		if fv.Kind() != reflect.Ptr || fv.Type().Elem().Kind() != reflect.Struct {
 			return reflect.Value{}
 		}
 		return fv
@@ -229,6 +237,13 @@ func substantiveFieldsAreZero(v reflect.Value) bool {
 			}
 		case fv.Kind() == reflect.Struct:
 			if !substantiveFieldsAreZero(fv) {
+				return false
+			}
+		case fv.Kind() == reflect.Slice || fv.Kind() == reflect.Map:
+			// reflect.Value.IsZero() on a Slice/Map is IsNil(): yaml.v2 decodes an explicit
+			// `[]` / `{}` into a non-nil, zero-length value, so IsZero() alone would read that
+			// as "set". Treat zero-length the same as nil here to match the doc comment above.
+			if fv.Len() != 0 {
 				return false
 			}
 		default:

--- a/configuration/schema_test.go
+++ b/configuration/schema_test.go
@@ -73,3 +73,35 @@ func TestReflectControlSchemas(t *testing.T) {
 		}
 	})
 }
+
+// controlBlockGuardFixture stands in for a ControlsConfig that has drifted: every control block
+// is a pointer to a struct today, and the two other shapes below are what a future field could
+// look like. Reflection cannot be type-checked at compile time, so the guard needs a fixture
+// that actually has the wrong shapes.
+type controlBlockGuardFixture struct {
+	Block *struct {
+		Enabled *bool `yaml:"enabled"`
+	} `yaml:"blockControl"`
+	Count *int `yaml:"countControl"`
+	Plain int  `yaml:"plainControl"`
+}
+
+// TestStructPointerField_OnlyAcceptsAPointerToStruct pins the guard IsUnconfigured depends on:
+// the value it gets back is dereferenced and walked with NumField, which panics on a pointer to
+// anything that is not a struct. "No block" is the honest answer for a field of any other shape,
+// and it is the answer that makes the control fall through to "asserts something" rather than
+// taking the process down.
+func TestStructPointerField_OnlyAcceptsAPointerToStruct(t *testing.T) {
+	fixture := reflect.ValueOf(&controlBlockGuardFixture{}).Elem()
+
+	got := structPointerField(fixture, "blockControl")
+	if !got.IsValid() || got.Kind() != reflect.Ptr || got.Type().Elem().Kind() != reflect.Struct {
+		t.Fatalf("blockControl = %v, want the pointer-to-struct field itself", got)
+	}
+
+	for _, name := range []string{"countControl", "plainControl", "noSuchControl"} {
+		if got := structPointerField(fixture, name); got.IsValid() {
+			t.Errorf("%s = %v, want an invalid Value: only a pointer to a struct can be walked", name, got)
+		}
+	}
+}

--- a/configuration/unconfigured_test.go
+++ b/configuration/unconfigured_test.go
@@ -1,0 +1,169 @@
+package configuration
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+// TestIsUnconfigured pins #459: a RequiresConfig control enabled with no substantive field is
+// unconfigured; one substantive field, a non-RequiresConfig control, a disabled control and a
+// nil block are not.
+func TestIsUnconfigured(t *testing.T) {
+	requires := firstRequiresConfigControl(t) // helper: first ControlsCatalog() entry with RequiresConfig, plus its provider
+	pcBare := plumberConfigWith(t, requires.Provider, requires.Name, map[string]interface{}{"enabled": true})
+	if !IsUnconfigured(pcBare, requires.Provider, requires.Name) {
+		t.Errorf("#459: %s with enabled:true only must be unconfigured", requires.Name)
+	}
+	pcSet := plumberConfigWith(t, requires.Provider, requires.Name, substantiveExample(t, requires.Name))
+	if IsUnconfigured(pcSet, requires.Provider, requires.Name) {
+		t.Errorf("#459: %s with a substantive field set must not be unconfigured", requires.Name)
+	}
+	plain := firstControlWhere(t, func(e ControlMeta) bool { return !e.RequiresConfig })
+	pcPlain := plumberConfigWith(t, plain.Provider, plain.Name, map[string]interface{}{"enabled": true})
+	if IsUnconfigured(pcPlain, plain.Provider, plain.Name) {
+		t.Errorf("#459: a control that asserts something unconfigured is never unconfigured")
+	}
+	pcOff := plumberConfigWith(t, requires.Provider, requires.Name, map[string]interface{}{"enabled": false})
+	if IsUnconfigured(pcOff, requires.Provider, requires.Name) {
+		t.Error("#459: a disabled control is skipped, not unconfigured")
+	}
+	if IsUnconfigured(&PlumberConfig{}, requires.Provider, requires.Name) {
+		t.Error("#459: an absent block is skipped, not unconfigured")
+	}
+}
+
+// TestIsUnconfigured_NestedToggleSettingOnlyItsOwnEnabledIsNotSubstantive pins the nested-struct
+// half of #459: a sub-control toggle block that sets nothing but its OWN `enabled` field turns no
+// sub-check on, so it does not make the parent control substantive either, matching the same
+// reading a bare top-level `enabled: true` gets. securityJobsMustNotBeWeakened is the one control
+// with a pointer-to-struct field beyond `enabled` in the catalog, which is why it is used here.
+func TestIsUnconfigured_NestedToggleSettingOnlyItsOwnEnabledIsNotSubstantive(t *testing.T) {
+	pc := plumberConfigWith(t, "gitlab", "securityJobsMustNotBeWeakened", map[string]interface{}{
+		"enabled": true,
+		"allowFailureMustBeFalse": map[string]interface{}{
+			"enabled": false,
+		},
+	})
+	if !IsUnconfigured(pc, "gitlab", "securityJobsMustNotBeWeakened") {
+		t.Error("#459: a sub-control toggle setting only its own enabled field turns nothing on and must be unconfigured")
+	}
+
+	pcSubstantive := plumberConfigWith(t, "gitlab", "securityJobsMustNotBeWeakened", map[string]interface{}{
+		"enabled":             true,
+		"securityJobPatterns": []interface{}{"secret_scan"},
+	})
+	if IsUnconfigured(pcSubstantive, "gitlab", "securityJobsMustNotBeWeakened") {
+		t.Error("#459: a securityJobPatterns entry is a substantive field and must not be unconfigured")
+	}
+}
+
+// requiresConfigControl is a (name, provider) pair picked out of ControlsCatalog() for the test
+// helpers below: enough to build a minimal .plumber.yaml fixture and call IsUnconfigured.
+type requiresConfigControl struct {
+	Name     string
+	Provider string
+}
+
+// firstRequiresConfigControl returns the first catalog entry with RequiresConfig true, paired
+// with one of the providers it applies to.
+func firstRequiresConfigControl(t *testing.T) requiresConfigControl {
+	t.Helper()
+	return firstControlWhere(t, func(e ControlMeta) bool { return e.RequiresConfig })
+}
+
+// firstControlWhere returns the first catalog entry matching pred, paired with one of the
+// providers it applies to.
+func firstControlWhere(t *testing.T, pred func(ControlMeta) bool) requiresConfigControl {
+	t.Helper()
+	for _, e := range ControlsCatalog() {
+		if pred(e.ControlMeta) && len(e.Providers) > 0 {
+			return requiresConfigControl{Name: e.Name, Provider: e.Providers[0]}
+		}
+	}
+	t.Fatal("no control matched the predicate")
+	return requiresConfigControl{}
+}
+
+// plumberConfigWith builds a v2 PlumberConfig with a single control block, provider and control
+// name given, its fields the ones supplied. Goes through the real YAML loader so the fixture is
+// exercised the same way a user's .plumber.yaml would be.
+func plumberConfigWith(t *testing.T, provider, controlName string, fields map[string]interface{}) *PlumberConfig {
+	t.Helper()
+	doc := map[string]interface{}{
+		"version": "2.0",
+		provider: map[string]interface{}{
+			"controls": map[string]interface{}{
+				controlName: fields,
+			},
+		},
+	}
+	data, err := yaml.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	pc, _, _, err := LoadPlumberConfigFromBytes(data, "test")
+	if err != nil {
+		t.Fatalf("load fixture: %v\n%s", err, data)
+	}
+	return pc
+}
+
+// substantiveExample returns a control block (enabled, plus its first non-`enabled` field set to
+// a non-zero value of its type) built from the control's own reflected schema, so the fixture can
+// never drift from the real config struct.
+func substantiveExample(t *testing.T, controlName string) map[string]interface{} {
+	t.Helper()
+	schema, ok := ConfigSchemaFor(controlName)
+	if !ok {
+		t.Fatalf("no config schema for %s", controlName)
+	}
+	for _, f := range schema.Fields {
+		if f.Name == "enabled" {
+			continue
+		}
+		return map[string]interface{}{
+			"enabled": true,
+			f.Name:    nonZeroValue(t, f),
+		}
+	}
+	t.Fatalf("schema for %s has no field beyond enabled", controlName)
+	return nil
+}
+
+// nonZeroValue builds a value of f's reflected type that is not its zero value. An object field
+// with no fixed sub-fields (a map) gets a single synthetic key; an object field with sub-fields
+// (a nested struct) recurses to its first leaf, since an empty object `{}` is itself zero.
+func nonZeroValue(t *testing.T, f SchemaField) interface{} {
+	t.Helper()
+	switch f.Type {
+	case "string":
+		return "x"
+	case "bool":
+		return true
+	case "integer", "number":
+		return 1
+	case "array":
+		if f.Elem != nil {
+			return []interface{}{nonZeroValue(t, *f.Elem)}
+		}
+		return []interface{}{"x"}
+	case "object":
+		if len(f.Fields) == 0 {
+			if f.Elem != nil {
+				return map[string]interface{}{"x": nonZeroValue(t, *f.Elem)}
+			}
+			return map[string]interface{}{"x": "x"}
+		}
+		for _, nf := range f.Fields {
+			if nf.Name == "enabled" {
+				continue
+			}
+			return map[string]interface{}{nf.Name: nonZeroValue(t, nf)}
+		}
+		t.Fatalf("object field %s has no non-enabled sub-field to set", f.Name)
+		return nil
+	default:
+		return "x"
+	}
+}

--- a/configuration/unconfigured_test.go
+++ b/configuration/unconfigured_test.go
@@ -58,6 +58,21 @@ func TestIsUnconfigured_NestedToggleSettingOnlyItsOwnEnabledIsNotSubstantive(t *
 	}
 }
 
+// TestIsUnconfigured_ExplicitEmptySliceIsZero pins the "empty slice or map" half of the
+// IsUnconfigured doc comment: yaml.v2 decodes an explicit `namePatterns: []` into a non-nil,
+// zero-length slice, which reflect.Value.IsZero() would read as "set" (IsZero on a slice is
+// IsNil). branchMustBeProtected.namePatterns must still count as not substantive, so the control
+// is still unconfigured.
+func TestIsUnconfigured_ExplicitEmptySliceIsZero(t *testing.T) {
+	pc := plumberConfigWith(t, "gitlab", "branchMustBeProtected", map[string]interface{}{
+		"enabled":      true,
+		"namePatterns": []interface{}{},
+	})
+	if !IsUnconfigured(pc, "gitlab", "branchMustBeProtected") {
+		t.Error("#459: an explicit empty namePatterns list sets nothing substantive and must be unconfigured")
+	}
+}
+
 // requiresConfigControl is a (name, provider) pair picked out of ControlsCatalog() for the test
 // helpers below: enough to build a minimal .plumber.yaml fixture and call IsUnconfigured.
 type requiresConfigControl struct {

--- a/control/dismissed.go
+++ b/control/dismissed.go
@@ -1,0 +1,82 @@
+package control
+
+import (
+	"github.com/getplumber/plumber/finding/identity"
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
+	"github.com/getplumber/plumber/internal/platform"
+	"github.com/sirupsen/logrus"
+)
+
+// ControlKeyFor names a finding's control the same way platformFindingControlName
+// (cmd/platform_push.go) names it when the finding is PUSHED: the registry lookup's
+// ControlName when the code is known, the raw code string otherwise. The two sides
+// must agree on this fallback, or a finding whose code the CLI's own registry cannot
+// classify would be pushed under its raw code but never matched back against a
+// dismissed entry the platform served under that same raw code.
+//
+// Exported so cmd/platform_push.go's platformFindingControlName calls this SAME
+// function rather than re-deriving the fallback independently: two copies of "look
+// up the code, else use it raw" can only drift, and a drift here means the push and
+// the matcher disagree about a control's name for exactly the findings that most
+// need them to agree (the unregistered ones).
+func ControlKeyFor(code string) string {
+	if info := LookupCode(ErrorCode(code)); info != nil {
+		return info.ControlName
+	}
+	return code
+}
+
+// MarkDismissed sets Dismissed on every finding whose platform identity matches a served
+// dismissed issue (#447) and returns how many it marked. Entries served under another recipe
+// version are skipped (honest non-suppression, never a cross-version match); control_type is
+// used only to avoid hashing a finding against entries of other controls, keyed by controlKeyFor
+// so it agrees with the raw-code fallback the push side uses. A codeless finding has no identity
+// (identity.PlatformHash reports !ok) and never matches. The marker is a claim about what
+// /context served; the platform's stored issue status stays the authority.
+//
+// Served entries (after the version filter) that matched no finding at all are counted and
+// logged at Debug, so a systematic mismatch between what the platform served and what this run
+// produced is at least diagnosable, not silently absorbed.
+func MarkDismissed(findings []opaengine.Finding, served []platform.DismissedIssue) int {
+	if len(served) == 0 {
+		return 0
+	}
+	byControl := map[string]map[string]struct{}{}
+	total := 0
+	for _, d := range served {
+		if d.RecipeVersion != identity.RecipeVersion {
+			continue
+		}
+		set, ok := byControl[d.ControlType]
+		if !ok {
+			set = map[string]struct{}{}
+			byControl[d.ControlType] = set
+		}
+		if _, dup := set[d.IdentityHash]; !dup {
+			set[d.IdentityHash] = struct{}{}
+			total++
+		}
+	}
+	matched := map[string]struct{}{}
+	marked := 0
+	for i := range findings {
+		key := ControlKeyFor(findings[i].Code)
+		set, ok := byControl[key]
+		if !ok {
+			continue
+		}
+		hash, _, ok := identity.PlatformHash(findings[i].IdentityInput())
+		if !ok {
+			continue
+		}
+		if _, hit := set[hash]; hit {
+			findings[i].Dismissed = true
+			marked++
+			matched[key+"\x00"+hash] = struct{}{}
+		}
+	}
+	if unmatched := total - len(matched); unmatched > 0 {
+		logrus.Debugf("dismissed_issues: %d served entries matched no finding", unmatched)
+	}
+	return marked
+}

--- a/control/dismissed_test.go
+++ b/control/dismissed_test.go
@@ -1,0 +1,115 @@
+package control
+
+import (
+	"testing"
+
+	"github.com/getplumber/plumber/finding/identity"
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
+	"github.com/getplumber/plumber/internal/platform"
+)
+
+// platformHashOf computes the platform digest via the same identity.PlatformHash the
+// production code calls: reusing it here is deliberate, not a shortcut, since the digest's
+// bit-for-bit stability is pinned separately by the golden test in
+// finding/identity/platformhash_test.go. What the tests in this file exercise is
+// MarkDismissed's own matching logic on top of that hash: recipe-version gating, the control
+// pre-filter (and its raw-code fallback), and that a codeless finding never matches.
+func platformHashOf(t *testing.T, f opaengine.Finding) string {
+	t.Helper()
+	hash, _, ok := identity.PlatformHash(f.IdentityInput())
+	if !ok {
+		t.Fatalf("fixture finding %+v must have an identity", f)
+	}
+	return hash
+}
+
+// TestMarkDismissed_MatchesOneEntryAmongDistractors pins #447: MarkDismissed marks exactly the
+// findings whose platform identity hash appears in the served list, under the current recipe
+// version, under their own control. A version mismatch, a different control's bucket, and a
+// codeless finding must never count as a match.
+func TestMarkDismissed_MatchesOneEntryAmongDistractors(t *testing.T) {
+	findingX := opaengine.Finding{Code: "ISSUE-103", File: ".gitlab-ci.yml", Job: "build"}
+	findingY := opaengine.Finding{Code: "ISSUE-701", File: ".github/workflows/ci.yml", Job: "build"}
+	codeless := opaengine.Finding{File: "whatever.yml"}
+
+	findings := []opaengine.Finding{findingX, findingY, codeless}
+
+	served := []platform.DismissedIssue{
+		// (a) matches findingX: right hash, right recipe version, right control.
+		{
+			IdentityHash:  platformHashOf(t, findingX),
+			RecipeVersion: identity.RecipeVersion,
+			ControlType:   "containerImageMustNotUseForbiddenTags",
+		},
+		// (b) findingY's own hash, but served under an old recipe version: skipped, honest
+		// non-suppression, never a cross-version match.
+		{
+			IdentityHash:  platformHashOf(t, findingY),
+			RecipeVersion: identity.RecipeVersion - 1,
+			ControlType:   "actionsMustBePinnedByCommitSha",
+		},
+		// (c) findingX's own hash again, but filed under a different control: control_type is a
+		// pre-filter, so this entry sits in another bucket and is never compared against findingX.
+		{
+			IdentityHash:  platformHashOf(t, findingX),
+			RecipeVersion: identity.RecipeVersion,
+			ControlType:   "actionsMustBePinnedByCommitSha",
+		},
+	}
+
+	marked := MarkDismissed(findings, served)
+	if marked != 1 {
+		t.Fatalf("MarkDismissed returned %d, want 1", marked)
+	}
+	if !findings[0].Dismissed {
+		t.Error("findingX must be marked dismissed")
+	}
+	if findings[1].Dismissed {
+		t.Error("findingY must not be marked dismissed: its only served entry is under an old recipe version")
+	}
+	if findings[2].Dismissed {
+		t.Error("a codeless finding must never be marked dismissed")
+	}
+}
+
+// A code the registry does not classify is still pushed to the platform, under its raw code
+// (platformFindingControlName, cmd/platform_push.go): a dismissed entry served under that same
+// raw code as control_type must still match. Without the fallback in controlKeyFor, such a
+// finding could never be re-matched after the platform served it back.
+func TestMarkDismissed_UnknownCodeMatchesUnderItsRawCode(t *testing.T) {
+	unknown := opaengine.Finding{Code: "ISSUE-999999-UNKNOWN", File: "whatever.yml"}
+	findings := []opaengine.Finding{unknown}
+	served := []platform.DismissedIssue{
+		{
+			IdentityHash:  platformHashOf(t, unknown),
+			RecipeVersion: identity.RecipeVersion,
+			ControlType:   "ISSUE-999999-UNKNOWN",
+		},
+	}
+
+	marked := MarkDismissed(findings, served)
+	if marked != 1 {
+		t.Fatalf("MarkDismissed returned %d, want 1", marked)
+	}
+	if !findings[0].Dismissed {
+		t.Error("a finding with an unregistered code must still match a served entry filed under its raw code")
+	}
+}
+
+// An empty served list is the standalone-mode / nothing-cached case: it must mark nothing and
+// never panic on a finding with no code.
+func TestMarkDismissed_EmptyServedListMarksNothing(t *testing.T) {
+	findings := []opaengine.Finding{
+		{Code: "ISSUE-103", File: ".gitlab-ci.yml", Job: "build"},
+		{File: "whatever.yml"},
+	}
+	marked := MarkDismissed(findings, nil)
+	if marked != 0 {
+		t.Fatalf("MarkDismissed returned %d, want 0", marked)
+	}
+	for i, f := range findings {
+		if f.Dismissed {
+			t.Errorf("findings[%d] must not be marked dismissed with an empty served list", i)
+		}
+	}
+}

--- a/control/lanes.go
+++ b/control/lanes.go
@@ -82,6 +82,14 @@ const (
 	// token without the scope for one endpoint is not a platform-mode
 	// condition.
 	ReasonCollectionFailed = "collection_failed"
+
+	// ReasonConfigRequired: the control is enabled but none of its
+	// substantive configuration fields is set, so it asserts nothing
+	// (getplumber/plumber#459, platform decision-queue row 19: honest
+	// not_evaluable, never a vacuous pass). Which controls can be in this
+	// state is authored truth (configuration.ControlMeta.RequiresConfig);
+	// which fields count is the catalog's own reflected schema.
+	ReasonConfigRequired = "config_required"
 )
 
 // controlsRequiringIncludeAttribution lists the GitLab controls whose
@@ -322,6 +330,24 @@ func MarkOwnCollectionGaps(result *AnalysisResult, entries []ControlEntry) {
 	if rawConfigUnavailable(result) {
 		markOne("pipelineMustNotOverrideJobVariables", ReasonRawConfigUnavailable)
 		markOne("pipelineMustNotIncludeHardcodedJobs", ReasonRawConfigUnavailable)
+	}
+	result.DropNotEvaluableFindings()
+}
+
+// MarkUnconfiguredControls flags every non-skipped RequiresConfig control whose enabled block sets
+// no substantive field (#459). Runs AFTER the lane-gap marks: a lane gap is the more specific
+// explanation and MarkNotEvaluable keeps the first reason.
+func MarkUnconfiguredControls(result *AnalysisResult, entries []ControlEntry, pc *configuration.PlumberConfig, provider string) {
+	if result == nil || pc == nil {
+		return
+	}
+	for _, e := range entries {
+		if e.Skipped {
+			continue
+		}
+		if configuration.IsUnconfigured(pc, provider, e.ControlName) {
+			result.MarkNotEvaluable(e.ControlName, ReasonConfigRequired)
+		}
 	}
 	result.DropNotEvaluableFindings()
 }
@@ -708,6 +734,18 @@ func ReEvaluateForConfig(
 	if provider == configuration.ProviderGitLab {
 		markPlatformLaneGapsFor(&scopedResult, &scopedConf, pc)
 	}
+	// An enabled-but-unconfigured control (#459) asserts nothing under ANY config, but which
+	// control that is depends on the policy's own tree just like the lane gaps above: the same
+	// re-marking is needed here, against the policy's own entries, or a control this policy
+	// leaves unconfigured would be scored as a vacuous pass instead of not_evaluable.
+	var entries []ControlEntry
+	switch provider {
+	case configuration.ProviderGitLab:
+		entries = GitLabControls(pc)
+	case configuration.ProviderGitHub:
+		entries = GitHubControls(pc)
+	}
+	MarkUnconfiguredControls(&scopedResult, entries, pc, provider)
 	scopedResult.DropNotEvaluableFindings()
 
 	counts := map[ErrorCode]int{}

--- a/control/lanes.go
+++ b/control/lanes.go
@@ -2,6 +2,7 @@ package control
 
 import (
 	"github.com/getplumber/plumber/configuration"
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
 	"github.com/getplumber/plumber/internal/ir"
 	"github.com/getplumber/plumber/internal/platform"
 )
@@ -748,8 +749,25 @@ func ReEvaluateForConfig(
 	MarkUnconfiguredControls(&scopedResult, entries, pc, provider)
 	scopedResult.DropNotEvaluableFindings()
 
+	// #447: these findings are fresh out of evaluatePolicies and still carry
+	// whatever File the rule engine reported (a GitHub-style absolute path
+	// via job.OriginFile, say) - NOT yet the repo-relative form the run-level
+	// path produces via cmd/analyze_shared.go's own StampFingerprints call.
+	// The platform hashed the STAMPED (repo-relative) file of the finding it
+	// was pushed, so matching against these findings before stamping them
+	// the same way would compare against a different identity and never
+	// match. Stamping here also fills Fingerprint, which a per-policy push
+	// previously sent empty.
+	opaengine.StampFingerprints(scopedResult.Findings, conf.GitRepoRoot)
+	if conf.PlatformRun != nil && conf.PlatformRun.Context != nil {
+		MarkDismissed(scopedResult.Findings, conf.PlatformRun.Context.DismissedIssues)
+	}
+
 	counts := map[ErrorCode]int{}
 	for _, f := range scopedResult.Findings {
+		if f.Dismissed {
+			continue
+		}
 		counts[ErrorCode(f.Code)]++
 	}
 	// The whole scoped result is returned, not just its findings. The marks

--- a/control/platform_call_inventory_test.go
+++ b/control/platform_call_inventory_test.go
@@ -274,6 +274,7 @@ gitlab:
       enabled: true
     pipelineMustNotOverrideJobVariables:
       enabled: true
+      variables: [CI_JOB_TOKEN]
 `
 
 // platformSnapshot builds the RunContext a fully-served platform run has:

--- a/control/scoring.go
+++ b/control/scoring.go
@@ -79,6 +79,13 @@ func forEachIssueCode(result *AnalysisResult, fn func(ErrorCode)) {
 		return
 	}
 	for _, f := range result.Findings {
+		if f.Dismissed {
+			// #447: out of the score like not_evaluable, never counted as a
+			// live occurrence. The single skip here is what keeps every
+			// reader of forEachIssueCode (AggregateIssueCodeCounts,
+			// CriticalIssueCodesSorted, and any future one) in agreement.
+			continue
+		}
 		fn(ErrorCode(f.Code))
 	}
 }

--- a/control/scoring_dismissed_test.go
+++ b/control/scoring_dismissed_test.go
@@ -1,0 +1,197 @@
+package control
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+	defaultconfig "github.com/getplumber/plumber/defaultConfig"
+	"github.com/getplumber/plumber/finding/identity"
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
+	"github.com/getplumber/plumber/internal/ir"
+	"github.com/getplumber/plumber/internal/platform"
+)
+
+// TestAggregateIssueCodeCounts_SkipsDismissedFindings pins #447 part 2: a
+// finding the platform dismissed is out of the score, the same as
+// not_evaluable, never counted toward its code's tally. Two findings of the
+// same code, one dismissed, must count as one.
+func TestAggregateIssueCodeCounts_SkipsDismissedFindings(t *testing.T) {
+	result := &AnalysisResult{
+		Findings: []opaengine.Finding{
+			{Code: string(CodeImpostorCommit)},
+			{Code: string(CodeImpostorCommit), Dismissed: true},
+		},
+	}
+	counts := AggregateIssueCodeCounts(result)
+	if got := counts[CodeImpostorCommit]; got != 1 {
+		t.Fatalf("counts[%s] = %d, want 1 (the dismissed duplicate must not count)", CodeImpostorCommit, got)
+	}
+}
+
+// TestCriticalIssueCodesSorted_StillListsCodeWhenLiveFindingRemains documents
+// the deliberate asymmetry: forEachIssueCode skips a dismissed finding for
+// EVERY reader (AggregateIssueCodeCounts and CriticalIssueCodesSorted alike,
+// since both walk through it), so a code stays "present" only because a
+// LIVE finding of it survives, not because the dismissed one is still
+// silently counted here while excluded from the score elsewhere.
+func TestCriticalIssueCodesSorted_StillListsCodeWhenLiveFindingRemains(t *testing.T) {
+	result := &AnalysisResult{
+		Findings: []opaengine.Finding{
+			{Code: string(CodeImpostorCommit)},
+			{Code: string(CodeImpostorCommit), Dismissed: true},
+		},
+	}
+	got := CriticalIssueCodesSorted(result)
+	if len(got) != 1 || got[0] != string(CodeImpostorCommit) {
+		t.Fatalf("CriticalIssueCodesSorted = %v, want [%s]: the live finding must keep the code listed", got, CodeImpostorCommit)
+	}
+}
+
+// TestCriticalIssueCodesSorted_OmitsCodeWhenAllDismissed is the other half:
+// when every finding of a code is dismissed, the code must not appear at
+// all: the shared skip in forEachIssueCode is what keeps
+// AggregateIssueCodeCounts and CriticalIssueCodesSorted from disagreeing.
+func TestCriticalIssueCodesSorted_OmitsCodeWhenAllDismissed(t *testing.T) {
+	result := &AnalysisResult{
+		Findings: []opaengine.Finding{
+			{Code: string(CodeImpostorCommit), Dismissed: true},
+		},
+	}
+	got := CriticalIssueCodesSorted(result)
+	if len(got) != 0 {
+		t.Fatalf("CriticalIssueCodesSorted = %v, want none: every finding of the code was dismissed", got)
+	}
+}
+
+// TestReEvaluateForConfig_DismissedFindingExcludedFromScore drives the real
+// per-policy path end to end: a served dismissed entry matching one of the
+// findings the policy's own re-evaluation produces must make the returned
+// score equal the score of the same evaluation with that finding removed
+// entirely, not merely reduced.
+//
+// The fixture job's OriginFile is deliberately an ABSOLUTE path under a temp
+// repo root, exactly what evaluatePolicies hands back before any stamping:
+// enrichFindingsWithJobLocation fills a codeless-location finding's File
+// from job.OriginFile verbatim, unstamped. The served dismissal is hashed
+// over the REPO-RELATIVE form instead, matching what the run-level path
+// pushes (cmd/analyze_shared.go stamps before MarkDismissed runs there). If
+// ReEvaluateForConfig marks against the raw, still-absolute File, the two
+// hashes never agree and the finding survives in the score; only stamping
+// scopedResult.Findings to repo-relative form BEFORE hashing closes that.
+//
+// GitHub is used deliberately: markPlatformLaneGapsFor only runs for
+// "gitlab", so engaging conf.PlatformRun.Context here (required for the
+// MarkDismissed guard) cannot also trip the include-attribution gap marking
+// and drop the fixture's own finding as not_evaluable for an unrelated
+// reason.
+func TestReEvaluateForConfig_DismissedFindingExcludedFromScore(t *testing.T) {
+	pc, _, _, err := configuration.LoadPlumberConfigFromBytes(defaultconfig.Get(), "test-default")
+	if err != nil {
+		t.Fatalf("LoadPlumberConfigFromBytes: %v", err)
+	}
+
+	repoRoot := t.TempDir()
+	relOriginFile := filepath.Join(".github", "workflows", "release.yml")
+	absOriginFile := filepath.Join(repoRoot, relOriginFile)
+
+	// actions/cache on a release-triggered job with an unscoped key: fires
+	// releaseWorkflowsMustNotRestoreUntrustedCache (ISSUE-705), pinned by
+	// TestCachePoisoningConfigContract as a real rego violation through the
+	// same embedded default config. OriginFile is what enrichFindingsWithJobLocation
+	// copies onto the finding's own File field when the rule itself sets none,
+	// which cache_poisoning.rego does not.
+	pipeline := &ir.NormalizedPipeline{Provider: ir.ProviderGitHub, Jobs: []ir.Job{{
+		Name:       "publish",
+		Triggers:   []string{"release"},
+		OriginFile: absOriginFile,
+		Uses:       []ir.Action{{Uses: "actions/cache@v4", With: map[string]any{"key": "deps-abc", "path": "~/.npm"}}},
+	}}}
+
+	// Baseline: no GitRepoRoot, so StampFingerprints' own repoRelative leaves
+	// an absolute File exactly as-is (root=="" is its explicit no-op case).
+	// This is only used to enumerate the OTHER findings the fixture produces,
+	// to build the "same evaluation minus ISSUE-705" expected score below.
+	baselineConf := &configuration.Configuration{PlumberConfig: pc}
+	baseline, _, ok := ReEvaluateForConfig(&AnalysisResult{CiValid: true, GitHubPipeline: pipeline}, baselineConf, "github", pc)
+	if !ok {
+		t.Fatal("baseline re-evaluation must succeed")
+	}
+	var target opaengine.Finding
+	found := false
+	for _, f := range baseline.Findings {
+		if f.Code == "ISSUE-705" {
+			target = f
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("fixture must produce ISSUE-705, got %+v", baseline.Findings)
+	}
+	if target.File != filepath.ToSlash(absOriginFile) {
+		t.Fatalf("baseline finding.File = %q, want the unstamped absolute origin %q (fixture assumption broken)", target.File, absOriginFile)
+	}
+
+	// Hash the REPO-RELATIVE form: this is what the platform actually
+	// hashed for the pushed finding (the run-level path stamps before
+	// pushing), not the raw absolute path evaluatePolicies produces.
+	relFinding := target
+	relFinding.File = filepath.ToSlash(relOriginFile)
+	hash, _, ok := identity.PlatformHash(relFinding.IdentityInput())
+	if !ok {
+		t.Fatal("the ISSUE-705 finding must carry a platform identity")
+	}
+
+	// The expected score: the baseline findings with every ISSUE-705 entry
+	// removed, scored directly, not merely "one fewer occurrence" but the
+	// exact same computation MarkDismissed's skip is meant to reproduce.
+	wantCounts := map[ErrorCode]int{}
+	for _, f := range baseline.Findings {
+		if f.Code == "ISSUE-705" {
+			continue
+		}
+		wantCounts[ErrorCode(f.Code)]++
+	}
+	want := ComputePlumberScore(wantCounts)
+
+	dismissedConf := &configuration.Configuration{
+		PlumberConfig: pc,
+		GitRepoRoot:   repoRoot,
+		PlatformRun: &platform.RunContext{
+			Context: &platform.ProjectContext{
+				DismissedIssues: []platform.DismissedIssue{{
+					IdentityHash:  hash,
+					RecipeVersion: identity.RecipeVersion,
+					ControlType:   "releaseWorkflowsMustNotRestoreUntrustedCache",
+				}},
+			},
+		},
+	}
+	scoped, score, ok := ReEvaluateForConfig(&AnalysisResult{CiValid: true, GitHubPipeline: pipeline}, dismissedConf, "github", pc)
+	if !ok {
+		t.Fatal("dismissed re-evaluation must succeed")
+	}
+
+	if score.FinalPoints != want.FinalPoints || score.Score != want.Score {
+		t.Fatalf("score with the finding dismissed = %+v, want %+v (computed with the finding entirely removed): the per-policy path must stamp File to repo-relative form BEFORE hashing against the served dismissal", score, want)
+	}
+	matched := false
+	for _, f := range scoped.Findings {
+		if f.Code == "ISSUE-705" {
+			if f.File != filepath.ToSlash(relOriginFile) {
+				t.Errorf("finding.File = %q, want the repo-relative form %q: the scoped result must be stamped too", f.File, relOriginFile)
+			}
+			if f.Fingerprint == "" {
+				t.Error("finding.Fingerprint must be filled by the stamp, not left empty for a per-policy push")
+			}
+			if !f.Dismissed {
+				t.Errorf("finding %+v must be marked dismissed", f)
+			}
+			matched = true
+		}
+	}
+	if !matched {
+		t.Fatal("the scoped result must still carry the ISSUE-705 finding, marked dismissed (never silently dropped)")
+	}
+}

--- a/control/task.go
+++ b/control/task.go
@@ -1104,6 +1104,10 @@ func RunAnalysis(conf *configuration.Configuration) (*AnalysisResult, error) {
 
 	markPlatformLaneGaps(result, conf)
 
+	// An enabled control asserting nothing until its substantive fields are set is not a clean
+	// pass either (#459): it is not_evaluable, config_required, same as any other lane gap.
+	MarkUnconfiguredControls(result, GitLabControls(conf.PlumberConfig), conf.PlumberConfig, configuration.ProviderGitLab)
+
 	reportProgress(conf, analysisStepCount, analysisStepCount, "Analysis complete")
 
 	l.WithFields(logrus.Fields{

--- a/control/task_github.go
+++ b/control/task_github.go
@@ -269,6 +269,11 @@ func RunGitHubAnalysis(conf *configuration.Configuration) (*AnalysisResult, erro
 	if conf.IsLocalProject && conf.GitRepoRoot != "" {
 		result.HeadCommitSha = utils.DetectGitHeadSHA(conf.GitRepoRoot)
 	}
+	// An enabled control asserting nothing until its substantive fields are set is not a clean
+	// pass either (#459): it is not_evaluable, config_required, same as any other lane gap. Runs
+	// before the finding-count aggregation below so a dropped not_evaluable finding never inflates
+	// the report's stats, matching the GitLab task's mark-before-assembly ordering.
+	MarkUnconfiguredControls(result, GitHubControls(conf.PlumberConfig), conf.PlumberConfig, configuration.ProviderGitHub)
 	ApplyGitHubFindingCounts(result.GitHubStats, result.Findings)
 	if conf.ProgressFunc != nil {
 		total := githubpkg.TotalProgressStepsForPipeline(pipeline)
@@ -372,6 +377,11 @@ func RunGitHubAnalysisRemote(conf *configuration.Configuration, owner, repo, ref
 		Warnings:         pipeline.AdvisoryWarnings,
 	}
 	applyGitHubDegraded(result, len(partial), branchFetchFailed)
+	// An enabled control asserting nothing until its substantive fields are set is not a clean
+	// pass either (#459): it is not_evaluable, config_required, same as any other lane gap. Runs
+	// before the finding-count aggregation below so a dropped not_evaluable finding never inflates
+	// the report's stats, matching the GitLab task's mark-before-assembly ordering.
+	MarkUnconfiguredControls(result, GitHubControls(conf.PlumberConfig), conf.PlumberConfig, configuration.ProviderGitHub)
 	ApplyGitHubFindingCounts(result.GitHubStats, result.Findings)
 	if conf.ProgressFunc != nil {
 		total := githubpkg.TotalProgressStepsForPipeline(pipeline)

--- a/control/task_github_test.go
+++ b/control/task_github_test.go
@@ -303,3 +303,92 @@ func TestRunGitHubAnalysis_NoWorkflows(t *testing.T) {
 		t.Errorf("expected no findings, got %d", len(result.Findings))
 	}
 }
+
+// TestRunGitHubAnalysis_MarksUnconfiguredControlNotEvaluable pins
+// MarkUnconfiguredControls' wiring into RunGitHubAnalysis (#459): a
+// RequiresConfig control enabled with no substantive field must surface
+// as config_required, not a silent pass, at the real entry point rather
+// than only in the unit-level configuration package tests.
+func TestRunGitHubAnalysis_MarksUnconfiguredControlNotEvaluable(t *testing.T) {
+	enabled := true
+	conf := &configuration.Configuration{
+		ProjectPath: "owner/repo",
+		GitRepoRoot: writeMinimalWorkflow(t),
+		PlumberConfig: &configuration.PlumberConfig{
+			GitHub: &configuration.ProviderConfig{
+				Controls: configuration.ControlsConfig{
+					WorkflowMustIncludeRequiredActions: &configuration.RequiredActionsControlConfig{
+						Enabled: &enabled,
+					},
+				},
+			},
+		},
+	}
+
+	result, err := RunGitHubAnalysis(conf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	reason, ok := result.NotEvaluableReason("workflowMustIncludeRequiredActions")
+	if !ok || reason != ReasonConfigRequired {
+		t.Fatalf("expected workflowMustIncludeRequiredActions to be config_required, got reason=%q ok=%v", reason, ok)
+	}
+
+	entry := findControlEntry(t, GitHubControls(conf.PlumberConfig), "workflowMustIncludeRequiredActions")
+	findingCount := len(FindingsByControl(result.Findings)["workflowMustIncludeRequiredActions"])
+	if got := StatusFor(entry, result, findingCount); got != StatusError {
+		t.Errorf("expected StatusFor %q, got %q", StatusError, got)
+	}
+}
+
+// TestRunGitHubAnalysisRemote_MarksUnconfiguredControlNotEvaluable is the
+// remote-fetch mirror of the above: MarkUnconfiguredControls is called
+// separately in RunGitHubAnalysisRemote (control/task_github.go), so the
+// local-path test alone leaves this call site free to be deleted with the
+// suite still green.
+func TestRunGitHubAnalysisRemote_MarksUnconfiguredControlNotEvaluable(t *testing.T) {
+	swapRemoteScan(t, remoteScanStub)
+
+	enabled := true
+	conf := &configuration.Configuration{
+		PlumberConfig: &configuration.PlumberConfig{
+			GitHub: &configuration.ProviderConfig{
+				Controls: configuration.ControlsConfig{
+					WorkflowMustIncludeRequiredActions: &configuration.RequiredActionsControlConfig{
+						Enabled: &enabled,
+					},
+				},
+			},
+		},
+	}
+
+	result, err := RunGitHubAnalysisRemote(conf, "owner", "repo", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	reason, ok := result.NotEvaluableReason("workflowMustIncludeRequiredActions")
+	if !ok || reason != ReasonConfigRequired {
+		t.Fatalf("expected workflowMustIncludeRequiredActions to be config_required, got reason=%q ok=%v", reason, ok)
+	}
+
+	entry := findControlEntry(t, GitHubControls(conf.PlumberConfig), "workflowMustIncludeRequiredActions")
+	findingCount := len(FindingsByControl(result.Findings)["workflowMustIncludeRequiredActions"])
+	if got := StatusFor(entry, result, findingCount); got != StatusError {
+		t.Errorf("expected StatusFor %q, got %q", StatusError, got)
+	}
+}
+
+// findControlEntry returns the ControlEntry named name out of entries, or
+// fails the test. Small helper shared by the two tests above.
+func findControlEntry(t *testing.T, entries []ControlEntry, name string) ControlEntry {
+	t.Helper()
+	for _, e := range entries {
+		if e.ControlName == name {
+			return e
+		}
+	}
+	t.Fatalf("no control entry named %s", name)
+	return ControlEntry{}
+}

--- a/control/task_unconfigured_gitlab_test.go
+++ b/control/task_unconfigured_gitlab_test.go
@@ -1,0 +1,67 @@
+package control
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/getplumber/plumber/configuration"
+)
+
+// bareBranchProtectionConfig enables a RequiresConfig GitLab control with
+// no substantive field beyond `enabled`, the #459 case.
+const bareBranchProtectionConfig = `version: "2.0"
+gitlab:
+  controls:
+    branchMustBeProtected:
+      enabled: true
+`
+
+// TestRunAnalysis_MarksUnconfiguredControlNotEvaluable pins
+// MarkUnconfiguredControls' wiring into RunAnalysis (control/task.go), the
+// GitLab mirror of TestRunGitHubAnalysis_MarksUnconfiguredControlNotEvaluable
+// and TestRunGitHubAnalysisRemote_MarksUnconfiguredControlNotEvaluable in
+// task_github_test.go: a RequiresConfig control enabled with no substantive
+// field must surface as config_required at the real entry point, not just
+// in the configuration package's own unit tests (#459). Deleting the
+// MarkUnconfiguredControls call in RunAnalysis must fail this test.
+//
+// RunAnalysis has no offline seam lighter than a served GitLab, so this
+// runs against the recording fake GitLab already built for the
+// platform-call inventory (control/platform_call_inventory_test.go:
+// gitlabRecorder, testProjectPath) rather than faking RunAnalysis itself.
+func TestRunAnalysis_MarksUnconfiguredControlNotEvaluable(t *testing.T) {
+	rec := &gitlabRecorder{sha: "0123456789abcdef0123456789abcdef01234567"}
+	srv := httptest.NewServer(rec)
+	defer srv.Close()
+
+	pc, _, _, err := configuration.LoadPlumberConfigFromBytes([]byte(bareBranchProtectionConfig), "unconfigured-test")
+	if err != nil {
+		t.Fatalf("loading the test config: %v", err)
+	}
+	conf := configuration.NewDefaultConfiguration()
+	conf.GitlabURL = srv.URL
+	conf.GitlabToken = "glpat-inventory"
+	conf.ProjectPath = testProjectPath
+	conf.HTTPClientTimeout = 10 * time.Second
+	// One attempt per request, matching inventoryConf: a deliberate 404
+	// ref probe should not multiply into retries here either.
+	conf.GitlabRetryMaxRetries = 0
+	conf.PlumberConfig = pc
+
+	result, err := RunAnalysis(conf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	reason, ok := result.NotEvaluableReason("branchMustBeProtected")
+	if !ok || reason != ReasonConfigRequired {
+		t.Fatalf("expected branchMustBeProtected to be config_required, got reason=%q ok=%v", reason, ok)
+	}
+
+	entry := findControlEntry(t, GitLabControls(conf.PlumberConfig), "branchMustBeProtected")
+	findingCount := len(FindingsByControl(result.Findings)["branchMustBeProtected"])
+	if got := StatusFor(entry, result, findingCount); got != StatusError {
+		t.Errorf("expected StatusFor %q, got %q", StatusError, got)
+	}
+}

--- a/control/unconfigured_test.go
+++ b/control/unconfigured_test.go
@@ -1,0 +1,113 @@
+package control
+
+import (
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/internal/ir"
+)
+
+// TestMarkUnconfiguredControls pins #459 at the marker level: a RequiresConfig control enabled
+// with no substantive field gets ReasonConfigRequired, StatusFor then reports it as error, and an
+// existing mark (a more specific lane gap) is kept rather than overwritten.
+func TestMarkUnconfiguredControls(t *testing.T) {
+	on := true
+	pc := &configuration.PlumberConfig{Version: "2.0", GitLab: &configuration.ProviderConfig{
+		Controls: configuration.ControlsConfig{
+			BranchMustBeProtected: &configuration.BranchProtectionControlConfig{Enabled: &on},
+		},
+	}}
+	entries := []ControlEntry{{ControlName: controlBranchMustBeProtected}}
+
+	t.Run("an unconfigured control is marked config_required and reports error", func(t *testing.T) {
+		result := &AnalysisResult{}
+		MarkUnconfiguredControls(result, entries, pc, configuration.ProviderGitLab)
+
+		reason, marked := result.NotEvaluableReason(controlBranchMustBeProtected)
+		if !marked || reason != ReasonConfigRequired {
+			t.Fatalf("want config_required mark, got (%q, %v)", reason, marked)
+		}
+		if got := StatusFor(entries[0], result, 0); got != StatusError {
+			t.Fatalf("want StatusError, got %q", got)
+		}
+	})
+
+	t.Run("a first reason already recorded is kept", func(t *testing.T) {
+		result := &AnalysisResult{}
+		result.MarkNotEvaluable(controlBranchMustBeProtected, ReasonLaneNotServed)
+		MarkUnconfiguredControls(result, entries, pc, configuration.ProviderGitLab)
+
+		reason, marked := result.NotEvaluableReason(controlBranchMustBeProtected)
+		if !marked || reason != ReasonLaneNotServed {
+			t.Fatalf("the earlier, more specific reason must survive, got (%q, %v)", reason, marked)
+		}
+	})
+
+	t.Run("a disabled control is skipped, not marked", func(t *testing.T) {
+		off := false
+		pcOff := &configuration.PlumberConfig{Version: "2.0", GitLab: &configuration.ProviderConfig{
+			Controls: configuration.ControlsConfig{
+				BranchMustBeProtected: &configuration.BranchProtectionControlConfig{Enabled: &off},
+			},
+		}}
+		result := &AnalysisResult{}
+		MarkUnconfiguredControls(result, []ControlEntry{{ControlName: controlBranchMustBeProtected, Skipped: true}}, pcOff, configuration.ProviderGitLab)
+		if _, marked := result.NotEvaluableReason(controlBranchMustBeProtected); marked {
+			t.Fatal("a skipped entry must never be marked")
+		}
+	})
+
+	t.Run("a configured control is not marked", func(t *testing.T) {
+		pcSet := &configuration.PlumberConfig{Version: "2.0", GitLab: &configuration.ProviderConfig{
+			Controls: configuration.ControlsConfig{
+				BranchMustBeProtected: &configuration.BranchProtectionControlConfig{Enabled: &on, NamePatterns: []string{"main"}},
+			},
+		}}
+		result := &AnalysisResult{}
+		MarkUnconfiguredControls(result, entries, pcSet, configuration.ProviderGitLab)
+		if _, marked := result.NotEvaluableReason(controlBranchMustBeProtected); marked {
+			t.Fatal("a control with a substantive field set asserts something and must not be marked")
+		}
+	})
+}
+
+// TestReEvaluateForConfigMarksUnconfiguredControls is the end-to-end half: two policies share the
+// same run, one leaves branchMustBeProtected enabled bare, the other sets a substantive field.
+// Only the bare policy's evaluation must come back marked config_required.
+func TestReEvaluateForConfigMarksUnconfiguredControls(t *testing.T) {
+	on := true
+	local := &configuration.PlumberConfig{Version: "2.0"}
+	conf := &configuration.Configuration{PlumberConfig: local}
+
+	result := &AnalysisResult{
+		CiValid:  true,
+		Pipeline: &ir.NormalizedPipeline{Provider: ir.ProviderGitLab, ProjectPath: "grp/app"},
+	}
+
+	barePolicy := &configuration.PlumberConfig{Version: "2.0", GitLab: &configuration.ProviderConfig{
+		Controls: configuration.ControlsConfig{
+			BranchMustBeProtected: &configuration.BranchProtectionControlConfig{Enabled: &on},
+		},
+	}}
+	configuredPolicy := &configuration.PlumberConfig{Version: "2.0", GitLab: &configuration.ProviderConfig{
+		Controls: configuration.ControlsConfig{
+			BranchMustBeProtected: &configuration.BranchProtectionControlConfig{Enabled: &on, NamePatterns: []string{"main"}},
+		},
+	}}
+
+	bareScoped, _, ok := ReEvaluateForConfig(result, conf, "gitlab", barePolicy)
+	if !ok {
+		t.Fatal("re-evaluation must succeed with a retained pipeline")
+	}
+	if _, marked := bareScoped.NotEvaluableReason(controlBranchMustBeProtected); !marked {
+		t.Fatal("the bare policy leaves branchMustBeProtected unconfigured and must be marked")
+	}
+
+	configuredScoped, _, ok := ReEvaluateForConfig(result, conf, "gitlab", configuredPolicy)
+	if !ok {
+		t.Fatal("re-evaluation must succeed with a retained pipeline")
+	}
+	if _, marked := configuredScoped.NotEvaluableReason(controlBranchMustBeProtected); marked {
+		t.Fatal("the configured policy set a substantive field and must not be marked")
+	}
+}

--- a/docs/platform-push-testing.md
+++ b/docs/platform-push-testing.md
@@ -114,6 +114,25 @@ entry, absent on every other one.
 `TestMaybePushPlatform_DismissedFindingWireShape` in
 `cmd/platform_push_test.go` is the pinned example.
 
+The wiring one level up - `markPlatformDismissedFindings` running between
+`StampFingerprints` and `buildComplianceSummary`, which is what makes the mark
+happen at all on a real run - lives in one place, `finalizeFindings`
+(`cmd/analyze_shared.go`), called by both entry points: `runWithProvider` for
+GitLab and `presentResultWithProvider` for the GitHub paths. It is pinned by
+`TestSharedPipeline_ServedDismissalMarksThePushAndLeavesTheScore` in the same
+file, which drives BOTH of them (the GitLab one with the provider's `Run`
+stubbed to a canned result). The test builds the served entry the way the
+platform does (`identity.PlatformHash` of the finding after stamping, at
+`identity.RecipeVersion`) and reads both the marker on the wire and the score
+that run computed, so dropping the call - or reintroducing a copy of the
+sequence without it - fails there instead of shipping.
+
+The `--output` JSON report is the one output with no marker on it, on purpose:
+its finding objects are the same bytes the identity recipe hashes, so a field
+added there would change the identity the platform and the CLI have to agree
+on. The CSV export (a `dismissed` column) and the OCSF export (a
+`dismissed: true` key) are free of that constraint and do carry it.
+
 A dismissed finding is never dropped anywhere it would otherwise appear: the
 terminal's Controls summary table counts it in a control's issue total and
 per-severity tally (a per-control inventory of what ran, not the live

--- a/docs/platform-push-testing.md
+++ b/docs/platform-push-testing.md
@@ -96,6 +96,31 @@ To check a change by hand against a live platform, POST a finding both ways
 and compare - without provenance it is a 422 naming the offending path, with
 `"valueProvenance": "ci_file"` it is a 201.
 
+## The dismissed marker
+
+A finding whose platform identity matches an entry in `/context`'s
+`dismissed_issues` (#447) is marked by `control.MarkDismissed` right after
+fingerprinting, and a failed control's pushed entries carry that as
+`"dismissed":true` (`platformFinding.Dismissed`, omitted entirely when
+false). The finding is still pushed, exactly like any other fail entry: the
+marker is a claim about what the platform already knows, not a reason to
+withhold data from it.
+
+To see it in a captured request, follow the same flow as above (an
+`httptest.Server` reading the push body), decode into `map[string]any`
+rather than `platformPush`, walk `results[0].findings`, and check each
+entry's `"dismissed"` key: present and `true` on a dismissed finding's
+entry, absent on every other one.
+`TestMaybePushPlatform_DismissedFindingWireShape` in
+`cmd/platform_push_test.go` is the pinned example.
+
+A dismissed finding is never dropped anywhere it would otherwise appear: the
+terminal's Controls summary table counts it in a control's issue total and
+per-severity tally (a per-control inventory of what ran, not the live
+verdict), while that same finding is excluded from the Plumber Score and
+called out separately, as "N issues, M dismissed", in the Failed Controls
+detail section right below it.
+
 ## Testing platform mode end to end
 
 Platform mode (`--platform`) reads `/context` and `/resolved-config` before

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -43,6 +43,8 @@ Both views are reported:
 - `counts.{critical,high,medium,low}`: total findings per severity (banner, MR comment).
 - `codeLosses[]`: per-code rows that drive the score (full breakdown via `--score-point`).
 
+An enabled control none of whose substantive configuration fields is set is not evaluated (`not_evaluable`, reason `config_required`) and contributes no findings; the loss-based points above are unaffected, so such a policy can still read 100 while every one of its controls is marked not evaluated (#459). Whether a policy with no evaluable control should have its score withheld instead is an open platform question.
+
 ---
 
 ## Step 1: Loss per issue code

--- a/docs/superpowers/plans/2026-09-10-cli-platform-rows.md
+++ b/docs/superpowers/plans/2026-09-10-cli-platform-rows.md
@@ -1,0 +1,509 @@
+# CLI <> Platform rows Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Platform-mode jobs on a root-owned checkout keep all their controls (#464); an enabled but unconfigured control is `not_evaluable` with reason `config_required` instead of a vacuous pass (#459); the CLI fetches the platform's dismissed issues, marks matching findings, excludes them from its score and pushes the marker (#447).
+
+**Architecture:** Three independent changes on the existing lanes: one git helper in `utils`, one marking pass next to the existing not_evaluable marks, and one match-and-mark pass between fingerprint stamping and scoring, fed by a new `/context` field and a new exported hash in the shared identity recipe.
+
+**Tech Stack:** Go 1.26, logrus, OPA findings, `make test` / `make lint` (golangci-lint v2) / `make deadcode`.
+
+**Spec:** `docs/superpowers/specs/2026-09-10-cli-platform-rows-design.md`
+
+## Global Constraints
+
+- Conventional commits (no commitlint here, but the release notes are generated from them; every feat/fix bumps a patch); a commit body line `Closes #<n>` for the issue the commit resolves. No em dash character anywhere. Never edit `CHANGELOG.md` (semantic-release writes it).
+- `go test ./...`, `go vet ./...`, `make lint` (0 issues), `make deadcode` (the two pre-existing findings `configuration/schema.go` and gofmt on `gitlab/request.go` are known; add nothing new) before every commit. Tests are fast here (no database); run the whole suite.
+- Frozen finding-status vocabulary `pass | fail | not_evaluable`; `dismissed` is an orthogonal boolean, never a status.
+- `identity.RecipeVersion` stays 4; `Of`, `Fingerprint`, `canonical()` and `Pairs()` are not modified (a change re-keys every finding).
+- `opaengine.Finding.MarshalJSON` output is unchanged (the platform hashes it).
+- `ComputePlumberScore` is unchanged; only its INPUT (the code counts) changes.
+- Every new test's doc comment names the issue it pins (`#464`, `#459`, `#447`).
+
+---
+
+### Task 1: git safe.directory and diagnostics on a root-owned checkout (#464)
+
+**Files:**
+- Modify: `utils/gitremote.go` (`DetectGitRemote`, `DetectGitRepoRoot`, `DetectGitHeadSHA`)
+- Modify: `templates/plumber.yml` (script block, ~:210-220)
+- Test: `utils/gitremote_safedir_test.go` (new), `cmd/platform_push_test.go` only if it parses the template (grep first)
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+package utils
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+// TestGitCommand_NamesTheDirectoryAsSafe pins #464: every git shell-out passes the inspected
+// directory as protected safe.directory configuration, so a checkout owned by another uid (the
+// GitLab docker executor clones as root, the image runs as uid 65532) is readable without a
+// global git config the image does not carry. The one directory, never '*'.
+func TestGitCommand_NamesTheDirectoryAsSafe(t *testing.T) {
+	cmd := gitCommand("/builds/group/project", "rev-parse", "--show-toplevel")
+	want := []string{"git", "-c", "safe.directory=/builds/group/project", "rev-parse", "--show-toplevel"}
+	if strings.Join(cmd.Args, " ") != strings.Join(want, " ") {
+		t.Fatalf("argv = %q, want %q", cmd.Args, want)
+	}
+	if cmd.Dir != "/builds/group/project" {
+		t.Fatalf("Dir = %q, want the inspected directory", cmd.Dir)
+	}
+}
+
+// TestDetectGitRepoRoot_LogsTheGitErrorAtWarn pins #464: a git failure is no longer silent. A
+// fake git on PATH exits 128 with the dubious-ownership message; the caller still gets "" (its
+// contract) and the first stderr line is logged at Warn so the job log explains the degraded run.
+func TestDetectGitRepoRoot_LogsTheGitErrorAtWarn(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "git")
+	script := "#!/bin/sh\necho \"fatal: detected dubious ownership in repository at '/builds/x'\" >&2\nexit 128\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	hook := test.NewGlobal()
+	defer hook.Reset()
+	logrus.SetLevel(logrus.DebugLevel)
+
+	if got := DetectGitRepoRoot(); got != "" {
+		t.Fatalf("repo root = %q, want empty on git failure", got)
+	}
+	var found bool
+	for _, e := range hook.AllEntries() {
+		if e.Level == logrus.WarnLevel && strings.Contains(e.Message, "dubious ownership") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no Warn entry naming the git error; entries: %+v", hook.AllEntries())
+	}
+	_ = exec.Command // keep the import honest if the fake needs it
+}
+```
+
+Check how `utils` logs today (`grep -n logrus utils/*.go`); if the package uses a package-level logger variable, log through it so the hook sees it. Adapt the assertion to the actual message format you choose (it must contain the stderr text).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./utils/ -run 'TestGitCommand_NamesTheDirectoryAsSafe|TestDetectGitRepoRoot_LogsTheGitErrorAtWarn' -count=1`
+Expected: FAIL (`gitCommand` undefined; no Warn entry).
+
+- [ ] **Step 3: Implement**
+
+In `utils/gitremote.go`:
+
+```go
+// gitCommand builds a git invocation scoped to dir with dir declared as safe.directory (#464).
+// -c is protected configuration, so git honors safe.directory from it even when the repository
+// is owned by another uid (the GitLab docker executor clones $CI_PROJECT_DIR as root while the
+// image runs as uid 65532); git >= 2.35.2 otherwise refuses with "detected dubious ownership".
+// The single inspected directory is named, never '*': the trust decision stays as narrow as the
+// question being asked.
+func gitCommand(dir string, args ...string) *exec.Cmd {
+	full := append([]string{"-c", "safe.directory=" + dir}, args...)
+	cmd := exec.Command("git", full...)
+	cmd.Dir = dir
+	return cmd
+}
+
+// runGit runs a gitCommand and returns its trimmed stdout. On failure it logs the first stderr
+// line at Warn (#464): before this, a dubious-ownership refusal and "not a git repository" were
+// indistinguishable to every caller, and platform mode silently lost five controls on the
+// default executor with nothing in the job log to explain it.
+func runGit(dir string, args ...string) (string, error) {
+	cmd := gitCommand(dir, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		first := strings.SplitN(strings.TrimSpace(stderr.String()), "\n", 2)[0]
+		logrus.WithFields(logrus.Fields{"dir": dir, "args": strings.Join(args, " ")}).
+			Warnf("git %s failed: %s", strings.Join(args, " "), first)
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+```
+
+`DetectGitRemote`: `dir, _ := os.Getwd()`; `remoteURL, err := runGit(dir, "remote", "get-url", "origin")`; keep the nil contract. `DetectGitRepoRoot`: `runGit(cwd, "rev-parse", "--show-toplevel")`. `DetectGitHeadSHA(repoRoot)`: `runGit(repoRoot, "rev-parse", "HEAD")`. If `utils` deliberately avoids logrus today, use the same logger the rest of the package uses; the requirement is a Warn with the stderr line.
+
+`templates/plumber.yml` script block, before `plumber analyze`:
+
+```yaml
+    # The docker executor clones $CI_PROJECT_DIR as root while this image runs as uid 65532;
+    # git refuses a repository owned by another uid unless it is declared safe (#464). The CLI
+    # also declares it per invocation; this line covers a custom image whose git predates that.
+    - if command -v git >/dev/null 2>&1 && [ -n "${CI_PROJECT_DIR:-}" ]; then git config --global --add safe.directory "$CI_PROJECT_DIR"; fi
+```
+
+- [ ] **Step 4: Run, lint, commit**
+
+Run: `go test ./... -count=1 && go vet ./... && make lint && make deadcode`
+Expected: PASS, 0 lint issues, deadcode unchanged.
+
+```bash
+git add utils/gitremote.go utils/gitremote_safedir_test.go templates/plumber.yml
+git commit -m "fix(platform): declare the checkout safe for git and log git failures, so a root-owned clone keeps its controls
+
+Closes #464"
+```
+
+---
+
+### Task 2: unconfigured controls are not_evaluable (#459)
+
+**Files:**
+- Modify: `configuration/schema.go` (new `IsUnconfigured`), `control/lanes.go` (new reason + `MarkUnconfiguredControls`, call in `ReEvaluateForConfig`), `control/task.go:~1103` (call after `MarkOwnCollectionGaps`), the GitHub task's result finalization (`control/task_github.go`: find where the GitHub `AnalysisResult` is completed; add the same call with `GitHubControls(conf.PlumberConfig)` and `configuration.ProviderGitHub`), `docs/scoring.md` (Inputs section).
+- Test: `configuration/unconfigured_test.go`, `control/unconfigured_test.go`.
+
+**Interfaces:**
+- Produces: `configuration.IsUnconfigured(pc *PlumberConfig, provider, controlName string) bool`; `control.ReasonConfigRequired = "config_required"`; `control.MarkUnconfiguredControls(result *AnalysisResult, entries []ControlEntry, pc *configuration.PlumberConfig, provider string)`.
+
+- [ ] **Step 1: Failing tests**
+
+```go
+package configuration
+
+import "testing"
+
+// TestIsUnconfigured pins #459: a RequiresConfig control enabled with no substantive field is
+// unconfigured; one substantive field, a non-RequiresConfig control, a disabled control and a
+// nil block are not.
+func TestIsUnconfigured(t *testing.T) {
+	requires := firstRequiresConfigControl(t) // helper: first ControlsCatalog() entry with RequiresConfig, plus its provider
+	pcBare := plumberConfigWith(t, requires.Provider, requires.Name, map[string]any{"enabled": true})
+	if !IsUnconfigured(pcBare, requires.Provider, requires.Name) {
+		t.Errorf("#459: %s with enabled:true only must be unconfigured", requires.Name)
+	}
+	pcSet := plumberConfigWith(t, requires.Provider, requires.Name, substantiveExample(t, requires.Name))
+	if IsUnconfigured(pcSet, requires.Provider, requires.Name) {
+		t.Errorf("#459: %s with a substantive field set must not be unconfigured", requires.Name)
+	}
+	plain := firstControlWhere(t, func(e ControlMeta) bool { return !e.RequiresConfig })
+	pcPlain := plumberConfigWith(t, plain.Provider, plain.Name, map[string]any{"enabled": true})
+	if IsUnconfigured(pcPlain, plain.Provider, plain.Name) {
+		t.Errorf("#459: a control that asserts something unconfigured is never unconfigured")
+	}
+	pcOff := plumberConfigWith(t, requires.Provider, requires.Name, map[string]any{"enabled": false})
+	if IsUnconfigured(pcOff, requires.Provider, requires.Name) {
+		t.Error("#459: a disabled control is skipped, not unconfigured")
+	}
+	if IsUnconfigured(&PlumberConfig{}, requires.Provider, requires.Name) {
+		t.Error("#459: an absent block is skipped, not unconfigured")
+	}
+}
+```
+
+Write the three helpers in the test file by building a `PlumberConfig` through the YAML loader the package already tests with (grep `yaml.Unmarshal` in `configuration/*_test.go`), and `substantiveExample` from `ConfigSchemaFor(name)`: pick the first non-`enabled` field and give it a non-zero value of its type (string "x", integer 1, bool true, array `["x"]`, object `{}` is NOT non-zero: for an object field recurse to its first leaf).
+
+`control/unconfigured_test.go`: build an `AnalysisResult` and entries for a RequiresConfig control enabled bare; call `MarkUnconfiguredControls`; assert `result.NotEvaluable[name] == ReasonConfigRequired`, `StatusFor(entry, result, 0) == StatusError`, and that a first-reason already present (`MarkNotEvaluable(name, ReasonLaneNotServed)` before) is kept. A second test through `ReEvaluateForConfig` with two policies (bare and configured) asserting only the bare one is marked; model it on the existing `ReEvaluateForConfig` tests (grep them).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./configuration/ ./control/ -run 'TestIsUnconfigured|Unconfigured' -count=1`
+Expected: compile failure.
+
+- [ ] **Step 3: Implement**
+
+`configuration/schema.go`:
+
+```go
+// IsUnconfigured reports whether controlName is enabled in pc but asserts nothing because none of
+// its substantive fields is set (#459): the control is RequiresConfig in the catalog, its block is
+// present and enabled, and every field other than `enabled` is at its zero value (nil pointer,
+// empty slice or map, "", 0, false; a nested struct is zero when all of its fields are). The field
+// enumeration is the SAME reflection the catalog exports (reflectControlSchemas), so a field the
+// schema shows is a field this check reads. False for a control that is not RequiresConfig, is
+// disabled, or has no block: those are "asserts something" or "skipped", never "unconfigured".
+func IsUnconfigured(pc *PlumberConfig, provider, controlName string) bool {
+	if pc == nil {
+		return false
+	}
+	meta, ok := controlMetaFor(provider, controlName) // ControlsCatalog() lookup by provider+name
+	if !ok || !meta.RequiresConfig {
+		return false
+	}
+	block := controlBlock(pc, provider, controlName) // reflect.Value of the config struct pointer, or invalid
+	if !block.IsValid() || block.IsNil() {
+		return false
+	}
+	if en, ok := block.Interface().(interface{ IsEnabled() bool }); !ok || !en.IsEnabled() {
+		return false
+	}
+	return substantiveFieldsAreZero(block.Elem())
+}
+```
+
+Implement `controlBlock` by walking `ControlsConfig`'s fields with `yamlName(f) == controlName` (the same loop `reflectControlSchemas` runs; factor the per-provider `ControlsConfig` access from `pc` the way `GitLabControls`/`GitHubControls` reach it), and `substantiveFieldsAreZero` with `reflect.Value.IsZero()` per field skipping the field whose yaml name is `enabled`, recursing into struct-typed fields.
+
+`control/lanes.go`:
+
+```go
+// ReasonConfigRequired: the control is enabled but none of its substantive configuration fields is
+// set, so it asserts nothing (#459, platform decision-queue row 19: honest not_evaluable, never a
+// vacuous pass). Which controls can be in this state is authored truth (configuration.ControlMeta
+// .RequiresConfig); which fields count is the catalog's own reflected schema.
+const ReasonConfigRequired = "config_required"
+
+// MarkUnconfiguredControls flags every non-skipped RequiresConfig control whose enabled block sets
+// no substantive field (#459). Runs AFTER the lane-gap marks: a lane gap is the more specific
+// explanation and MarkNotEvaluable keeps the first reason.
+func MarkUnconfiguredControls(result *AnalysisResult, entries []ControlEntry, pc *configuration.PlumberConfig, provider string) {
+	if result == nil || pc == nil {
+		return
+	}
+	for _, e := range entries {
+		if e.Skipped {
+			continue
+		}
+		if configuration.IsUnconfigured(pc, provider, e.ControlName) {
+			result.MarkNotEvaluable(e.ControlName, ReasonConfigRequired)
+		}
+	}
+}
+```
+
+Call sites: `control/task.go` right after `markPlatformLaneGaps(result, conf)` (~:1105): `MarkUnconfiguredControls(result, GitLabControls(conf.PlumberConfig), conf.PlumberConfig, configuration.ProviderGitLab)`; the GitHub task's finalization with `GitHubControls`/`ProviderGitHub`; `ReEvaluateForConfig` after `markPlatformLaneGapsFor` and before `DropNotEvaluableFindings`: `MarkUnconfiguredControls(&scopedResult, entriesFor(provider, pc), pc, provider)` (use the existing per-provider entries builder the function or its callers already use).
+
+`docs/scoring.md` "Inputs: per-code counts": add "An enabled control none of whose substantive configuration fields is set is not evaluated (`not_evaluable`, reason `config_required`) and contributes nothing: a policy made of unconfigured controls does not score 100, it scores over nothing (#459)."
+
+- [ ] **Step 4: Run, lint, commit**
+
+Run: `go test ./... -count=1 && go vet ./... && make lint && make deadcode`
+
+```bash
+git add configuration/schema.go configuration/unconfigured_test.go control/lanes.go control/unconfigured_test.go control/task.go control/task_github.go docs/scoring.md
+git commit -m "feat(scoring): report an enabled but unconfigured control as not_evaluable (config_required) instead of a vacuous pass
+
+Closes #459"
+```
+
+---
+
+### Task 3: dismissed issues: wire type, platform hash, match and mark (#447, part 1)
+
+**Files:**
+- Modify: `internal/platform/types.go` (`DismissedIssue`, `ProjectContext.DismissedIssues`), `finding/identity/identity.go` (`PlatformHash`), `internal/engine/opa/engine.go` (`Finding.Dismissed`, exported `IdentityInput()` if `identityInput` must be reachable from `control`), `control/dismissed.go` (new: `MarkDismissed`)
+- Test: `internal/platform/types_test.go` (decode), `finding/identity/platformhash_test.go`, `control/dismissed_test.go`
+
+**Interfaces:**
+- Produces: `platform.DismissedIssue{IdentityHash string; RecipeVersion int; ControlType string}`; `identity.PlatformHash(f Finding) (hash string, version int, ok bool)`; `opaengine.Finding.Dismissed bool`; `control.MarkDismissed(findings []opaengine.Finding, served []platform.DismissedIssue) int`.
+
+- [ ] **Step 1: Failing tests**
+
+`finding/identity/platformhash_test.go`:
+
+```go
+// TestPlatformHash_MatchesThePlatformDigest pins #447: PlatformHash is sha256 hex over
+// json.Marshal(fields.Pairs()), the platform's own issueident.Hash by construction, so a
+// dismissed issue served by identity_hash matches the CLI's finding without a second recipe.
+func TestPlatformHash_MatchesThePlatformDigest(t *testing.T) {
+	f := Finding{Code: "ISSUE-103", File: ".gitlab-ci.yml", Job: "build", Message: "m", Data: map[string]any{"image": "nginx:latest"}}
+	fields, ok := Of(f)
+	if !ok {
+		t.Fatal("fixture must have a code")
+	}
+	pairs, _ := json.Marshal(fields.Pairs())
+	sum := sha256.Sum256(pairs)
+	want := hex.EncodeToString(sum[:])
+	got, version, ok := PlatformHash(f)
+	if !ok || got != want || version != RecipeVersion {
+		t.Fatalf("PlatformHash = (%q, %d, %v), want (%q, %d, true)", got, version, ok, want, RecipeVersion)
+	}
+	if _, _, ok := PlatformHash(Finding{}); ok {
+		t.Error("a codeless finding has no identity and no platform hash")
+	}
+}
+```
+
+Also a golden: hard-code the `want` value you observe for that exact fixture as a second assertion with a comment "wire-stable: the platform stores this digest; changing Pairs() or the marshal is a recipe bump".
+
+`control/dismissed_test.go`: served list with (a) a matching entry for a finding of code X, (b) an entry with `RecipeVersion: 3` for another finding (skipped), (c) an entry whose `ControlType` names a different control (never compared), (d) a codeless finding; assert exactly the one match is marked and `MarkDismissed` returns 1; an empty served list marks nothing.
+
+`internal/platform/types_test.go`: decode a `/context` JSON with and without `dismissed_issues`; the field is nil when absent and populated when present (three fields).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./finding/identity/ ./control/ ./internal/platform/ -run 'PlatformHash|Dismissed' -count=1`
+Expected: compile failure.
+
+- [ ] **Step 3: Implement**
+
+`finding/identity/identity.go`:
+
+```go
+// PlatformHash returns the digest the platform stores as an issue's identity_hash (its own
+// issueident.Hash): sha256 hex over json.Marshal(Of(f).Pairs()), full length, plus the recipe
+// version the fields were selected under. ok is false for a codeless finding. Distinct from
+// Fingerprint (the truncated export identifier over canonical()): the two never had to agree
+// on a hash, only on the field selection, and this function exists so the CLI can match the
+// platform's served dismissed_issues (#447) without a second recipe.
+func PlatformHash(f Finding) (hash string, version int, ok bool) {
+	fields, ok := Of(f)
+	if !ok {
+		return "", 0, false
+	}
+	pairs, err := json.Marshal(fields.Pairs())
+	if err != nil {
+		return "", 0, false
+	}
+	sum := sha256.Sum256(pairs)
+	return hex.EncodeToString(sum[:]), fields.Version, true
+}
+```
+
+`internal/platform/types.go`:
+
+```go
+// DismissedIssue is one entry of ProjectContext.DismissedIssues: the match key for a finding the
+// platform has in status Dismissed (#447). IdentityHash is the platform's full sha256 hex over
+// the shared recipe's Pairs() (identity.PlatformHash); RecipeVersion is the recipe the hash was
+// computed under and versions never mix; ControlType rides along as a cheap pre-filter, never
+// part of the key.
+type DismissedIssue struct {
+	IdentityHash  string `json:"identity_hash"`
+	RecipeVersion int    `json:"recipe_version"`
+	ControlType   string `json:"control_type"`
+}
+```
+
+and `DismissedIssues []DismissedIssue \`json:"dismissed_issues"\`` on `ProjectContext`.
+
+`internal/engine/opa/engine.go`: `Dismissed bool \`json:"-"\`` on `Finding` with the doc "set by control.MarkDismissed when the platform served this finding's identity as dismissed (#447); never emitted by MarshalJSON (the platform hashes that object) and never a status: pass|fail|not_evaluable is frozen"; export `func (f Finding) IdentityInput() identity.Finding` (rename `identityInput` or add a public wrapper) so `control` can compute the hash.
+
+`control/dismissed.go`:
+
+```go
+// MarkDismissed sets Dismissed on every finding whose platform identity matches a served
+// dismissed issue (#447) and returns how many it marked. Entries served under another recipe
+// version are skipped (honest non-suppression, never a cross-version match); control_type is
+// used only to avoid hashing a finding against entries of other controls. A codeless finding
+// has no identity and never matches. The marker is a claim about what /context served; the
+// platform's stored issue status stays the authority.
+func MarkDismissed(findings []opaengine.Finding, served []platform.DismissedIssue) int {
+	if len(served) == 0 {
+		return 0
+	}
+	byControl := map[string]map[string]struct{}{}
+	for _, d := range served {
+		if d.RecipeVersion != identity.RecipeVersion {
+			continue
+		}
+		set, ok := byControl[d.ControlType]
+		if !ok {
+			set = map[string]struct{}{}
+			byControl[d.ControlType] = set
+		}
+		set[d.IdentityHash] = struct{}{}
+	}
+	marked := 0
+	for i := range findings {
+		set, ok := byControl[LookupCode(ErrorCode(findings[i].Code)).ControlName]
+		if !ok {
+			continue
+		}
+		hash, _, ok := identity.PlatformHash(findings[i].IdentityInput())
+		if !ok {
+			continue
+		}
+		if _, hit := set[hash]; hit {
+			findings[i].Dismissed = true
+			marked++
+		}
+	}
+	return marked
+}
+```
+
+Verify `LookupCode`'s exact name and return shape (`control/codes.go`) and whether `control` may import `internal/platform` without a cycle (`configuration` already imports it; `control` imports `configuration`; check with `go build ./...`).
+
+- [ ] **Step 4: Run, lint, commit**
+
+Run: `go test ./... -count=1 && go vet ./... && make lint && make deadcode` (MarkDismissed has no caller yet: if deadcode flags it, note that Task 4 wires it and add the exemption only if the target fails the build; otherwise proceed.)
+
+```bash
+git add internal/platform/types.go internal/platform/types_test.go finding/identity/identity.go finding/identity/platformhash_test.go internal/engine/opa/engine.go control/dismissed.go control/dismissed_test.go
+git commit -m "feat(platform): decode dismissed_issues, add the platform identity hash and mark matching findings"
+```
+
+---
+
+### Task 4: dismissed findings: wire the mark, exclude from the score, push the marker, show it (#447, part 2)
+
+**Files:**
+- Modify: `cmd/analyze_shared.go` (call `MarkDismissed` after each `StampFingerprints`, ~:37 and ~:455, when `conf.PlatformRun != nil && conf.PlatformRun.Context != nil`), `control/scoring.go` (`forEachIssueCode` skips `Dismissed`), `control/lanes.go` (`ReEvaluateForConfig`: call `MarkDismissed` on `scopedResult.Findings` with `conf.PlatformRun.Context.DismissedIssues` when available, and skip dismissed in its count loop), `cmd/platform_push.go` (`platformFinding.Dismissed`, set on the fail branch), `cmd/analyze_shared.go` (`findingGroup.Dismissed int`), `cmd/render_details.go` (tag), `docs/platform-push-testing.md`.
+- Test: `control/scoring_dismissed_test.go`, `cmd/platform_push_test.go` (extend), a renderer test next to the existing ones.
+
+- [ ] **Step 1: Failing tests**
+
+`control/scoring_dismissed_test.go`: an `AnalysisResult` with two fail findings of the same code, one `Dismissed`; `AggregateIssueCodeCounts` returns 1 for that code; `CriticalIssueCodesSorted` still lists the code if the other finding is live (document: dismissed findings are out of the score, the code is still "present" only if a live finding carries it: apply the skip in `forEachIssueCode` so both agree). `ReEvaluateForConfig` test: with a served dismissed entry matching one of the scoped findings, the returned score equals the score of the same result without that finding (compute both).
+
+`cmd/platform_push_test.go`: a fail finding with `Dismissed: true` produces a `platformFinding` with `Status: "fail"` and `Dismissed: true`; the request golden (grep the existing goldens in `docs/platform-push-testing.md` and the test fixtures) shows `"dismissed":true` on that entry and is absent on the others.
+
+Renderer test: a control with one live and one dismissed finding renders the dismissed one with a `dismissed` tag and the failed count reads 1.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./control/ ./cmd/ -run 'Dismissed' -count=1`
+Expected: FAIL (counts 2; no marker; no tag).
+
+- [ ] **Step 3: Implement**
+
+`control/scoring.go`:
+
+```go
+func forEachIssueCode(result *AnalysisResult, fn func(ErrorCode)) {
+	if result == nil {
+		return
+	}
+	for _, f := range result.Findings {
+		if f.Dismissed { // #447: out of the score like not_evaluable, never counted as pass
+			continue
+		}
+		fn(ErrorCode(f.Code))
+	}
+}
+```
+
+`ReEvaluateForConfig`: after `scopedResult.DropNotEvaluableFindings()`: `if conf.PlatformRun != nil && conf.PlatformRun.Context != nil { MarkDismissed(scopedResult.Findings, conf.PlatformRun.Context.DismissedIssues) }`, and `if f.Dismissed { continue }` in its count loop. `cmd/analyze_shared.go`: the same guard-and-call right after each `StampFingerprints`. `platformFinding`: `Dismissed bool \`json:"dismissed,omitempty"\``; in `platformFindingsFor`'s fail branch set it from `f.Dismissed` (extend `decoratedPlatformFinding` or set the field after). `findingGroup.Dismissed int` counted where the group is built; `render_details.go`: in `renderFailedControl`, print each dismissed finding's line with a trailing ` [dismissed on the platform]` and exclude them from the count shown for the control (read how the count is derived; keep `StatusFor` untouched). `docs/platform-push-testing.md`: one paragraph on the marker and how to see it in a captured request.
+
+- [ ] **Step 4: Run, lint, commit**
+
+Run: `go test ./... -count=1 && go vet ./... && make lint && make deadcode`
+
+```bash
+git add cmd/analyze_shared.go control/scoring.go control/lanes.go cmd/platform_push.go cmd/render_details.go control/scoring_dismissed_test.go cmd/platform_push_test.go cmd/*_test.go docs/platform-push-testing.md
+git commit -m "feat(platform): exclude platform-dismissed findings from the score, push the dismissed marker and show it
+
+Closes #447"
+```
+
+---
+
+### Task 5: README and handover notes
+
+**Files:**
+- Modify: `README.md` (platform mode section: one sentence each on the safe.directory behavior, `config_required`, and dismissed findings), `docs/superpowers/specs/2026-09-10-cli-platform-rows-design.md` (a "Shipped" line naming the four commits).
+
+- [ ] **Step 1: Edit and commit**
+
+```bash
+git add README.md docs/superpowers/specs/2026-09-10-cli-platform-rows-design.md
+git commit -m "docs(platform): document the safe checkout, config_required and dismissed findings"
+```
+
+## Self-review notes
+
+- Spec coverage: s1 -> Task 1; s2 -> Task 2; s3 -> Tasks 3, 4; s4 -> Task 5 plus the `Closes` trailers.
+- Type consistency: `identity.PlatformHash(f Finding) (string, int, bool)` used in Task 3's `MarkDismissed`; `opaengine.Finding.Dismissed` read by Task 4's `forEachIssueCode`, `platformFindingsFor` and the renderer; `platform.DismissedIssue` fields match the platform contract (`identity_hash`, `recipe_version`, `control_type`).
+- Plan-time uncertainties flagged in place: the `utils` logger, the GitHub task's finalization site, `LookupCode`'s shape and the `control` -> `internal/platform` import direction, whether the exporters serialize through `MarshalJSON`.

--- a/docs/superpowers/specs/2026-09-10-cli-platform-rows-design.md
+++ b/docs/superpowers/specs/2026-09-10-cli-platform-rows-design.md
@@ -1,0 +1,168 @@
+# CLI <> Platform rows: non-root checkout, unconfigured controls, dismissal propagation (design)
+
+Date: 2026-09-10. Scope: the open-source CLI only (`getplumber/plumber`). Closes #464, #459, #447. The
+platform side of each item is already live or needs only a pin bump (noted per section).
+
+Rows 2 (#448), 3 (#449) and 12 (#454) of the platform's decision queue were checked against
+v0.4.57 before this spec: the identity declarations table is exhaustive and guarded
+(`finding/identity/parity_test.go`), `DeriveIncludeJobs` compares project paths with
+`strings.EqualFold` since commit 81322b0, and the catalog export (#458, v0.4.56) is the source of
+truth the docs site consumes. Nothing remains for them in this repo.
+
+## s1. Platform mode on a root-owned checkout (#464)
+
+**The fact.** The image runs as uid 65532 (`Dockerfile`: `USER plumber`), the GitLab docker
+executor clones `$CI_PROJECT_DIR` as root, and git 2.35.2+ refuses the repository ("detected
+dubious ownership"). `utils.DetectGitRemote`, `DetectGitRepoRoot` and `DetectGitHeadSHA`
+(`utils/gitremote.go`) shell out to git and return nil or "" on ANY error, so `conf.GitRepoRoot`
+is empty and `conf.CheckoutIsAnalyzedProject` is false. Downstream: `computeLocalCIDigest`
+(`cmd/platform_mode.go:83`) refuses the digest and the run is treated as divergent (resolve
+endpoint instead of the free cache hit), `useCheckoutInPlatformMode` (`control/task.go:814`) is
+false so the CI file is fetched anonymously and 404s on a private project, and
+`ConfigAndIncludesAgree` (`internal/platform/run.go:133`) is false so every include-attribution
+control reports `include_attribution_unavailable`. Five controls lost on every platform-mode job
+on the default executor, silently.
+
+**Design.** Two independent levers, both applied.
+
+1. **CLI, self-healing.** Every git shell-out in `utils/gitremote.go` goes through one helper
+   `gitCommand(dir string, args ...string) *exec.Cmd` that prepends `-c safe.directory=<dir>`
+   where `dir` is the absolute working directory being inspected (the process cwd for the two
+   detection calls, `repoRoot` for the HEAD read). `-c` is protected configuration, so git honors
+   it for `safe.directory`; naming the one directory, never `*`, keeps the trust decision narrow.
+   On failure the helper captures stderr and logs at Warn: `git <args> failed in <dir>: <stderr
+   first line>`, so "not a git repository" and "dubious ownership" stop being indistinguishable.
+   The three callers keep their nil/"" contract.
+2. **Component template, belt and braces.** `templates/plumber.yml` gains, before `plumber
+   analyze`, `git config --global --add safe.directory "$CI_PROJECT_DIR"` guarded by `command -v
+   git` (the image has git; a custom image might not). The template's own header says it is the
+   source of truth for the component, so the change is documented there.
+
+**Out of scope.** `ResolvedConfig.Includes` (the resolve endpoint's `includes` are not decoded and
+`ConfigAndIncludesAgree` is snapshot-only): a separate ask, tracked on #464's last paragraph, not
+this batch.
+
+**Tests.** A unit test that the helper's argv is exactly `git -c safe.directory=<dir> <args>`; a
+unit test that a failing git (a fake `git` on PATH exiting 128 with stderr) logs the stderr line
+at Warn and the caller still returns nil; the existing `utils` detection tests unchanged; a
+template test if one exists (grep `plumber.yml` in `*_test.go`), else a yaml parse check that
+the script block still has `plumber analyze` last.
+
+## s2. Unconfigured controls score honestly (#459)
+
+**The fact.** `configuration.ControlMeta.RequiresConfig` (`configuration/registry.go:62`,
+14 controls) is authored truth that a bare `enabled: true` block asserts nothing, but the runtime
+ignores it: the control runs through Rego with zero-valued fields, produces zero findings, and
+`ComputePlumberScore` scores 100 (`control/scoring.go:175`: no denominator, an empty count map is
+100). A fresh policy therefore governs nothing while looking green.
+
+**Ruling (platform decision queue row 19, 2026-09-07).** Empty or absent config on a
+`RequiresConfig` control yields `not_evaluable`, zero points, out of the denominator, with a
+machine-readable reason. No platform-side band-aid; the platform surfaces the reason.
+
+**Design.**
+
+- New reason constant in `control/lanes.go`: `ReasonConfigRequired = "config_required"`, doc: the
+  control is enabled but none of its substantive fields is set, so it asserts nothing.
+- `configuration.IsUnconfigured(pc *PlumberConfig, provider, controlName string) bool`: true iff
+  the control is `RequiresConfig` in `ControlsCatalog()`, its config pointer is non-nil and
+  `IsEnabled()`, and every field of the config struct other than `enabled` is at its zero value
+  (reflection over the struct: nil pointer, empty slice or map, "", 0, false; nested structs
+  recurse). Lives next to `reflectControlSchemas` (`configuration/schema.go`) so the field
+  enumeration is the one the catalog exports (a field the schema exports is a field this check
+  reads).
+- `control.MarkUnconfiguredControls(result *AnalysisResult, entries []ControlEntry, pc
+  *configuration.PlumberConfig, provider string)`: for each non-skipped entry with
+  `IsUnconfigured`, `MarkNotEvaluable(name, ReasonConfigRequired)`. Called at the three sites
+  that already mark lane gaps: the GitLab task (`control/task.go:1103`, next to
+  `MarkOwnCollectionGaps`), the GitHub task's equivalent (`control/task_github.go`, find where
+  its not_evaluable marks or `MarkOwnCollectionGaps` run), and `ReEvaluateForConfig`
+  (`control/lanes.go`, with the SCOPED policy's `pc`, since each platform policy has its own
+  config). First-reason-wins is preserved by calling it AFTER the lane-gap marks (a lane gap is
+  the more specific explanation).
+- No change to `ComputePlumberScore`: a not_evaluable control has no findings and `StatusFor`
+  already reports `StatusError`, which the push maps to `not_evaluable` with `{"reason":
+  "config_required"}` (`cmd/platform_push.go:420,434`). The terminal "Not evaluated" bucket
+  prints the reason already; the CSV/OCSF surfaces read `result.NotEvaluable` directly.
+- Docs: `docs/scoring.md` gains a sentence in "Inputs" (an enabled control with no substantive
+  configuration is not evaluated and does not count); the README's controls section, if it lists
+  `requires_config`, points at it.
+
+**Platform side.** The stored reason is served verbatim; the pin bump to the release carrying
+this adopts the behavior (row 19's "ships with the CLI pin bump"). No contract change.
+
+**Tests.** `IsUnconfigured` table test over: a RequiresConfig control with `enabled: true` only
+(true), the same with one substantive field set (false), a non-RequiresConfig control with
+`enabled: true` only (false), disabled (false), nil (false). An end-to-end analysis test where a
+RequiresConfig control is enabled bare: `StatusFor` is `StatusError`, the push finding is
+`not_evaluable` with reason `config_required`, and the score does not report 100 for a policy
+whose only control is unconfigured (assert the "Not evaluated" bucket carries it and no `pass`
+finding exists for it). `ReEvaluateForConfig` with two policies, one bare and one configured:
+only the bare one is marked.
+
+## s3. Dismissal propagation, the CLI half (#447)
+
+**The fact.** The platform serves `ProjectContext.dismissed_issues` (`[{identity_hash,
+recipe_version, control_type}]`, capped 1000, always present) and accepts an optional
+`dismissed: true` on a pushed finding (orthogonal to `pass|fail|not_evaluable`). The CLI decodes
+neither: `internal/platform.ProjectContext` has no field and `cmd/platform_push.go`'s
+`platformFinding` has no marker. The platform's `identity_hash` is `sha256hex(json.Marshal(
+fields.Pairs()))` over `identity.Of(identity.FromMap(finding data))` (platform `issueident.Hash`);
+`recipe_version` is `identity.RecipeVersion` (4).
+
+**Design.**
+
+- **Wire.** `internal/platform.DismissedIssue{IdentityHash string; RecipeVersion int;
+  ControlType string}` and `ProjectContext.DismissedIssues []DismissedIssue
+  json:"dismissed_issues"` (absent decodes to nil, treated as empty).
+- **Shared recipe, one more exported function.** `finding/identity.PlatformHash(f Finding)
+  (hash string, version int, ok bool)`: `Of(f)`, then `sha256` hex over
+  `json.Marshal(fields.Pairs())`, version `RecipeVersion`. Byte-identical to the platform's
+  `issueident.Hash` by construction (same input, same marshal, same digest); a golden test pins
+  one fixture's hash so a later change to `Pairs()` or the marshal breaks loudly. The platform
+  will delegate `issueident.Hash` to it on its next pin bump (platform follow-up, not this repo).
+- **Match and mark.** `opaengine.Finding` gains `Dismissed bool` (`json:"-"`, NOT emitted by
+  `MarshalJSON`: the marker rides the push envelope, not the finding data the platform hashes).
+  `control.MarkDismissed(findings []opaengine.Finding, served []platform.DismissedIssue) int`:
+  builds a set of `(hash, version)` from the served entries whose `RecipeVersion ==
+  identity.RecipeVersion` (others skipped, honest non-suppression), pre-filters by
+  `ControlType == LookupCode(f.Code).ControlName` (cheap, not part of the key), computes
+  `identity.PlatformHash(f.identityInput())` and sets `Dismissed` on a match; returns the count.
+  Called once on `result.Findings` in the platform-mode analysis path after `StampFingerprints`
+  and before scoring (`cmd/analyze_shared.go` ~:37 and ~:455), and in `ReEvaluateForConfig`
+  on the scoped findings (the served list is the same; it must be reachable from `conf`:
+  thread `conf.PlatformRun.Context.DismissedIssues`, read how `PlatformRun` exposes the
+  `RunContext`). Standalone mode: nothing served, nothing marked.
+- **Score.** `AggregateIssueCodeCounts` skips `Dismissed` findings; `ReEvaluateForConfig`'s own
+  count loop skips them too. Out of the denominator like `not_evaluable`, never counted as pass.
+  `ComputePlumberScore` itself is unchanged.
+- **Push.** `platformFinding` gains `Dismissed bool json:"dismissed,omitempty"`;
+  `platformFindingsFor` sets it from the finding on the `StatusFailed` branch. A control whose
+  every finding is dismissed still reports those findings as `fail` with the marker (never
+  omitted, never `pass`: omitting would read as Fixed platform-side).
+- **Display.** `findingGroup` (`cmd/analyze_shared.go`) gains `Dismissed int`; the terminal
+  renderer (`cmd/render_details.go`) prints dismissed findings inside the control's section
+  with a `dismissed` tag and excludes them from the failed count; `StatusFor` is unchanged (a
+  control with only dismissed findings still has `findingCount > 0` and reads failed on the
+  console: the platform's issue status is the authority; the score is what the marker changes).
+  JSON/CSV/OCSF: the finding carries `dismissed: true` in the CLI's own exports (add it to
+  `MarshalJSON` ONLY for those exporters? No: keep `MarshalJSON` unchanged for hash stability and
+  add the field in the exporters' own row builders where they already add `fingerprint`; if an
+  exporter serializes the finding through `MarshalJSON` directly, leave it and note it).
+
+**Sequencing.** No flag day: the platform accepts the marker today and excludes Dismissed issues
+from its own recompute by stored status, so a CLI that marks and excludes agrees with the
+platform card. The platform pin bump adopts `PlatformHash` and this scoring input change together.
+
+**Tests.** `PlatformHash` golden; `MarkDismissed` table (match, version mismatch skipped, control
+prefilter, codeless finding never matches, empty served list); `AggregateIssueCodeCounts` skips
+dismissed; `ReEvaluateForConfig` skips dismissed; push payload carries `dismissed: true` on the
+fail entry and the request golden (the platform push testing doc, `docs/platform-push-testing.md`)
+updated; renderer shows the tag.
+
+## s4. Records
+
+Each fix is one conventional commit whose body says `Closes #<n>`; the CHANGELOG is generated by
+semantic-release. `docs/platform-push-testing.md` and `docs/scoring.md` updated where s2/s3 say.
+The platform's decision queue rows 17 and 19 flip to SHIPPED, and rows 2, 3, 12 to "resolved
+upstream (#458, 81322b0)", in the platform pin-bump PR that follows the release.

--- a/docs/superpowers/specs/2026-09-10-cli-platform-rows-design.md
+++ b/docs/superpowers/specs/2026-09-10-cli-platform-rows-design.md
@@ -33,20 +33,26 @@ on the default executor, silently.
    On failure the helper captures stderr and logs at Warn: `git <args> failed in <dir>: <stderr
    first line>`, so "not a git repository" and "dubious ownership" stop being indistinguishable.
    The three callers keep their nil/"" contract.
-2. **Component template, belt and braces.** `templates/plumber.yml` gains, before `plumber
-   analyze`, `git config --global --add safe.directory "$CI_PROJECT_DIR"` guarded by `command -v
-   git` (the image has git; a custom image might not). The template's own header says it is the
-   source of truth for the component, so the change is documented there.
+2. **Component template, belt and braces. DROPPED** (whole-branch security review,
+   2026-09-10). The line `git config --global --add safe.directory "$CI_PROJECT_DIR"` was added
+   to `templates/plumber.yml` before `plumber analyze` and then removed again: lever 1 is the
+   complete fix (`-c` is protected configuration, so any git that enforces ownership honours it,
+   which makes the "custom image whose git predates that" case empty), while a global `--add`
+   costs real safety. It appends on every job, forever, on a shell executor with a persistent
+   HOME, and a project that shadows `CI_PROJECT_DIR` with `*` writes a permanent global wildcard
+   into the runner's git config, trusting every repository it will ever check out. Only lever 1
+   ships.
 
 **Out of scope.** `ResolvedConfig.Includes` (the resolve endpoint's `includes` are not decoded and
 `ConfigAndIncludesAgree` is snapshot-only): a separate ask, tracked on #464's last paragraph, not
 this batch.
 
-**Tests.** A unit test that the helper's argv is exactly `git -c safe.directory=<dir> <args>`; a
-unit test that a failing git (a fake `git` on PATH exiting 128 with stderr) logs the stderr line
-at Warn and the caller still returns nil; the existing `utils` detection tests unchanged; a
-template test if one exists (grep `plumber.yml` in `*_test.go`), else a yaml parse check that
-the script block still has `plumber analyze` last.
+**Tests.** A unit test that the helper's argv is exactly `git -c safe.directory=<dir> <args>`, and
+one that an EMPTY dir omits the argument entirely (an empty value resets git's safe list rather
+than adding to it); a unit test that a failing git (a fake `git` on PATH exiting 128 with stderr)
+logs the stderr line at Warn and the caller still returns nil; a unit test that a credential in a
+remote URL is redacted out of that log line; the existing `utils` detection tests unchanged. No
+template test: lever 2 is dropped, so the template is unchanged by this batch.
 
 ## s2. Unconfigured controls score honestly (#459)
 
@@ -165,3 +171,30 @@ Each fix is one conventional commit whose body says `Closes #<n>`; the CHANGELOG
 semantic-release. `docs/platform-push-testing.md` and `docs/scoring.md` updated where s2/s3 say.
 The platform's decision queue rows 17 and 19 flip to SHIPPED, and rows 2, 3, 12 to "resolved
 upstream (#458, 81322b0)", in the platform pin-bump PR that follows the release.
+
+## Shipped
+
+- `c3e3fba` - declare the checkout safe for git per invocation and log git failures.
+- `6a29251` - stop the safedir logrus leak and log "not a git repository" at Debug, other
+  failures at Warn.
+- `6db7d07` - report an enabled but unconfigured `RequiresConfig` control as `not_evaluable`
+  (`config_required`) instead of a vacuous pass.
+- `9653a9f` - correct the #459 score claim, recurse nested config blocks in `IsUnconfigured`,
+  and mark GitHub unconfigured controls before report assembly.
+- `8c40f16` - decode `dismissed_issues` from the platform context, add `identity.PlatformHash`,
+  and mark matching findings `Dismissed`.
+- `0ee25ac` - mirror the push-side raw-code fallback in the dismissed control key.
+- `4875154` - exclude dismissed findings from the score, push the `dismissed` marker, and show
+  it in the terminal renderer.
+- `0f650cc` - stamp per-policy findings before dismissed matching, add the CSV/OCSF dismissed
+  markers.
+
+Two follow-ups are open, not in this repo:
+
+1. **Platform fix for `dismissed_issues.recipe_version`.** The field is served from the
+   platform's `hash_version` today; the CLI matches served entries on the recipe version per the
+   contract (`identity.RecipeVersion`), so the platform side needs to serve the recipe version,
+   not the hash version, for the match to hold as the two evolve independently.
+2. **Whether a policy with no evaluable control should have its score withheld.** Open on the
+   platform's decision queue (also noted in `docs/scoring.md`): today such a policy can still
+   read 100 while every one of its controls is `not_evaluable`.

--- a/docs/superpowers/specs/2026-09-10-cli-platform-rows-design.md
+++ b/docs/superpowers/specs/2026-09-10-cli-platform-rows-design.md
@@ -95,9 +95,8 @@ this adopts the behavior (row 19's "ships with the CLI pin bump"). No contract c
 (true), the same with one substantive field set (false), a non-RequiresConfig control with
 `enabled: true` only (false), disabled (false), nil (false). An end-to-end analysis test where a
 RequiresConfig control is enabled bare: `StatusFor` is `StatusError`, the push finding is
-`not_evaluable` with reason `config_required`, and the score does not report 100 for a policy
-whose only control is unconfigured (assert the "Not evaluated" bucket carries it and no `pass`
-finding exists for it). `ReEvaluateForConfig` with two policies, one bare and one configured:
+`not_evaluable` with reason `config_required` (assert the "Not evaluated" bucket carries it and
+no `pass` finding exists for it). `ReEvaluateForConfig` with two policies, one bare and one configured:
 only the bare one is marked.
 
 ## s3. Dismissal propagation, the CLI half (#447)

--- a/finding/identity/identity.go
+++ b/finding/identity/identity.go
@@ -35,6 +35,7 @@ package identity
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"slices"
 	"strings"
 )
@@ -224,6 +225,25 @@ func Of(f Finding) (Fields, bool) {
 		out.Selected = append(out.Selected, Field{Key: key, Value: v})
 	}
 	return out, true
+}
+
+// PlatformHash returns the digest the platform stores as an issue's identity_hash (its own
+// issueident.Hash): sha256 hex over json.Marshal(Of(f).Pairs()), full length, plus the recipe
+// version the fields were selected under. ok is false for a codeless finding. Distinct from
+// Fingerprint (the truncated export identifier over canonical()): the two never had to agree
+// on a hash, only on the field selection, and this function exists so the CLI can match the
+// platform's served dismissed_issues (#447) without a second recipe.
+func PlatformHash(f Finding) (hash string, version int, ok bool) {
+	fields, ok := Of(f)
+	if !ok {
+		return "", 0, false
+	}
+	pairs, err := json.Marshal(fields.Pairs())
+	if err != nil {
+		return "", 0, false
+	}
+	sum := sha256.Sum256(pairs)
+	return hex.EncodeToString(sum[:]), fields.Version, true
 }
 
 // Fingerprint returns the short, line-independent identifier of a finding: the

--- a/finding/identity/platformhash_test.go
+++ b/finding/identity/platformhash_test.go
@@ -1,0 +1,36 @@
+package identity
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+)
+
+// TestPlatformHash_MatchesThePlatformDigest pins #447: PlatformHash is sha256 hex over
+// json.Marshal(fields.Pairs()), the platform's own issueident.Hash by construction, so a
+// dismissed issue served by identity_hash matches the CLI's finding without a second recipe.
+func TestPlatformHash_MatchesThePlatformDigest(t *testing.T) {
+	f := Finding{Code: "ISSUE-103", File: ".gitlab-ci.yml", Job: "build", Message: "m", Data: map[string]any{"image": "nginx:latest"}}
+	fields, ok := Of(f)
+	if !ok {
+		t.Fatal("fixture must have a code")
+	}
+	pairs, _ := json.Marshal(fields.Pairs())
+	sum := sha256.Sum256(pairs)
+	want := hex.EncodeToString(sum[:])
+	got, version, ok := PlatformHash(f)
+	if !ok || got != want || version != RecipeVersion {
+		t.Fatalf("PlatformHash = (%q, %d, %v), want (%q, %d, true)", got, version, ok, want, RecipeVersion)
+	}
+	if _, _, ok := PlatformHash(Finding{}); ok {
+		t.Error("a codeless finding has no identity and no platform hash")
+	}
+
+	// wire-stable: the platform stores this digest; changing Pairs() or the marshal is a recipe
+	// bump.
+	const golden = "b8d0fa47166be499d224422c5481db6aa9dca50849f8747e151d6bbda410c6dc"
+	if got != golden {
+		t.Fatalf("PlatformHash golden mismatch: got %q, want %q (Pairs() or the marshal changed)", got, golden)
+	}
+}

--- a/internal/engine/opa/dismissed_test.go
+++ b/internal/engine/opa/dismissed_test.go
@@ -1,0 +1,43 @@
+package opa
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// The platform hashes a finding's serialized JSON object as part of its own identity
+// computation, so MarshalJSON must never let the CLI-local Dismissed marker (#447) leak into
+// that object: a finding marshaled with Dismissed true or false must produce byte-identical
+// output, with no "dismissed" key either way.
+func TestFindingMarshalJSON_NeverEmitsDismissed(t *testing.T) {
+	base := Finding{
+		Code: "ISSUE-103", File: ".gitlab-ci.yml", Job: "build", Message: "m",
+		Data: map[string]any{"imageRepo": "nginx"},
+	}
+	notDismissed := base
+	notDismissed.Dismissed = false
+	dismissed := base
+	dismissed.Dismissed = true
+
+	gotNot, err := json.Marshal(notDismissed)
+	if err != nil {
+		t.Fatalf("marshal (Dismissed=false): %v", err)
+	}
+	gotDismissed, err := json.Marshal(dismissed)
+	if err != nil {
+		t.Fatalf("marshal (Dismissed=true): %v", err)
+	}
+
+	if !bytes.Equal(gotNot, gotDismissed) {
+		t.Fatalf("Dismissed changed the marshaled bytes: false=%s true=%s", gotNot, gotDismissed)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(gotDismissed, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, present := decoded["dismissed"]; present {
+		t.Fatalf("MarshalJSON must never emit a \"dismissed\" key, got %s", gotDismissed)
+	}
+}

--- a/internal/engine/opa/engine.go
+++ b/internal/engine/opa/engine.go
@@ -53,8 +53,12 @@ type Finding struct {
 	// stamped once by StampFingerprints so every output format carries the same
 	// value and a consumer can track the same finding across runs even as line
 	// numbers drift. Empty until stamped, and for codeless findings.
-	Fingerprint string         `json:"-"`
-	Data        map[string]any `json:"-"`
+	Fingerprint string `json:"-"`
+	// Dismissed is set by control.MarkDismissed when the platform served this finding's identity
+	// as dismissed (#447); never emitted by MarshalJSON (the platform hashes that object) and
+	// never a status: pass|fail|not_evaluable is frozen.
+	Dismissed bool           `json:"-"`
+	Data      map[string]any `json:"-"`
 }
 
 // MarshalJSON flattens the canonical fields and the Data payload into
@@ -115,6 +119,13 @@ func (f Finding) identityInput() identity.Finding {
 		Message: f.Message,
 		Data:    f.Data,
 	}
+}
+
+// IdentityInput is the exported form of identityInput, for a caller outside this package that
+// needs the identity recipe's own view of the finding: the control package hashes it against the
+// platform's served dismissed_issues (#447) without duplicating the field selection.
+func (f Finding) IdentityInput() identity.Finding {
+	return f.identityInput()
 }
 
 // computeFingerprint hashes the identity field set above into the short, stable

--- a/internal/platform/types.go
+++ b/internal/platform/types.go
@@ -406,14 +406,26 @@ func (s Snapshot) Anchor() *ResolutionAnchor {
 	return s.Data.ResolutionAnchor
 }
 
+// DismissedIssue is one entry of ProjectContext.DismissedIssues: the match key for a finding the
+// platform has in status Dismissed (#447). IdentityHash is the platform's full sha256 hex over
+// the shared recipe's Pairs() (identity.PlatformHash); RecipeVersion is the recipe the hash was
+// computed under and versions never mix; ControlType rides along as a cheap pre-filter, never
+// part of the key.
+type DismissedIssue struct {
+	IdentityHash  string `json:"identity_hash"`
+	RecipeVersion int    `json:"recipe_version"`
+	ControlType   string `json:"control_type"`
+}
+
 // ProjectContext is the GET .../context response: the resolved policy set
 // plus the cached data snapshot. Fetching it never triggers a collection on
 // the platform - it is always a cache read.
 type ProjectContext struct {
-	SchemaVersion int      `json:"schema_version"`
-	Project       string   `json:"project"`
-	Policies      []Policy `json:"policies"`
-	Snapshot      Snapshot `json:"snapshot"`
+	SchemaVersion   int              `json:"schema_version"`
+	Project         string           `json:"project"`
+	Policies        []Policy         `json:"policies"`
+	Snapshot        Snapshot         `json:"snapshot"`
+	DismissedIssues []DismissedIssue `json:"dismissed_issues"`
 }
 
 // ResolveRequest asks the platform to resolve the CI config at a specific

--- a/internal/platform/types_test.go
+++ b/internal/platform/types_test.go
@@ -1,0 +1,40 @@
+package platform
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// dismissed_issues (#447) is forward-tolerant like every other /context field:
+// absent decodes to nil, treated the same as an empty served list, and present
+// decodes into the three-field match key.
+func TestProjectContext_DecodesDismissedIssues(t *testing.T) {
+	t.Run("absent", func(t *testing.T) {
+		var ctx ProjectContext
+		if err := json.Unmarshal([]byte(`{"schema_version":1,"project":"grp/app","policies":[],"snapshot":{}}`), &ctx); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if ctx.DismissedIssues != nil {
+			t.Fatalf("DismissedIssues = %#v, want nil when the field is absent", ctx.DismissedIssues)
+		}
+	})
+
+	t.Run("present", func(t *testing.T) {
+		body := `{"schema_version":1,"project":"grp/app","policies":[],"snapshot":{},
+		  "dismissed_issues":[
+		    {"identity_hash":"abc123","recipe_version":4,"control_type":"containerImageMustNotUseForbiddenTags"}
+		  ]}`
+		var ctx ProjectContext
+		if err := json.Unmarshal([]byte(body), &ctx); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(ctx.DismissedIssues) != 1 {
+			t.Fatalf("DismissedIssues = %#v, want exactly one entry", ctx.DismissedIssues)
+		}
+		got := ctx.DismissedIssues[0]
+		want := DismissedIssue{IdentityHash: "abc123", RecipeVersion: 4, ControlType: "containerImageMustNotUseForbiddenTags"}
+		if got != want {
+			t.Fatalf("DismissedIssues[0] = %#v, want %#v", got, want)
+		}
+	})
+}

--- a/templates/plumber.yml
+++ b/templates/plumber.yml
@@ -217,10 +217,6 @@ spec:
     # a custom threshold reaches the CLI (and triggers the deprecation
     # warning there).
     - if [ "${PLUMBER_ANALYZE_THRESHOLD:-}" = "100" ]; then unset PLUMBER_ANALYZE_THRESHOLD; fi
-    # The docker executor clones $CI_PROJECT_DIR as root while this image runs as uid 65532;
-    # git refuses a repository owned by another uid unless it is declared safe (#464). The CLI
-    # also declares it per invocation; this line covers a custom image whose git predates that.
-    - if command -v git >/dev/null 2>&1 && [ -n "${CI_PROJECT_DIR:-}" ]; then git config --global --add safe.directory "$CI_PROJECT_DIR"; fi
     - plumber analyze
   artifacts:
     paths:

--- a/templates/plumber.yml
+++ b/templates/plumber.yml
@@ -217,6 +217,10 @@ spec:
     # a custom threshold reaches the CLI (and triggers the deprecation
     # warning there).
     - if [ "${PLUMBER_ANALYZE_THRESHOLD:-}" = "100" ]; then unset PLUMBER_ANALYZE_THRESHOLD; fi
+    # The docker executor clones $CI_PROJECT_DIR as root while this image runs as uid 65532;
+    # git refuses a repository owned by another uid unless it is declared safe (#464). The CLI
+    # also declares it per invocation; this line covers a custom image whose git predates that.
+    - if command -v git >/dev/null 2>&1 && [ -n "${CI_PROJECT_DIR:-}" ]; then git config --global --add safe.directory "$CI_PROJECT_DIR"; fi
     - plumber analyze
   artifacts:
     paths:

--- a/utils/gitremote.go
+++ b/utils/gitremote.go
@@ -1,12 +1,15 @@
 package utils
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 // GitRemoteInfo contains parsed information from a git remote URL.
@@ -92,18 +95,56 @@ func hasGitHubWorkflows(repoRoot string) bool {
 	return false
 }
 
+// gitCommand builds a git invocation scoped to dir with dir declared as safe.directory (#464).
+// -c is protected configuration, so git honors safe.directory from it even when the repository
+// is owned by another uid (the GitLab docker executor clones $CI_PROJECT_DIR as root while the
+// image runs as uid 65532); git >= 2.35.2 otherwise refuses with "detected dubious ownership".
+// The single inspected directory is named, never '*': the trust decision stays as narrow as the
+// question being asked.
+func gitCommand(dir string, args ...string) *exec.Cmd {
+	full := append([]string{"-c", "safe.directory=" + dir}, args...)
+	cmd := exec.Command("git", full...)
+	cmd.Dir = dir
+	return cmd
+}
+
+// runGit runs a gitCommand and returns its trimmed stdout. On failure it logs the first stderr
+// line (#464): before this, a dubious-ownership refusal and "not a git repository" were
+// indistinguishable to every caller, and platform mode silently lost five controls on the
+// default executor with nothing in the job log to explain it.
+//
+// "not a git repository" is the routine, expected case for every plumber invocation outside a
+// git checkout (`plumber analyze` runs at Warn by default), so it logs at Debug; any other
+// failure, dubious ownership included, is unexpected in a real checkout and logs at Warn.
+func runGit(dir string, args ...string) (string, error) {
+	cmd := gitCommand(dir, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		first := strings.SplitN(strings.TrimSpace(stderr.String()), "\n", 2)[0]
+		entry := logrus.WithFields(logrus.Fields{"dir": dir, "args": strings.Join(args, " ")})
+		if strings.Contains(first, "not a git repository") {
+			entry.Debugf("git %s failed: %s", strings.Join(args, " "), first)
+		} else {
+			entry.Warnf("git %s failed: %s", strings.Join(args, " "), first)
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // DetectGitRemote attempts to detect GitLab URL and project path from git remote.
 // It tries the "origin" remote first.
 // Returns nil if detection fails (not a git repo, no remote, not a GitLab URL, etc.)
 func DetectGitRemote() *GitRemoteInfo {
 	// Try to get the origin remote URL
-	cmd := exec.Command("git", "remote", "get-url", "origin")
-	output, err := cmd.Output()
+	dir, _ := os.Getwd()
+	remoteURL, err := runGit(dir, "remote", "get-url", "origin")
 	if err != nil {
 		return nil
 	}
 
-	remoteURL := strings.TrimSpace(string(output))
 	if remoteURL == "" {
 		return nil
 	}
@@ -129,12 +170,12 @@ func DetectGitRemote() *GitRemoteInfo {
 // DetectGitRepoRoot returns the absolute path to the root of the current git repository.
 // Returns an empty string if not in a git repository.
 func DetectGitRepoRoot() string {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	output, err := cmd.Output()
+	dir, _ := os.Getwd()
+	out, err := runGit(dir, "rev-parse", "--show-toplevel")
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(output))
+	return out
 }
 
 // DetectGitHeadSHA returns the full commit SHA of HEAD at repoRoot.
@@ -146,12 +187,11 @@ func DetectGitHeadSHA(repoRoot string) string {
 	if repoRoot == "" {
 		return ""
 	}
-	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "HEAD")
-	output, err := cmd.Output()
+	out, err := runGit(repoRoot, "rev-parse", "HEAD")
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(output))
+	return out
 }
 
 // ParseGitRemoteURL parses a git remote URL and extracts host and project path.

--- a/utils/gitremote.go
+++ b/utils/gitremote.go
@@ -101,11 +101,33 @@ func hasGitHubWorkflows(repoRoot string) bool {
 // image runs as uid 65532); git >= 2.35.2 otherwise refuses with "detected dubious ownership".
 // The single inspected directory is named, never '*': the trust decision stays as narrow as the
 // question being asked.
+//
+// An empty dir means "run wherever the process already is" (a cwd caller whose os.Getwd failed),
+// and the -c argument is then omitted entirely rather than emitted empty: `safe.directory=` with
+// an empty value is git's documented way to RESET the list, so passing it would discard whatever
+// entries a real global config carries instead of adding one.
 func gitCommand(dir string, args ...string) *exec.Cmd {
-	full := append([]string{"-c", "safe.directory=" + dir}, args...)
+	full := args
+	if dir != "" {
+		full = append([]string{"-c", "safe.directory=" + dir}, args...)
+	}
 	cmd := exec.Command("git", full...)
 	cmd.Dir = dir
 	return cmd
+}
+
+// credentialInURL matches a URL's userinfo segment: everything between "://" and the "@" that
+// closes it. Deliberately greedy about what counts as userinfo (any run of characters that is
+// not a slash, another "@" or whitespace) and blind to what it means: a bare
+// `https://<token>@host` carries a secret in the position an ordinary user name occupies, so
+// telling the two apart is guesswork a log line does not need to attempt.
+var credentialInURL = regexp.MustCompile(`://[^/@\s]+@`)
+
+// redactCredentials rewrites every `://<userinfo>@` segment of s to `://***@`, so a remote URL
+// echoed back by git cannot carry a token into a log line. Everything else is left byte for
+// byte: the point of logging git's own message is that it is git's own message.
+func redactCredentials(s string) string {
+	return credentialInURL.ReplaceAllString(s, "://***@")
 }
 
 // runGit runs a gitCommand and returns its trimmed stdout. On failure it logs the first stderr
@@ -113,20 +135,34 @@ func gitCommand(dir string, args ...string) *exec.Cmd {
 // indistinguishable to every caller, and platform mode silently lost five controls on the
 // default executor with nothing in the job log to explain it.
 //
-// "not a git repository" is the routine, expected case for every plumber invocation outside a
-// git checkout (`plumber analyze` runs at Warn by default), so it logs at Debug; any other
-// failure, dubious ownership included, is unexpected in a real checkout and logs at Warn.
+// Two cases are routine, expected and log at Debug rather than Warn (`plumber analyze` runs at
+// Warn by default, and the wizard runs in front of a user): "not a git repository", which is every
+// plumber invocation outside a checkout, and a failure with NOTHING on stderr, which is how git
+// reports a question with no answer - `config --get remote.origin.url` in a repository that has no
+// origin exits 1 and says nothing. Warning about the latter printed an empty message mid-wizard.
+// Any other failure, dubious ownership included, is unexpected in a real checkout and logs at Warn.
+//
+// The logged stderr line goes through redactCredentials, which covers the credentials git echoes
+// back from a remote URL. That is the ONLY redaction here, so this helper must not be used for a
+// network-touching git command (fetch, ls-remote, clone, push) without extending it: those
+// commands report far more of their inputs on failure - proxy settings, request headers, an
+// askpass-supplied credential - and none of that is covered today. The local inspections it
+// serves (remote get-url, rev-parse) print the repository path and, at most, the configured
+// remote URL.
 func runGit(dir string, args ...string) (string, error) {
 	cmd := gitCommand(dir, args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		first := strings.SplitN(strings.TrimSpace(stderr.String()), "\n", 2)[0]
+		first := redactCredentials(strings.SplitN(strings.TrimSpace(stderr.String()), "\n", 2)[0])
 		entry := logrus.WithFields(logrus.Fields{"dir": dir, "args": strings.Join(args, " ")})
-		if strings.Contains(first, "not a git repository") {
+		switch {
+		case first == "":
+			entry.Debugf("git %s failed with no output", strings.Join(args, " "))
+		case strings.Contains(first, "not a git repository"):
 			entry.Debugf("git %s failed: %s", strings.Join(args, " "), first)
-		} else {
+		default:
 			entry.Warnf("git %s failed: %s", strings.Join(args, " "), first)
 		}
 		return "", err
@@ -134,11 +170,29 @@ func runGit(dir string, args ...string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// GitOutput runs a read-only git command in dir and returns its trimmed stdout, with the same
+// safe.directory declaration and the same failure diagnostics every git shell-out in this package
+// gets. It exists so that a caller outside this package (`plumber init`, reading the origin
+// remote) does not reach for exec.Command directly and quietly reintroduce #464: a raw invocation
+// is refused on a checkout owned by another uid, and says nothing about why.
+//
+// The contract on runGit applies unchanged: local inspections only, never a network-touching git
+// command.
+func GitOutput(dir string, args ...string) (string, error) {
+	return runGit(dir, args...)
+}
+
 // DetectGitRemote attempts to detect GitLab URL and project path from git remote.
 // It tries the "origin" remote first.
 // Returns nil if detection fails (not a git repo, no remote, not a GitLab URL, etc.)
 func DetectGitRemote() *GitRemoteInfo {
-	// Try to get the origin remote URL
+	// Try to get the origin remote URL.
+	//
+	// The declared directory is the process cwd, and git matches safe.directory against the
+	// WORKTREE ROOT, not the directory it was started in: a run from a subdirectory of a
+	// foreign-owned clone is therefore still refused. That is not the #464 scenario (a CI job
+	// runs at the project root, which is exactly what gets declared here), and walking up to the
+	// root before declaring it is a possible follow-up rather than something this needs.
 	dir, _ := os.Getwd()
 	remoteURL, err := runGit(dir, "remote", "get-url", "origin")
 	if err != nil {
@@ -170,6 +224,8 @@ func DetectGitRemote() *GitRemoteInfo {
 // DetectGitRepoRoot returns the absolute path to the root of the current git repository.
 // Returns an empty string if not in a git repository.
 func DetectGitRepoRoot() string {
+	// Same cwd caveat as DetectGitRemote: safe.directory is matched on the worktree root, so this
+	// declaration only covers a run started at the root itself.
 	dir, _ := os.Getwd()
 	out, err := runGit(dir, "rev-parse", "--show-toplevel")
 	if err != nil {

--- a/utils/gitremote_safedir_test.go
+++ b/utils/gitremote_safedir_test.go
@@ -1,0 +1,110 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+// captureLogrus installs a test hook on the package-global logger at Debug level and restores
+// the original level and hook set in t.Cleanup. logrus.StandardLogger() is process-global, so
+// without this restoration a test that raises the level or adds a hook leaks both into every
+// later test of the same binary.
+func captureLogrus(t *testing.T) *test.Hook {
+	t.Helper()
+	std := logrus.StandardLogger()
+	savedLevel := std.GetLevel()
+	savedHooks := std.Hooks
+	std.SetLevel(logrus.DebugLevel)
+	hook := test.NewLocal(std)
+	t.Cleanup(func() {
+		std.ReplaceHooks(savedHooks)
+		std.SetLevel(savedLevel)
+	})
+	return hook
+}
+
+// TestGitCommand_NamesTheDirectoryAsSafe pins #464: every git shell-out passes the inspected
+// directory as protected safe.directory configuration, so a checkout owned by another uid (the
+// GitLab docker executor clones as root, the image runs as uid 65532) is readable without a
+// global git config the image does not carry. The one directory, never '*'.
+func TestGitCommand_NamesTheDirectoryAsSafe(t *testing.T) {
+	cmd := gitCommand("/builds/group/project", "rev-parse", "--show-toplevel")
+	want := []string{"git", "-c", "safe.directory=/builds/group/project", "rev-parse", "--show-toplevel"}
+	if strings.Join(cmd.Args, " ") != strings.Join(want, " ") {
+		t.Fatalf("argv = %q, want %q", cmd.Args, want)
+	}
+	if cmd.Dir != "/builds/group/project" {
+		t.Fatalf("Dir = %q, want the inspected directory", cmd.Dir)
+	}
+}
+
+// fakeGit puts a fake `git` binary on PATH (via t.Setenv) that writes stderr and exits 128,
+// mimicking a real git failure without depending on one being installed or on the test's own
+// checkout state.
+func fakeGit(t *testing.T, stderr string) {
+	t.Helper()
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "git")
+	script := "#!/bin/sh\necho \"" + stderr + "\" >&2\nexit 128\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+}
+
+// TestDetectGitRepoRoot_LogsTheGitErrorAtWarn pins #464: a git failure that is not the routine
+// "not a git repository" case is no longer silent. A fake git on PATH exits 128 with the
+// dubious-ownership message; the caller still gets "" (its contract) and the first stderr line
+// is logged at Warn so the job log explains the degraded run.
+func TestDetectGitRepoRoot_LogsTheGitErrorAtWarn(t *testing.T) {
+	fakeGit(t, "fatal: detected dubious ownership in repository at '/builds/x'")
+	hook := captureLogrus(t)
+
+	if got := DetectGitRepoRoot(); got != "" {
+		t.Fatalf("repo root = %q, want empty on git failure", got)
+	}
+	var foundWarn bool
+	for _, e := range hook.AllEntries() {
+		if e.Level == logrus.WarnLevel && strings.Contains(e.Message, "dubious ownership") {
+			foundWarn = true
+		}
+	}
+	if !foundWarn {
+		t.Fatalf("no Warn entry naming the git error; entries: %+v", hook.AllEntries())
+	}
+}
+
+// TestDetectGitRepoRoot_NotAGitRepositoryLogsAtDebugOnly pins the noise fix: `plumber analyze`
+// runs at Warn by default, and every invocation outside a git checkout is a routine, expected
+// case, not a degraded run worth surfacing at Warn. A fake git emitting the ordinary
+// "not a git repository" refusal must log at Debug and must NOT log at Warn.
+func TestDetectGitRepoRoot_NotAGitRepositoryLogsAtDebugOnly(t *testing.T) {
+	fakeGit(t, "fatal: not a git repository (or any of the parent directories): .git")
+	hook := captureLogrus(t)
+
+	if got := DetectGitRepoRoot(); got != "" {
+		t.Fatalf("repo root = %q, want empty on git failure", got)
+	}
+	var foundDebug, foundWarn bool
+	for _, e := range hook.AllEntries() {
+		if strings.Contains(e.Message, "not a git repository") {
+			switch e.Level {
+			case logrus.DebugLevel:
+				foundDebug = true
+			case logrus.WarnLevel:
+				foundWarn = true
+			}
+		}
+	}
+	if !foundDebug {
+		t.Fatalf("no Debug entry naming the git error; entries: %+v", hook.AllEntries())
+	}
+	if foundWarn {
+		t.Fatalf("a Warn entry was logged for the routine \"not a git repository\" case; entries: %+v", hook.AllEntries())
+	}
+}

--- a/utils/gitremote_safedir_test.go
+++ b/utils/gitremote_safedir_test.go
@@ -108,3 +108,138 @@ func TestDetectGitRepoRoot_NotAGitRepositoryLogsAtDebugOnly(t *testing.T) {
 		t.Fatalf("a Warn entry was logged for the routine \"not a git repository\" case; entries: %+v", hook.AllEntries())
 	}
 }
+
+// TestGitCommand_EmptyDirOmitsSafeDirectory pins the reason the argument is conditional: an
+// empty `-c safe.directory=` does not name "nothing", it RESETS git's safe list, dropping the
+// entries a real global config may legitimately carry. The two cwd callers derive dir from
+// os.Getwd, which can fail, so the helper must never emit the empty value.
+func TestGitCommand_EmptyDirOmitsSafeDirectory(t *testing.T) {
+	cmd := gitCommand("", "rev-parse", "HEAD")
+	want := []string{"git", "rev-parse", "HEAD"}
+	if strings.Join(cmd.Args, " ") != strings.Join(want, " ") {
+		t.Fatalf("argv = %q, want %q: an empty safe.directory value resets git's list", cmd.Args, want)
+	}
+	if cmd.Dir != "" {
+		t.Fatalf("Dir = %q, want empty (git runs in the process cwd)", cmd.Dir)
+	}
+}
+
+// TestRedactCredentials pins that a credential embedded in a remote URL never reaches a log
+// line. git echoes the remote it was given back in its error messages, and a token in the
+// userinfo segment (`https://oauth2:<token>@host/...`, or a bare `https://<token>@host/...`) is
+// exactly what a CI job hands it.
+func TestRedactCredentials(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{
+			"fatal: unable to access 'https://oauth2:glpat-secret@gitlab.example.com/g/p.git/': 403",
+			"fatal: unable to access 'https://***@gitlab.example.com/g/p.git/': 403",
+		},
+		{
+			"fatal: could not read Username for 'https://token@github.com'",
+			"fatal: could not read Username for 'https://***@github.com'",
+		},
+		{
+			// Two remotes in one line: every occurrence goes, not just the first.
+			"https://a:b@one.example.com and https://c:d@two.example.com",
+			"https://***@one.example.com and https://***@two.example.com",
+		},
+		{
+			// The SSH form carries no secret, but the user name is redacted too:
+			// telling "harmless user name" from "token used as the user" apart is
+			// guesswork, and the log line needs neither.
+			"ssh://git@gitlab.example.com/g/p.git",
+			"ssh://***@gitlab.example.com/g/p.git",
+		},
+		{
+			"fatal: detected dubious ownership in repository at '/builds/g/p'",
+			"fatal: detected dubious ownership in repository at '/builds/g/p'",
+		},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := redactCredentials(c.in); got != c.want {
+			t.Errorf("redactCredentials(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestRunGit_LogsRedactedStderr pins the redaction where it matters: on the log line itself, not
+// only in the helper's own test. A fake git prints a remote URL carrying a token; the logged
+// entry must not contain it.
+func TestRunGit_LogsRedactedStderr(t *testing.T) {
+	fakeGit(t, "fatal: unable to access 'https://oauth2:glpat-secret@gitlab.example.com/g/p.git/': 403")
+	hook := captureLogrus(t)
+
+	if _, err := runGit(t.TempDir(), "ls-remote"); err == nil {
+		t.Fatal("runGit returned no error for a git exiting 128")
+	}
+	var found bool
+	for _, e := range hook.AllEntries() {
+		if strings.Contains(e.Message, "glpat-secret") {
+			t.Fatalf("the log line carries the credential: %q", e.Message)
+		}
+		if strings.Contains(e.Message, "https://***@gitlab.example.com") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no log entry with the redacted remote; entries: %+v", hook.AllEntries())
+	}
+}
+
+// TestGitOutput_IsRunGitsExportedForm pins that the exported helper carries the same
+// safe.directory declaration and diagnostics as the package-internal callers: `plumber init`
+// reads the origin remote through it, and a raw exec.Command there would keep the #464 failure
+// mode (a root-owned checkout refused, silently).
+func TestGitOutput_IsRunGitsExportedForm(t *testing.T) {
+	fakeGit(t, "fatal: detected dubious ownership in repository at '/builds/g/p'")
+	hook := captureLogrus(t)
+
+	out, err := GitOutput(t.TempDir(), "config", "--get", "remote.origin.url")
+	if err == nil {
+		t.Fatal("GitOutput returned no error for a git exiting 128")
+	}
+	if out != "" {
+		t.Fatalf("out = %q, want empty on failure", out)
+	}
+	var found bool
+	for _, e := range hook.AllEntries() {
+		if e.Level == logrus.WarnLevel && strings.Contains(e.Message, "dubious ownership") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("GitOutput swallowed the git diagnostic; entries: %+v", hook.AllEntries())
+	}
+}
+
+// TestRunGit_EmptyStderrLogsAtDebugOnly pins the wizard fix: `git config --get
+// remote.origin.url` exits 1 with NOTHING on stderr in a repository that simply has no origin
+// remote, which is an ordinary answer ("there is none"), not a degraded run. Warning about it
+// printed a Warn line with an empty message in the middle of `plumber config init`.
+func TestRunGit_EmptyStderrLogsAtDebugOnly(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "git")
+	// Exit 1 with nothing on either stream: git's own behaviour for a config key that is not set.
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	hook := captureLogrus(t)
+
+	if _, err := GitOutput(t.TempDir(), "config", "--get", "remote.origin.url"); err == nil {
+		t.Fatal("no error returned for a git exiting 1")
+	}
+	var foundDebug bool
+	for _, e := range hook.AllEntries() {
+		if e.Level == logrus.WarnLevel {
+			t.Errorf("a Warn entry was logged for an empty-stderr failure: %q", e.Message)
+		}
+		if e.Level == logrus.DebugLevel && strings.Contains(e.Message, "config --get remote.origin.url") {
+			foundDebug = true
+		}
+	}
+	if !foundDebug {
+		t.Fatalf("no Debug entry naming the failed command; entries: %+v", hook.AllEntries())
+	}
+}


### PR DESCRIPTION
## What

Three platform-mode fixes on the CLI <> Platform boundary, each closing its issue.

- **Root-owned checkout keeps its controls (#464).** Every git shell-out now declares the inspected directory as `safe.directory` for that invocation and logs why git failed (Warn, or Debug for the ordinary "not a git repository"), so a docker-executor clone owned by root is readable by the image's non-root user and the run stays on the snapshot's cache-hit path with the include-attribution controls evaluated. A component-template global config write was tried and dropped in review: on a persistent shell-executor home it appends forever, and a project shadowing `CI_PROJECT_DIR` could write a permanent wildcard; the per-invocation declaration is the complete fix.
- **Unconfigured controls are not evaluated (#459).** An enabled `requiresConfig` control none of whose substantive fields is set is reported `not_evaluable` with reason `config_required` instead of passing vacuously. The check reflects over the same config schema the catalog exports (nested blocks included). The loss-based points are unaffected, so a policy made only of such controls can still read 100 while every control shows not evaluated; whether such a policy should have its score withheld is queued as a platform decision. The embedded default config is guarded against enabling any control bare.
- **Dismissal propagation (#447).** `/context`'s `dismissed_issues` are decoded; findings are matched through the shared identity recipe (`identity.PlatformHash`, the platform's own digest by construction, pinned by a golden), marked `dismissed`, excluded from the score input, still pushed as `fail` with the `dismissed: true` marker (never omitted, never `pass`), and shown with a `[dismissed on the platform]` tag; CSV and OCSF exports carry the marker. Per-policy re-evaluation stamps file paths repo-relative before matching, and the push and the matcher share one control-name key. Served entries under another recipe version are skipped (honest non-suppression).

## Cross-repo notes

- The platform serves `recipe_version` from its own hash-scheme version today (always 2), so no dismissal can match until getplumber/monorepo PR #278 lands; the CLI follows the contract (recipe version 4).
- The platform's decision queue rows for the declarations table (#448), nested-include path equality (#449) and docs generation (#454) were checked against v0.4.57: all resolved upstream (catalog export #458, commit 81322b0, the parity guard). Nothing remained for them here.
- The platform pin bump to the release carrying this branch adopts the new score input and reasons.
- Two questions surfaced for the platform's decision queue: whether a policy with no evaluable control should have its score withheld rather than read 100, and whether a plain-http platform URL should be refused now that served dismissals can move the score gate.

## Testing

TDD red-before-green per task. `go test ./...`, `go vet`, `make lint` (0 issues) and `make deadcode` (only the pre-existing `ConfigSchemas` finding) green on the branch rebased onto v0.4.58. Load-bearing tests: the git helper argv and the Warn/Debug split with a fake git; `IsUnconfigured` over real config structs plus the default-config guard; the platform-hash golden and identity parity; matching (version skip, control pre-filter, unknown code, codeless); score exclusion in both scoring paths; the push wire shape; the renderer tag and counts.

## Review

Per-task reviews on every task (four small fix rounds). Whole-branch review: security and code-review lenses; results in the PR conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUFtr3m8zC2mVNKVTQvaNz
