### PR TITLE
feat(platform): a linked cli evaluates only the platform's policies and takes its verdict

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,9 +229,22 @@ With `--platform`, Plumber first reads the project's context from the
 platform - the resolved policy set and a cached settings snapshot - and uses
 it to decide what to collect and what to report:
 
-- **One result per policy.** The platform's policy set decides how many
-  results the run produces, each keyed to its own policy and carrying its own
-  score. Policies that share a control configuration are evaluated once.
+- **Only the platform's policies are evaluated.** A linked run reads the
+  resolved policy set and evaluates each policy under its own control
+  configuration; policies sharing a configuration are evaluated once. The
+  local `.plumber.yaml` (or the built-in default) is not evaluated at all: if
+  one is present the log says it was ignored. The job log prints one section
+  per policy (its controls, findings and score), then a `Platform verdict`
+  block with the platform's decision per policy, the platform's global score
+  and the exit code.
+- **The platform decides the exit code.** `--min-points`, `--min-score` and
+  the deprecated `--threshold` are ignored in platform mode (one notice each):
+  each policy's own `enforcement` and `min_points`, as configured on the
+  platform, decide whether the job fails. A degraded collection is pushed and
+  gated by the platform, never failed locally.
+- **No policy, nothing evaluated.** If the platform is unreachable or resolves
+  no policy for the project, the run evaluates nothing, prints one line saying
+  so, pushes nothing and exits 0.
 - **The CI configuration comes from the platform.** Resolving `include:`
   directives needs an API a CI job token cannot reach, so platform mode reads
   the resolved configuration from the platform instead of asking the git host
@@ -295,6 +308,22 @@ it to decide what to collect and what to report:
   objects are the same bytes the platform hashes into a finding's identity, so
   adding a field to them would change what the CLI and the platform agree a
   finding is.
+- The `--output` JSON report in platform mode carries `platformMode: true`, a
+  `policies` array (one entry per policy: name, id, enforcement, min_points,
+  applied, reason, score, findings; the finding objects are byte-identical to
+  the standalone ones), and `plumberScore` = the platform's global score when
+  the push returned one; the legacy per-control `*Result` blocks,
+  `plumberConfig`, `minPoints`/`minScore`/`threshold` and `notEvaluable` are
+  omitted (they described the local configuration). Parsers of platform-mode
+  reports must read `policies`.
+- PBOM and CycloneDX carry the same `policies` array and the global score as a
+  property; per-image compliance verdicts come from the policies' findings and
+  are omitted when no policy evaluates the image controls. SARIF and the
+  GitLab SAST report carry the union of the policies' findings tagged with the
+  policy names. CSV gains a trailing `policies` column and OCSF a `policies`
+  key in platform mode only.
+- In platform mode the push happens before the artifacts are written, so the
+  artifact notices print after the platform verdict block.
 
 Platform mode reports *less* when data is missing, never something different:
 a run that cannot evaluate a control says so.
@@ -475,16 +504,17 @@ More details:
 
 | Code | Meaning |
 |---|---|
-| `0` | The Plumber Score meets the gate (`--min-points` / `--min-score`), or `--no-controls` was used and data collection succeeded |
-| `1` | The Plumber Score is below the gate (or the deprecated `--threshold` is not met) |
+| `0` | The Plumber Score meets the gate (`--min-points` / `--min-score`), or `--no-controls` was used and data collection succeeded, or platform mode and the platform's gate did not block (or could not be reached) |
+| `1` | The Plumber Score is below the gate (or the deprecated `--threshold` is not met), or the platform's gate blocked the run (platform mode) |
 | `2` | Invalid usage, configuration, or a runtime / provider / auth / network failure |
-| `3` | A check could not be verified and `--fail-warnings` is set (e.g. an action version that could not be resolved) |
+| `3` | A check could not be verified and `--fail-warnings` is set (e.g. an action version that could not be resolved) (not in platform mode: a degraded collection is pushed and gated by the platform) |
 
 The deprecated `--threshold` gate is computed from each control's own
 pass/fail rather than the Plumber Score, so a control whose only findings are
 dismissed on the platform still counts as failing there, unlike the score
 gate (`--min-points` / `--min-score`), which excludes dismissed findings;
-prefer `--min-points`.
+prefer `--min-points`. In platform mode neither gate runs: the platform's
+per-policy verdict decides.
 
 ## Self-Hosted GitLab
 

--- a/README.md
+++ b/README.md
@@ -310,12 +310,14 @@ it to decide what to collect and what to report:
   finding is.
 - The `--output` JSON report in platform mode carries `platformMode: true`, a
   `policies` array (one entry per policy: name, id, enforcement, min_points,
-  applied, reason, score, findings; the finding objects are byte-identical to
-  the standalone ones), and `plumberScore` = the platform's global score when
-  the push returned one; the legacy per-control `*Result` blocks,
-  `plumberConfig`, `minPoints`/`minScore`/`threshold` and `notEvaluable` are
-  omitted (they described the local configuration). Parsers of platform-mode
-  reports must read `policies`.
+  applied, reason, score, findings, notEvaluable; the finding objects are
+  byte-identical to the standalone ones), and `plumberScore` = the platform's
+  global score when the push returned one; the legacy per-control `*Result`
+  blocks, `plumberConfig`, `minPoints`/`minScore`/`threshold` and the
+  top-level `notEvaluable` are omitted (they described the local
+  configuration). An entry's `notEvaluable` is that policy run's own map of
+  control name to reason, an object even when empty, and null on a policy that
+  was not applied. Parsers of platform-mode reports must read `policies`.
 - PBOM and CycloneDX carry the same `policies` array and the global score as a
   property; per-image compliance verdicts come from the policies' findings and
   are omitted when no policy evaluates the image controls. SARIF and the

--- a/cmd/analyze_github.go
+++ b/cmd/analyze_github.go
@@ -112,6 +112,7 @@ func runGitHubAnalyze(info *utils.GitRemoteInfo, controlsFilterList, skipControl
 	}
 
 	conf := buildGitHubLocalConf(info, plumberConfig, configPath, controlsFilterList, skipControlsList)
+	platformModeNotices(conf)
 
 	printGitHubAuthBanner(conf.GithubAPIHost, false)
 
@@ -153,6 +154,7 @@ func runGitHubAnalyzeRemote(host, project, ref string, controlsFilterList, skipC
 	printGitHubAuthBanner(apiHost, true)
 
 	conf := buildGitHubRemoteConf(owner, repo, ref, apiHost, plumberConfig, configPath, controlsFilterList, skipControlsList)
+	platformModeNotices(conf)
 
 	p, ok := plumberprovider.Get("github")
 	if !ok {

--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -1481,6 +1481,10 @@ type complianceSummary struct {
 	noControls bool
 	// platformMode: every local gate is inert, the platform's verdict is the
 	// exit code (spec s4).
+	//
+	// It is platformPolicyMode, so it is already false on a --no-controls
+	// run: that run takes the standalone branch and its artifacts are the
+	// standalone ones. Every writer may therefore read this field alone.
 	platformMode bool
 }
 

--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -1112,9 +1112,15 @@ func normalizeYAMLValue(v any) any {
 }
 
 // platformPolicyReportEntries renders the report's `policies` array: one entry
-// per resolved policy of every run, in /context order, exactly as the push
-// reports them (buildPolicyResults) so the file and the record cannot
-// disagree about what a policy found.
+// per resolved policy of every run, in /context order, carrying the same
+// findings and the same score the push reports for it (buildPolicyResults),
+// so the file and the record cannot disagree about what a policy found.
+//
+// The two sets are not identical, on purpose: the report lists EVERY resolved
+// policy, marking the ones that were not evaluated `applied:false` with a null
+// score, while the push omits those entirely (it records results, and there is
+// no result to record). The file is the run's own account, and a policy that
+// silently vanished from it would read as one that was never assigned.
 //
 // The finding objects inside an entry are the ones the report already emits
 // per control (projectFinding). They are FROZEN bytes: the platform hashes a

--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -775,6 +775,7 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 
 	conf := buildGitLabConf(cleanGitlabURL, gitlabToken, flags, remote, plumberConfig, controlsFilterList, skipControlsList)
 	conf.ConfigFilePath = configPath
+	platformModeNotices(conf)
 
 	p, ok := plumberprovider.Get("gitlab")
 	if !ok {
@@ -1361,6 +1362,9 @@ type complianceSummary struct {
 	// which is what tells the gate and the renderer apart a deliberate
 	// zero-control run from a misconfiguration that evaluated nothing.
 	noControls bool
+	// platformMode: every local gate is inert, the platform's verdict is the
+	// exit code (spec s4).
+	platformMode bool
 }
 
 // pointsGateActive reports whether the points gate applies: either it was set
@@ -1383,6 +1387,9 @@ func (s complianceSummary) gateErr() error {
 	// fail-closed further down exists to catch a run that MEANT to check
 	// something and checked nothing, which is not this.
 	if s.noControls {
+		return nil
+	}
+	if s.platformMode {
 		return nil
 	}
 	if s.thresholdSet {
@@ -1429,6 +1436,9 @@ func (s complianceSummary) gateLine() string {
 	// renders "PASSED (0.0% of controls passing, deprecated threshold 100%)".
 	if s.noControls {
 		return "no controls requested, nothing to score"
+	}
+	if s.platformMode {
+		return "enforcement comes from the platform's policies"
 	}
 	if s.thresholdSet {
 		return fmt.Sprintf("%.1f%% of controls passing, deprecated threshold %.0f%%", s.compliance, s.threshold)

--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -993,8 +993,10 @@ func buildAnalysisJSONReport(result *control.AnalysisResult, pc *configuration.P
 	if s.platformMode {
 		output["platformMode"] = true
 		// notEvaluable is the same thing in miniature: a per-control claim
-		// keyed on the local catalog. Each run's own marks reach the reader
-		// through its policy entry.
+		// keyed on the local catalog, so the top-level key goes with them.
+		// The marks themselves are not lost: every applied policy entry
+		// carries its own run's marks in its own notEvaluable object
+		// (platformPolicyReportEntries).
 		delete(output, "notEvaluable")
 	} else {
 		output["plumberConfig"] = buildPlumberConfigBlock(pc)
@@ -1127,17 +1129,31 @@ func normalizeYAMLValue(v any) any {
 // finding object into that finding's identity (#467), so the policy dimension
 // is carried by the array entry and nothing is added to a finding.
 //
-// A run that was not applied carries a null score and null findings rather
-// than a zero score and an empty list: it evaluated nothing, and an empty
-// verdict would read as a policy that found nothing wrong.
+// A run that was not applied carries a null score, null findings and a null
+// notEvaluable rather than a zero score and empty collections: it evaluated
+// nothing, and an empty verdict would read as a policy that found nothing
+// wrong.
+//
+// notEvaluable is the entry's own copy of the run's marks (control name ->
+// reason). It is the only place they reach a machine consumer in platform
+// mode: the report's top-level notEvaluable key is deleted there because it
+// is keyed on the LOCAL catalog, and a control a policy could not evaluate
+// must never read as an evaluated, clean one. It is emitted as an object even
+// when the run marked nothing, so a parser reads one shape.
 func platformPolicyReportEntries(runs []policyRun) []map[string]any {
 	out := make([]map[string]any, 0, len(runs))
 	for _, run := range runs {
 		var score any
 		var findings any
+		var notEvaluable any
 		if run.Applied {
 			score = platformScoreFrom(run.Score)
 			findings = projectFindings(run.Result.Findings, "job")
+			marks := make(map[string]string, len(run.Result.NotEvaluable))
+			for controlName, reason := range run.Result.NotEvaluable {
+				marks[controlName] = reason
+			}
+			notEvaluable = marks
 		}
 		for _, pol := range run.Policies {
 			var minPoints any
@@ -1149,13 +1165,14 @@ func platformPolicyReportEntries(runs []policyRun) []map[string]any {
 				// Only a real policy id is stamped, never the nil uuid the
 				// derived "[Plumber default]" placeholder carries: it is not
 				// a policies row (see realPolicyID).
-				"id":          realPolicyID(pol),
-				"enforcement": string(pol.Enforcement),
-				"min_points":  minPoints,
-				"applied":     run.Applied,
-				"reason":      run.Reason,
-				"score":       score,
-				"findings":    findings,
+				"id":           realPolicyID(pol),
+				"enforcement":  string(pol.Enforcement),
+				"min_points":   minPoints,
+				"applied":      run.Applied,
+				"reason":       run.Reason,
+				"score":        score,
+				"findings":     findings,
+				"notEvaluable": notEvaluable,
 			})
 		}
 	}

--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -858,7 +858,12 @@ func parseControlsFilter(raw string) ([]string, error) {
 // buildAnalysisJSONReport assembles the ordered analysis JSON payload. The
 // same bytes are written to --output and pushed to the score service, so the
 // stored badge record and the file on disk can never diverge.
-func buildAnalysisJSONReport(result *control.AnalysisResult, pc *configuration.PlumberConfig, s complianceSummary, p jsonOutputParams) ([]byte, error) {
+//
+// runs and verdict are the platform-mode inputs (spec s5), nil everywhere
+// else: the evaluated policy runs become the `policies` array, and the push
+// response's global score becomes the single top-level `plumberScore`. Passed
+// nil/nil a report is byte-for-byte what it has always been.
+func buildAnalysisJSONReport(result *control.AnalysisResult, pc *configuration.PlumberConfig, s complianceSummary, p jsonOutputParams, runs []policyRun, verdict *platformVerdict) ([]byte, error) {
 	score, scoreMode, provider, includeOnly, skip :=
 		s.score, s.scoreMode, p.provider, p.includeOnly, p.skip
 	// Marshal AnalysisResult into a generic map so the per-control
@@ -879,14 +884,20 @@ func buildAnalysisJSONReport(result *control.AnalysisResult, pc *configuration.P
 	// gate emits minPoints / minScore; the deprecated --threshold gate emits
 	// threshold for the pipelines still supplying it. The compliance
 	// percentage itself is gone (#320) — plumberScore is the grade.
-	if s.thresholdSet {
-		output["threshold"] = s.threshold
-	} else {
-		if s.pointsGateActive() {
-			output["minPoints"] = s.minPoints
-		}
-		if s.minScore != "" {
-			output["minScore"] = s.minScore
+	//
+	// In platform mode none of them ran (spec s4: every local gate is inert),
+	// so none of them is emitted: a minPoints key beside a verdict the
+	// platform produced would read as the gate that decided it.
+	if !s.platformMode {
+		if s.thresholdSet {
+			output["threshold"] = s.threshold
+		} else {
+			if s.pointsGateActive() {
+				output["minPoints"] = s.minPoints
+			}
+			if s.minScore != "" {
+				output["minScore"] = s.minScore
+			}
 		}
 	}
 	// The reported commit is the resolved one, never the "HEAD" placeholder a
@@ -919,8 +930,27 @@ func buildAnalysisJSONReport(result *control.AnalysisResult, pc *configuration.P
 	if p.noControls {
 		output["noControls"] = true
 	}
-	if scoreMode && score != nil {
+	// !s.platformMode is belt and braces: the summary already leaves score nil
+	// in platform mode (buildComplianceSummary), and this is the one place a
+	// local grade could still reach the file if that ever changed.
+	if scoreMode && score != nil && !s.platformMode {
 		output["plumberScore"] = score
+	}
+	// Platform mode replaces both of the above (spec s5). `passed` is the
+	// platform's gate verdict, the only gate there is; `plumberScore` is the
+	// platform's own global score and is ABSENT when the push returned none,
+	// because the alternative is a locally computed figure the platform never
+	// agreed to - exactly the wrong-verdict failure the mode exists to remove
+	// (QUESTIONS row 44).
+	if s.platformMode {
+		output["passed"] = platformGatePassed(verdict)
+		output["policies"] = platformPolicyReportEntries(runs)
+		if verdict != nil && verdict.GlobalScore != nil {
+			output["plumberScore"] = map[string]any{
+				"letter": verdict.GlobalScore.Letter,
+				"points": verdict.GlobalScore.Points,
+			}
+		}
 	}
 	// `partialControls` surfaces the postflight-skipped story so CI
 	// consumers can detect "we couldn't fully evaluate X" without
@@ -1049,9 +1079,54 @@ func normalizeYAMLValue(v any) any {
 	}
 }
 
+// platformPolicyReportEntries renders the report's `policies` array: one entry
+// per resolved policy of every run, in /context order, exactly as the push
+// reports them (buildPolicyResults) so the file and the record cannot
+// disagree about what a policy found.
+//
+// The finding objects inside an entry are the ones the report already emits
+// per control (projectFinding). They are FROZEN bytes: the platform hashes a
+// finding object into that finding's identity (#467), so the policy dimension
+// is carried by the array entry and nothing is added to a finding.
+//
+// A run that was not applied carries a null score and null findings rather
+// than a zero score and an empty list: it evaluated nothing, and an empty
+// verdict would read as a policy that found nothing wrong.
+func platformPolicyReportEntries(runs []policyRun) []map[string]any {
+	out := make([]map[string]any, 0, len(runs))
+	for _, run := range runs {
+		var score any
+		var findings any
+		if run.Applied {
+			score = platformScoreFrom(run.Score)
+			findings = projectFindings(run.Result.Findings, "job")
+		}
+		for _, pol := range run.Policies {
+			var minPoints any
+			if pol.MinPoints != nil {
+				minPoints = *pol.MinPoints
+			}
+			out = append(out, map[string]any{
+				"name": pol.Name,
+				// Only a real policy id is stamped, never the nil uuid the
+				// derived "[Plumber default]" placeholder carries: it is not
+				// a policies row (see realPolicyID).
+				"id":          realPolicyID(pol),
+				"enforcement": string(pol.Enforcement),
+				"min_points":  minPoints,
+				"applied":     run.Applied,
+				"reason":      run.Reason,
+				"score":       score,
+				"findings":    findings,
+			})
+		}
+	}
+	return out
+}
+
 // writeJSONToFile builds the analysis JSON report and writes it to p.filePath.
-func writeJSONToFile(result *control.AnalysisResult, pc *configuration.PlumberConfig, s complianceSummary, p jsonOutputParams) error {
-	payload, err := buildAnalysisJSONReport(result, pc, s, p)
+func writeJSONToFile(result *control.AnalysisResult, pc *configuration.PlumberConfig, s complianceSummary, p jsonOutputParams, runs []policyRun, verdict *platformVerdict) error {
+	payload, err := buildAnalysisJSONReport(result, pc, s, p, runs, verdict)
 	if err != nil {
 		return err
 	}
@@ -1090,6 +1165,9 @@ var analysisJSONLegacyKeyHead = []string{
 	"ciConfigSource", "ciValid", "ciMissing", "ciErrors",
 	"pipelineOriginMetrics", "pipelineImageMetrics",
 	"minPoints", "minScore", "threshold", "passed", "plumberScore",
+	// policies is the platform-mode per-policy array (spec s5); absent from
+	// every other run, so this entry changes no standalone report.
+	"policies",
 }
 
 // analysisJSONLegacyKeyTail lists keys pinned to the END of the object, after

--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -966,9 +966,26 @@ func buildAnalysisJSONReport(result *control.AnalysisResult, pc *configuration.P
 	// comments and formatting never leave the repo) plus a content hash. The
 	// CLI does NOT classify standard-vs-custom (it's the untrusted client); the
 	// score service classifies server-side from this object and its hash.
-	output["plumberConfig"] = buildPlumberConfigBlock(pc)
-	for k, v := range legacyResultsByName(result, pc, provider, includeOnly, skip, p.noControls) {
-		output[k] = v
+	//
+	// Both blocks below are the LOCAL configuration's view: plumberConfig names
+	// the local file as the policy that produced the grade, and the per-control
+	// *Result blocks are control.GitLabControls(pc) evaluated over the local
+	// findings. In platform mode neither is true of this run - the policies
+	// produced the verdict, one control set each - so both are omitted rather
+	// than published beside a platform score they had no part in. The
+	// `policies` array is the per-control view there, and platformMode tells a
+	// consumer why the blocks it used to parse are gone.
+	if s.platformMode {
+		output["platformMode"] = true
+		// notEvaluable is the same thing in miniature: a per-control claim
+		// keyed on the local catalog. Each run's own marks reach the reader
+		// through its policy entry.
+		delete(output, "notEvaluable")
+	} else {
+		output["plumberConfig"] = buildPlumberConfigBlock(pc)
+		for k, v := range legacyResultsByName(result, pc, provider, includeOnly, skip, p.noControls) {
+			output[k] = v
+		}
 	}
 
 	// Top-level aggregate blocks (pipelineOriginMetrics +
@@ -1165,9 +1182,10 @@ var analysisJSONLegacyKeyHead = []string{
 	"ciConfigSource", "ciValid", "ciMissing", "ciErrors",
 	"pipelineOriginMetrics", "pipelineImageMetrics",
 	"minPoints", "minScore", "threshold", "passed", "plumberScore",
-	// policies is the platform-mode per-policy array (spec s5); absent from
-	// every other run, so this entry changes no standalone report.
-	"policies",
+	// platformMode and policies are the platform-mode block (spec s5); both
+	// are absent from every other run, so these entries change no standalone
+	// report.
+	"platformMode", "policies",
 }
 
 // analysisJSONLegacyKeyTail lists keys pinned to the END of the object, after

--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -269,7 +269,15 @@ func buildRunHeaderRows(providerName string, result *control.AnalysisResult, con
 	}
 	rows = append(rows, headerRow{"Platform", platform})
 
-	if conf.ConfigFilePath != "" {
+	// In platform mode the controls, their configuration and the verdict all
+	// come from the platform's policies (spec s2). Naming a local file (or
+	// the built-in default) here would assert a configuration this run did
+	// not evaluate, which is the wrong-verdict reading the mode exists to
+	// remove (QUESTIONS row 44).
+	switch {
+	case platformPolicyMode(conf.NoControls):
+		rows = append(rows, headerRow{"Config", "the platform's policies"})
+	case conf.ConfigFilePath != "":
 		rows = append(rows, headerRow{"Config", conf.ConfigFilePath})
 	}
 	switch result.CIConfigSource {
@@ -341,8 +349,15 @@ func loadEmbeddedDefaultConfig() (*configuration.PlumberConfig, string, []string
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("failed to load built-in default config: %w", err)
 	}
-	fmt.Fprintln(os.Stderr, "No .plumber.yaml found; using Plumber's built-in default configuration.")
-	fmt.Fprintln(os.Stderr, "Generate your own with 'plumber config generate' ('plumber config init' for the interactive wizard); see the default with 'plumber config view'.")
+	// Silent in platform mode: the embedded default is still loaded (the
+	// collection needs a configuration to run), but it is not what produced
+	// the verdict, so announcing it - and telling the operator to author
+	// their own - would point them at a file the report never used (spec
+	// s2). The run header says where the configuration came from instead.
+	if !platformPolicyMode(noControls) {
+		fmt.Fprintln(os.Stderr, "No .plumber.yaml found; using Plumber's built-in default configuration.")
+		fmt.Fprintln(os.Stderr, "Generate your own with 'plumber config generate' ('plumber config init' for the interactive wizard); see the default with 'plumber config view'.")
+	}
 	return pc, path, warnings, nil
 }
 

--- a/cmd/analyze_gitlab_test.go
+++ b/cmd/analyze_gitlab_test.go
@@ -424,3 +424,57 @@ func TestEqualIgnoringScheme(t *testing.T) {
 		}
 	}
 }
+
+// Spec s2: platform mode evaluates the platform's policies, not the local
+// configuration, so the zero-config notice would point the reader at a
+// configuration that produced none of the verdict they are about to read.
+// The embedded default is still loaded (collection needs one), it is just not
+// announced as the thing that was evaluated.
+func TestLoadEmbeddedDefaultConfig_PlatformModeSkipsTheZeroConfigNotice(t *testing.T) {
+	restore := withPlatformTestEnv(t, "https://platform.example.com", "tok")
+	defer restore()
+
+	var err error
+	out := captureStderr(t, func() {
+		_, _, _, err = loadEmbeddedDefaultConfig()
+	})
+
+	if err != nil {
+		t.Fatalf("the embedded default must still load in platform mode: %v", err)
+	}
+	if strings.Contains(out, "No .plumber.yaml found") || strings.Contains(out, "Generate your own with") {
+		t.Fatalf("platform mode did not evaluate a local configuration, so neither line may be printed:\n%s", out)
+	}
+}
+
+// A standalone run is unchanged: no local file means the zero-config notice
+// and the follow-up that says how to author one.
+func TestLoadEmbeddedDefaultConfig_StandaloneStillAnnouncesTheDefault(t *testing.T) {
+	restore := withPlatformTestEnv(t, "", "")
+	defer restore()
+
+	var err error
+	out := captureStderr(t, func() {
+		_, _, _, err = loadEmbeddedDefaultConfig()
+	})
+
+	if err != nil {
+		t.Fatalf("loadEmbeddedDefaultConfig: %v", err)
+	}
+	assertContains(t, out, "No .plumber.yaml found; using Plumber's built-in default configuration.")
+	assertContains(t, out, "Generate your own with")
+}
+
+// --no-controls takes the standalone branch under every mode (continueRun),
+// so its output is unchanged there too.
+func TestLoadEmbeddedDefaultConfig_NoControlsUnderPlatformKeepsTheNotice(t *testing.T) {
+	restore := withPlatformTestEnv(t, "https://platform.example.com", "tok")
+	defer restore()
+	orig := noControls
+	noControls = true
+	defer func() { noControls = orig }()
+
+	out := captureStderr(t, func() { _, _, _, _ = loadEmbeddedDefaultConfig() })
+
+	assertContains(t, out, "No .plumber.yaml found; using Plumber's built-in default configuration.")
+}

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -65,15 +65,24 @@ func continueRun(p provider.Provider, cmd *cobra.Command, conf *configuration.Co
 			return err
 		}
 	}
-	if err := writeOutputsWithProvider(p, result, conf, summary); err != nil {
+	if err := writeOutputsWithProvider(p, result, conf, summary, nil, nil); err != nil {
 		return err
 	}
 	return publishAndFinalize(p, cmd, result, conf, summary, nil)
 }
 
 // runPlatformMode is the platform-mode tail: evaluate the resolved policies,
-// render one section per evaluated run, write the artifacts, push, render the
-// platform's verdict, finalize.
+// render one section per evaluated run, push, render the platform's verdict,
+// write the artifacts from it, run the post actions, finalize.
+//
+// The push comes BEFORE the artifacts here, the reverse of a standalone run,
+// and that order is the whole of spec s5: the single score an artifact may
+// carry is the platform's global one, which only exists once the push has
+// answered. Writing first (as this did) produced files and a badge with no
+// score at all, and the only way to fill them without waiting would be to
+// compute a local figure - the wrong-verdict failure the mode removes
+// (QUESTIONS row 44). The standalone order is untouched: publishAndFinalize
+// still runs after writeOutputsWithProvider on that path.
 //
 // A run that resolved no policy evaluates NOTHING (spec s4, invariant 5): it
 // prints the one-line notice, exits 0, pushes nothing and writes no artifact.
@@ -104,10 +113,14 @@ func runPlatformMode(p provider.Provider, cmd *cobra.Command, conf *configuratio
 		renderPolicySections(p, conf, runs, controlsFilterList, skipControlsList)
 		renderWarnings(result.Warnings)
 	}
-	if err := writeOutputsWithProvider(p, result, conf, summary); err != nil {
+	verdict, platformErr := publishRun(p, conf, result, summary, runs)
+	if err := writeOutputsWithProvider(p, result, conf, summary, runs, verdict); err != nil {
 		return err
 	}
-	return publishAndFinalize(p, cmd, result, conf, summary, runs)
+	if err := runPostActions(p, cmd, result, conf, summary, runs, verdict); err != nil {
+		return err
+	}
+	return finalizeRun(result, summary, platformErr)
 }
 
 // finalizeFindings turns a raw analysis result into the summary the rest of the
@@ -199,6 +212,20 @@ func publishAndFinalize(p provider.Provider, cmd *cobra.Command, result *control
 		return finalizeRun(result, summary, nil)
 	}
 
+	verdict, platformErr := publishRun(p, conf, result, summary, runs)
+	if err := runPostActions(p, cmd, result, conf, summary, runs, verdict); err != nil {
+		return err
+	}
+	return finalizeRun(result, summary, platformErr)
+}
+
+// publishRun is the publish leg: the hosted score badge, the platform push,
+// and the platform-mode verdict block the push produces. It is split out of
+// publishAndFinalize because platform mode has to run it BEFORE the artifacts
+// (the only score they may carry is the one the push returns) while a
+// standalone run keeps writing them first; both callers run the same steps in
+// the same order, so the two paths cannot drift.
+func publishRun(p provider.Provider, conf *configuration.Configuration, result *control.AnalysisResult, summary complianceSummary, runs []policyRun) (*platformVerdict, error) {
 	jsonPayload := buildPublishPayload(p, conf, result, summary)
 	handleScorePublishing(p, conf, result, summary, jsonPayload)
 	verdict, platformErr := maybePushPlatform(p, conf, result, summary.score, runs)
@@ -209,7 +236,21 @@ func publishAndFinalize(p provider.Provider, cmd *cobra.Command, result *control
 	if summary.platformMode && printOutput {
 		renderPlatformVerdict(runs, verdict, platformErr)
 	}
+	return verdict, platformErr
+}
 
+// runPostActions hands the provider its post-analysis side effects (the
+// GitLab badge and merge-request comment).
+//
+// In platform mode the summary they read is the platform's, not the run's:
+// the score is nil there by construction, and Passed is the platform's gate
+// answer rather than a local gate that did not run. Everything the badge and
+// the comment then say comes from Platform (spec s5), so neither can publish
+// a figure the platform did not produce.
+func runPostActions(p provider.Provider, cmd *cobra.Command, result *control.AnalysisResult, conf *configuration.Configuration, summary complianceSummary, runs []policyRun, verdict *platformVerdict) error {
+	if cmd == nil {
+		return nil
+	}
 	pas := provider.PostActionSummary{
 		Passed:     summary.passed(),
 		GateLine:   summary.gateLine(),
@@ -217,13 +258,11 @@ func publishAndFinalize(p provider.Provider, cmd *cobra.Command, result *control
 		ScoreMode:  summary.scoreMode,
 		ScorePoint: summary.scorePoint,
 	}
-	if cmd != nil {
-		if err := p.PostAnalysisActions(cmd, result, conf, pas); err != nil {
-			return err
-		}
+	if summary.platformMode {
+		pas.Passed = platformGatePassed(verdict)
+		pas.Platform = platformPostSummary(runs, verdict)
 	}
-
-	return finalizeRun(result, summary, platformErr)
+	return p.PostAnalysisActions(cmd, result, conf, pas)
 }
 
 // inertFlagsUnderNoControls lists the flags that read or publish a score and
@@ -511,7 +550,18 @@ func buildProviderControlSummariesAndGroups(p provider.Provider, result *control
 
 // writeOutputsWithProvider writes all requested artifact files (JSON, PBOM,
 // CycloneDX, SARIF, GitLab SAST, CSV, OCSF) using the provider's writers.
-func writeOutputsWithProvider(p provider.Provider, result *control.AnalysisResult, conf *configuration.Configuration, s complianceSummary) error {
+//
+// runs and verdict are the platform-mode inputs (spec s5), nil on every other
+// path: the evaluated policy runs are what the reports describe per policy,
+// and the push response's global score is the only run-level score they may
+// carry. Both nil, every writer produces exactly the bytes it always has.
+//
+// The security reports (SARIF, GitLab SAST) are written from the UNION of the
+// policy runs rather than from the collected result: their consumers key on
+// one alert per finding, and the collected result's findings are the LOCAL
+// configuration's, which platform mode does not publish. CSV and OCSF are
+// untouched by this task and still describe the collected run.
+func writeOutputsWithProvider(p provider.Provider, result *control.AnalysisResult, conf *configuration.Configuration, s complianceSummary, runs []policyRun, verdict *platformVerdict) error {
 	// Artifacts are still written on a degraded run (they are files the user
 	// asked for, and the exit-3 gate, not the file's absence, protects CI).
 	// Each format stamps itself degraded; warn so a partial report is not
@@ -523,21 +573,36 @@ func writeOutputsWithProvider(p provider.Provider, result *control.AnalysisResul
 	// artifact writer below reports the same commit the same way (#443).
 	result.ArtifactCommitSHA, result.ArtifactRef = resolveArtifactRef(p, result, conf)
 	result.ArtifactRepoURI = artifactRepoURI(conf, result, p.Name())
+	// Everything platform-mode below is nil or unchanged outside it, which is
+	// what makes every writer take exactly the path it always took.
+	platformPBOM := platformPBOMSummary(runs, verdict)
+	// The run-level score the PBOM writers stamp. buildComplianceSummary
+	// already leaves it nil in platform mode; nilling it again here is the
+	// same belt and braces the JSON report applies, because these two are the
+	// only writers that would carry a local grade if that ever changed.
+	score := s.score
+	if s.platformMode {
+		score = nil
+	}
+	reportResult := result
+	if len(runs) > 0 && (sarifFile != "" || glsastFile != "") {
+		reportResult = platformUnionResult(result, runs)
+	}
 	if outputFile != "" {
 		params := jsonOutputParams{filePath: outputFile, provider: p.Name(), includeOnly: conf.ControlsFilter, skip: conf.SkipControlsFilter, noControls: conf.NoControls}
-		if err := writeJSONToFile(result, conf.PlumberConfig, s, params); err != nil {
+		if err := writeJSONToFile(result, conf.PlumberConfig, s, params, runs, verdict); err != nil {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "Results written to: %s\n", outputFile)
 	}
 	if pbomFile != "" {
-		if err := p.WritePBOM(result, conf, pbomFile, s.score, s.scoreMode); err != nil {
+		if err := p.WritePBOM(result, conf, pbomFile, score, s.scoreMode, platformPBOM); err != nil {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "PBOM written to: %s\n", pbomFile)
 	}
 	if pbomCycloneDXFile != "" {
-		if err := p.WritePBOMCycloneDX(result, conf, pbomCycloneDXFile, s.score, s.scoreMode); err != nil {
+		if err := p.WritePBOMCycloneDX(result, conf, pbomCycloneDXFile, score, s.scoreMode, platformPBOM); err != nil {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "PBOM (CycloneDX) written to: %s\n", pbomCycloneDXFile)
@@ -550,13 +615,13 @@ func writeOutputsWithProvider(p provider.Provider, result *control.AnalysisResul
 	// nobody checked. There is no field that fixes that, so they are not
 	// written at all; warnInertFlagsUnderNoControls names them.
 	if sarifFile != "" && !conf.NoControls {
-		if err := writeSARIFToFile(result, sarifFile, p.Name()); err != nil {
+		if err := writeSARIFToFile(reportResult, sarifFile, p.Name()); err != nil {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "SARIF written to: %s\n", sarifFile)
 	}
 	if glsastFile != "" && !conf.NoControls {
-		if err := writeGLSASTToFile(result, glsastFile, p.Name()); err != nil {
+		if err := writeGLSASTToFile(reportResult, glsastFile, p.Name()); err != nil {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "GitLab SAST report written to: %s\n", glsastFile)
@@ -670,9 +735,12 @@ func buildPublishPayload(p provider.Provider, conf *configuration.Configuration,
 		pc = conf.PlumberConfig
 		includeOnly, skip = conf.ControlsFilter, conf.SkipControlsFilter
 	}
+	// nil runs / nil verdict: the hosted score service is never the platform
+	// (effectiveScorePush turns the badge push off whenever --platform is on),
+	// so this payload is always a standalone one.
 	payload, err := buildAnalysisJSONReport(result, pc, summary, jsonOutputParams{
 		provider: p.Name(), includeOnly: includeOnly, skip: skip, forScorePush: true,
-	})
+	}, nil, nil)
 	if err != nil {
 		scoreWarn(fmt.Sprintf("could not build the publish payload: %v", err))
 		return nil

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -276,7 +276,7 @@ func outputTextWithProvider(p provider.Provider, result *control.AnalysisResult,
 		renderDegradedCaveat(result.DegradedReasons)
 	}
 
-	controls, groups := buildProviderControlSummariesAndGroups(p, result, conf, controlsFilterList, skipControlsList)
+	controls, groups := buildProviderControlSummariesAndGroups(p, result, conf.PlumberConfig, controlsFilterList, skipControlsList)
 	// Nothing was selected, so listing every control as "skipped" is noise
 	// that reads like a misconfiguration.
 	if s.noControls {
@@ -357,9 +357,14 @@ func countNotEvaluated(groups []findingGroup) int {
 // buildProviderControlSummariesAndGroups builds the control summary and finding
 // group slices for any provider using the provider's catalog and registered
 // stats builder.
-func buildProviderControlSummariesAndGroups(p provider.Provider, result *control.AnalysisResult, conf *configuration.Configuration, controlsFilterList, skipControlsList []string) ([]controlSummary, []findingGroup) {
+//
+// pc is the configuration the result was evaluated under, and it is a
+// parameter rather than conf.PlumberConfig because in platform mode that is
+// the POLICY's configuration, not the run's: a section rendered from the
+// local config would enumerate controls the policy never declared.
+func buildProviderControlSummariesAndGroups(p provider.Provider, result *control.AnalysisResult, pc *configuration.PlumberConfig, controlsFilterList, skipControlsList []string) ([]controlSummary, []findingGroup) {
 	findingsByControl := control.FindingsByControl(result.Findings)
-	entries := p.Controls(conf.PlumberConfig)
+	entries := p.Controls(pc)
 	control.MarkSkippedByFilter(entries, controlsFilterList, skipControlsList)
 	dataCollectionFailed := !result.CiValid && !result.CiMissing
 
@@ -378,7 +383,7 @@ func buildProviderControlSummariesAndGroups(p provider.Provider, result *control
 			}
 		}
 		skipped := e.Skipped || dataCollectionFailed
-		stats := provider.BuildControlStats(p.Name(), e.ControlName, result, conf.PlumberConfig, findings)
+		stats := provider.BuildControlStats(p.Name(), e.ControlName, result, pc, findings)
 		// A control whose lane supplied nothing must not render as passed.
 		//
 		// Keyed on result.NotEvaluable rather than StatusFor: StatusFor also

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -253,6 +253,7 @@ func buildComplianceSummary(p provider.Provider, result *control.AnalysisResult,
 		scoreMode:    scoreMode,
 		scorePoint:   showScorePoint,
 		noControls:   conf.NoControls,
+		platformMode: func() bool { on, _ := effectivePlatformPush(); return on }(),
 	}
 }
 
@@ -603,8 +604,13 @@ func buildPublishPayload(p provider.Provider, conf *configuration.Configuration,
 // the score gate (or the deprecated --threshold gate). A platform token failure
 // is evaluated LAST so a broken id-token grant can never mask a security
 // finding the scan just made.
+//
+// In platform mode (s.platformMode) the degraded exit 3 and the local score
+// gate do not apply: a degraded collection is pushed and the platform's
+// verdict decides (I3), and platformErr, a blocking gate or a token failure,
+// is the only score-related exit.
 func finalizeRun(result *control.AnalysisResult, s complianceSummary, platformErr error) error {
-	if result.DataCollectionDegraded {
+	if result.DataCollectionDegraded && !s.platformMode {
 		return &IncompleteDataError{Reasons: result.DegradedReasons}
 	}
 	if failWarnings && len(result.Warnings) > 0 {

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -576,6 +576,9 @@ func writeOutputsWithProvider(p provider.Provider, result *control.AnalysisResul
 	// Everything platform-mode below is nil or unchanged outside it, which is
 	// what makes every writer take exactly the path it always took.
 	platformPBOM := platformPBOMSummary(runs, verdict)
+	if platformPBOM != nil {
+		platformPBOM.ImageControlsEvaluated = platformImageControlsEvaluated(p, runs)
+	}
 	// The run-level score the PBOM writers stamp. buildComplianceSummary
 	// already leaves it nil in platform mode; nilling it again here is the
 	// same belt and braces the JSON report applies, because these two are the
@@ -584,8 +587,18 @@ func writeOutputsWithProvider(p provider.Provider, result *control.AnalysisResul
 	if s.platformMode {
 		score = nil
 	}
+	// reportResult is what every FINDING-DERIVED artifact is written from. In
+	// platform mode that is the policy runs' union, never the collected run's
+	// own findings, which are the local configuration's (spec s5 + the review
+	// ruling: every output derives from the policies). It carries the same
+	// collected inventory and run-level facts, so the PBOM's images and
+	// includes are unchanged; only what a finding asserts about them moves.
+	//
+	// The JSON report is the exception: it reads `result` because its policy
+	// entries carry each run's findings separately, which is a strictly richer
+	// view than the union.
 	reportResult := result
-	if len(runs) > 0 && (sarifFile != "" || glsastFile != "") {
+	if len(runs) > 0 {
 		reportResult = platformUnionResult(result, runs)
 	}
 	if outputFile != "" {
@@ -596,13 +609,13 @@ func writeOutputsWithProvider(p provider.Provider, result *control.AnalysisResul
 		fmt.Fprintf(os.Stderr, "Results written to: %s\n", outputFile)
 	}
 	if pbomFile != "" {
-		if err := p.WritePBOM(result, conf, pbomFile, score, s.scoreMode, platformPBOM); err != nil {
+		if err := p.WritePBOM(reportResult, conf, pbomFile, score, s.scoreMode, platformPBOM); err != nil {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "PBOM written to: %s\n", pbomFile)
 	}
 	if pbomCycloneDXFile != "" {
-		if err := p.WritePBOMCycloneDX(result, conf, pbomCycloneDXFile, score, s.scoreMode, platformPBOM); err != nil {
+		if err := p.WritePBOMCycloneDX(reportResult, conf, pbomCycloneDXFile, score, s.scoreMode, platformPBOM); err != nil {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "PBOM (CycloneDX) written to: %s\n", pbomCycloneDXFile)
@@ -627,13 +640,13 @@ func writeOutputsWithProvider(p provider.Provider, result *control.AnalysisResul
 		fmt.Fprintf(os.Stderr, "GitLab SAST report written to: %s\n", glsastFile)
 	}
 	if csvFile != "" {
-		if err := writeCSVToFile(p, result, conf, csvFile); err != nil {
+		if err := writeCSVToFile(p, reportResult, conf, csvFile, runs); err != nil {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "CSV written to: %s\n", csvFile)
 	}
 	if ocsfFile != "" {
-		if err := writeOCSFToFile(p, result, conf, ocsfFile); err != nil {
+		if err := writeOCSFToFile(p, reportResult, conf, ocsfFile, runs); err != nil {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "OCSF report written to: %s\n", ocsfFile)

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -596,7 +596,7 @@ func writeOutputsWithProvider(p provider.Provider, result *control.AnalysisResul
 	// what makes every writer take exactly the path it always took.
 	platformPBOM := platformPBOMSummary(runs, verdict)
 	if platformPBOM != nil {
-		platformPBOM.ImageControlsEvaluated = platformImageControlsEvaluated(p, runs)
+		platformPBOM.ForbiddenTagEvaluated, platformPBOM.AuthorizedSourceEvaluated = platformImageControlsEvaluated(p, runs)
 	}
 	// The run-level score the PBOM writers stamp. buildComplianceSummary
 	// already leaves it nil in platform mode; nilling it again here is the

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -135,7 +135,10 @@ func publishAndFinalize(p provider.Provider, cmd *cobra.Command, result *control
 
 	jsonPayload := buildPublishPayload(p, conf, result, summary)
 	handleScorePublishing(p, conf, result, summary, jsonPayload)
-	_, platformErr := maybePushPlatform(p, conf, result, summary.score)
+	// The per-policy runs are not wired through this tail yet: platform mode
+	// still pushes the single locally-named entry here until the shared
+	// pipeline evaluates them (next slice of the policies-only plan).
+	_, platformErr := maybePushPlatform(p, conf, result, summary.score, nil)
 	reportPlatformOutcome(conf.PlatformRun)
 
 	pas := provider.PostActionSummary{

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -135,7 +135,7 @@ func publishAndFinalize(p provider.Provider, cmd *cobra.Command, result *control
 
 	jsonPayload := buildPublishPayload(p, conf, result, summary)
 	handleScorePublishing(p, conf, result, summary, jsonPayload)
-	platformErr := maybePushPlatform(p, conf, result, summary.score)
+	_, platformErr := maybePushPlatform(p, conf, result, summary.score)
 	reportPlatformOutcome(conf.PlatformRun)
 
 	pas := provider.PostActionSummary{

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -45,8 +45,19 @@ func runWithProvider(p provider.Provider, cmd *cobra.Command, conf *configuratio
 //
 // The non-platform branch is the sequence both callers ran inline before, in
 // the same order, so a standalone run is byte-for-byte what it was.
+//
+// --no-controls outranks the mode and takes that same branch. It is an
+// INVENTORY run: it evaluates nothing under any mode, so there are no
+// policies to report and nothing for the platform to gate, but there is still
+// an inventory to write and a collection to vouch for. The platform branch
+// would return early on a zero-policy run and skip both - a CI-less project
+// would exit 0 having written no artifact and said nothing about why, exactly
+// the empty-PBOM-as-a-result failure publishAndFinalize's no-controls guards
+// exist to prevent. Those guards live down here and still run; the same
+// branch's publish suppression already withholds the badge, the score push,
+// the MR comment and the platform push, so nothing is published either way.
 func continueRun(p provider.Provider, cmd *cobra.Command, conf *configuration.Configuration, result *control.AnalysisResult, summary complianceSummary, controlsFilterList, skipControlsList []string) error {
-	if summary.platformMode {
+	if summary.platformMode && !summary.noControls {
 		return runPlatformMode(p, cmd, conf, result, summary, controlsFilterList, skipControlsList)
 	}
 	if printOutput {

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -368,7 +368,14 @@ func buildComplianceSummary(p provider.Provider, result *control.AnalysisResult,
 	// the existing withhold-the-score path (every consumer already guards
 	// on a nil score), so the outputs carry no score instead of a fake one.
 	scoreMode := !conf.NoControls
-	platformMode := func() bool { on, _ := effectivePlatformPush(); return on }()
+	// platformPolicyMode, not the bare link: --no-controls takes the
+	// standalone branch in continueRun under every mode, and this flag is
+	// what the writers key on. Set from the link alone, a linked inventory
+	// run wrote a report claiming platformMode with an empty policies array
+	// and none of the local blocks it takes the standalone branch to produce
+	// (the re-review finding). One condition, stated once, for the routing
+	// and for what the artifacts then say about it.
+	platformMode := platformPolicyMode(conf.NoControls)
 	// In platform mode there is no run-level score to compute: every verdict
 	// comes from the policies the platform resolved (spec s2), each with its
 	// own score over its own control set. A local figure computed here would

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -107,11 +107,30 @@ func runPlatformMode(p provider.Provider, cmd *cobra.Command, conf *configuratio
 		if printOutput {
 			renderNothingEvaluated(platformRunOf(conf))
 		}
-		return nil
+		// Nothing was evaluated, so neither the degraded exit nor a gate can
+		// fire here (both are inert in platform mode anyway), but
+		// --fail-warnings is the other exit source spec s4 keeps and it is
+		// about the COLLECTION, not the verdict: a bare nil made the opt-in
+		// silently inert on exactly the runs where the warnings are all the
+		// operator has left.
+		return finalizeRun(result, summary, nil)
 	}
 	if printOutput {
 		renderPolicySections(p, conf, runs, controlsFilterList, skipControlsList)
 		renderWarnings(result.Warnings)
+		// The collection-truth diagnostics outputTextWithProvider prints on
+		// every standalone run. They are facts about what was COLLECTED, not
+		// a verdict: the CI errors explain why an inventory is thin, and the
+		// tier caveats explain why a control could not be checked on this
+		// GitLab plan. Platform mode replaces the local verdict, not the
+		// truth about the collection, so all five stay.
+		if len(result.CiErrors) > 0 {
+			printCIErrors(result)
+		}
+		renderApprovalRulesTierCaveat(result)
+		renderMRApprovalSettingsTierCaveat(result)
+		renderMRSettingsPremiumCaveat(result)
+		renderSecurityPolicyTierCaveat(result)
 	}
 	verdict, platformErr := publishRun(p, conf, result, summary, runs)
 	if err := writeOutputsWithProvider(p, result, conf, summary, runs, verdict); err != nil {

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -36,17 +36,67 @@ func runWithProvider(p provider.Provider, cmd *cobra.Command, conf *configuratio
 
 	summary := finalizeFindings(p, conf, result)
 
+	return continueRun(p, cmd, conf, result, summary, controlsFilterList, skipControlsList)
+}
+
+// continueRun is the tail both entry points share after finalizeFindings: in
+// platform mode the resolved policies are evaluated and drive everything
+// (spec s2); otherwise today's single local evaluation does.
+//
+// The non-platform branch is the sequence both callers ran inline before, in
+// the same order, so a standalone run is byte-for-byte what it was.
+func continueRun(p provider.Provider, cmd *cobra.Command, conf *configuration.Configuration, result *control.AnalysisResult, summary complianceSummary, controlsFilterList, skipControlsList []string) error {
+	if summary.platformMode {
+		return runPlatformMode(p, cmd, conf, result, summary, controlsFilterList, skipControlsList)
+	}
 	if printOutput {
 		if err := outputTextWithProvider(p, result, conf, summary, controlsFilterList, skipControlsList); err != nil {
 			return err
 		}
 	}
-
 	if err := writeOutputsWithProvider(p, result, conf, summary); err != nil {
 		return err
 	}
+	return publishAndFinalize(p, cmd, result, conf, summary, nil)
+}
 
-	return publishAndFinalize(p, cmd, result, conf, summary)
+// runPlatformMode is the platform-mode tail: evaluate the resolved policies,
+// render one section per evaluated run, write the artifacts, push, render the
+// platform's verdict, finalize.
+//
+// A run that resolved no policy evaluates NOTHING (spec s4, invariant 5): it
+// prints the one-line notice, exits 0, pushes nothing and writes no artifact.
+// There is no local fallback anywhere on this path - a report produced from
+// the local configuration under a platform link is exactly the wrong-verdict
+// failure the mode exists to remove (QUESTIONS row 44) - and an artifact
+// stamped with a verdict nobody computed would be worse than none.
+func runPlatformMode(p provider.Provider, cmd *cobra.Command, conf *configuration.Configuration, result *control.AnalysisResult, summary complianceSummary, controlsFilterList, skipControlsList []string) error {
+	runs := evaluatePlatformPolicies(p, conf, result)
+	if printOutput {
+		renderRunHeader(p, result, conf)
+		if result.DataCollectionDegraded {
+			renderDegradedCaveat(result.DegradedReasons)
+		}
+	}
+	// Zero runs covers both shapes of "no policy resolved": a context that
+	// could not be fetched or assigned nothing, and a nil PlatformRun (the
+	// platform URL is set but setupPlatformMode never ran, e.g. the project
+	// path could not be resolved). renderNothingEvaluated states the reason
+	// for either.
+	if len(runs) == 0 {
+		if printOutput {
+			renderNothingEvaluated(platformRunOf(conf))
+		}
+		return nil
+	}
+	if printOutput {
+		renderPolicySections(p, conf, runs, controlsFilterList, skipControlsList)
+		renderWarnings(result.Warnings)
+	}
+	if err := writeOutputsWithProvider(p, result, conf, summary); err != nil {
+		return err
+	}
+	return publishAndFinalize(p, cmd, result, conf, summary, runs)
 }
 
 // finalizeFindings turns a raw analysis result into the summary the rest of the
@@ -90,7 +140,12 @@ func markPlatformDismissedFindings(conf *configuration.Configuration, result *co
 // actions, then map the outcome onto the exit code. Keeping it in one place is
 // what stops the two paths from drifting on things like the --no-controls
 // guard below.
-func publishAndFinalize(p provider.Provider, cmd *cobra.Command, result *control.AnalysisResult, conf *configuration.Configuration, summary complianceSummary) error {
+//
+// runs are the evaluated platform policy runs (empty outside platform mode).
+// They are what the push reports one entry per policy for, and what the
+// "Platform verdict" block explains the platform's answer in - the same runs
+// the sections above printed, so the log and the record cannot disagree.
+func publishAndFinalize(p provider.Provider, cmd *cobra.Command, result *control.AnalysisResult, conf *configuration.Configuration, summary complianceSummary, runs []policyRun) error {
 	// Everything here publishes or comments on a verdict. Under
 	// --no-controls there is no verdict: a badge, a score push, a platform
 	// push or an MR comment built from a run that evaluated nothing would
@@ -135,11 +190,14 @@ func publishAndFinalize(p provider.Provider, cmd *cobra.Command, result *control
 
 	jsonPayload := buildPublishPayload(p, conf, result, summary)
 	handleScorePublishing(p, conf, result, summary, jsonPayload)
-	// The per-policy runs are not wired through this tail yet: platform mode
-	// still pushes the single locally-named entry here until the shared
-	// pipeline evaluates them (next slice of the policies-only plan).
-	_, platformErr := maybePushPlatform(p, conf, result, summary.score, nil)
+	verdict, platformErr := maybePushPlatform(p, conf, result, summary.score, runs)
 	reportPlatformOutcome(conf.PlatformRun)
+	// The verdict block closes the platform-mode report: it is the last
+	// thing printed because it is what the exit code is, and printing it
+	// before the push that produces it is not possible.
+	if summary.platformMode && printOutput {
+		renderPlatformVerdict(runs, verdict, platformErr)
+	}
 
 	pas := provider.PostActionSummary{
 		Passed:     summary.passed(),
@@ -241,6 +299,22 @@ func buildComplianceSummary(p provider.Provider, result *control.AnalysisResult,
 	// the existing withhold-the-score path (every consumer already guards
 	// on a nil score), so the outputs carry no score instead of a fake one.
 	scoreMode := !conf.NoControls
+	platformMode := func() bool { on, _ := effectivePlatformPush(); return on }()
+	// In platform mode there is no run-level score to compute: every verdict
+	// comes from the policies the platform resolved (spec s2), each with its
+	// own score over its own control set. A local figure computed here would
+	// be the one that contradicted the platform's (QUESTIONS row 44), so it
+	// is not computed at all rather than computed and hopefully ignored.
+	//
+	// scoreMode is deliberately left alone: it is the --no-controls withhold
+	// switch, and flipping it would change what an artifact says about WHY
+	// there is no score. Every consumer of the score already guards on nil
+	// (the JSON report, the PBOM writers, the banner, the badge, the MR
+	// comment, the gate), so a nil here withholds rather than crashes.
+	score := computeScoreResult(result, scoreMode)
+	if platformMode {
+		score = nil
+	}
 	return complianceSummary{
 		compliance:   compliance,
 		controlCount: controlCount,
@@ -249,11 +323,11 @@ func buildComplianceSummary(p provider.Provider, result *control.AnalysisResult,
 		minPoints:    minPoints,
 		minPointsSet: minPointsSet,
 		minScore:     minScore,
-		score:        computeScoreResult(result, scoreMode),
+		score:        score,
 		scoreMode:    scoreMode,
 		scorePoint:   showScorePoint,
 		noControls:   conf.NoControls,
-		platformMode: func() bool { on, _ := effectivePlatformPush(); return on }(),
+		platformMode: platformMode,
 	}
 }
 
@@ -511,15 +585,7 @@ func presentResultWithProvider(p provider.Provider, cmd *cobra.Command, result *
 	}
 
 	summary := finalizeFindings(p, conf, result)
-	if printOutput {
-		if err := outputTextWithProvider(p, result, conf, summary, conf.ControlsFilter, conf.SkipControlsFilter); err != nil {
-			return err
-		}
-	}
-	if err := writeOutputsWithProvider(p, result, conf, summary); err != nil {
-		return err
-	}
-	return publishAndFinalize(p, cmd, result, conf, summary)
+	return continueRun(p, cmd, conf, result, summary, conf.ControlsFilter, conf.SkipControlsFilter)
 }
 
 func joinStrings(ss []string) string {

--- a/cmd/artifact_provenance_test.go
+++ b/cmd/artifact_provenance_test.go
@@ -284,7 +284,7 @@ func TestWriteOutputsStampsProvenance(t *testing.T) {
 
 	result := &control.AnalysisResult{ProjectPath: "acme/target"}
 	conf := &configuration.Configuration{GitlabURL: "https://gitlab.example"}
-	if err := writeOutputsWithProvider(&providerPkg.GitLabProvider{}, result, conf, complianceSummary{}); err != nil {
+	if err := writeOutputsWithProvider(&providerPkg.GitLabProvider{}, result, conf, complianceSummary{}, nil, nil); err != nil {
 		t.Fatalf("writeOutputsWithProvider: %v", err)
 	}
 	if result.ArtifactCommitSHA != sha {

--- a/cmd/csv.go
+++ b/cmd/csv.go
@@ -42,12 +42,29 @@ import (
 // when the finding is not about a job (a branch, an include, a required
 // template, component or action). Those findings carry what they are about in
 // their structured payload and in the identity block of the JSON report.
-func buildCSV(entries []control.ControlEntry, result *control.AnalysisResult) [][]string {
+// withPolicies adds the trailing `policies` column: the platform policies that
+// reported a finding, semicolon-joined, empty on a non-failing control's
+// summary row (the same emptiness convention `dismissed` uses on that row
+// shape). It is added only in platform mode, where there are policies to name;
+// adding it unconditionally would change every standalone CSV's header and
+// every row, which is exactly what a report consumer parses positionally.
+func buildCSV(entries []control.ControlEntry, result *control.AnalysisResult, withPolicies bool) [][]string {
 	// dismissed carries the platform's #447 marker: "true"/"false" on a
 	// finding row, empty on a non-failing control's summary row (there is
 	// no finding to have an opinion about), the same emptiness convention
 	// code and fingerprint already use on that row shape.
 	header := []string{"code", "fingerprint", "controlName", "status", "severity", "message", "context", "file", "line", "url", "docUrl", "dismissed"}
+	if withPolicies {
+		header = append(header, "policies")
+	}
+	// row appends the policies cell when the column exists, so every row is
+	// built through one place and cannot drift in width from the header.
+	row := func(cells []string, policies string) []string {
+		if withPolicies {
+			cells = append(cells, policies)
+		}
+		return csvSafeRow(cells)
+	}
 	byControl := control.FindingsByControl(result.Findings)
 
 	var nonFailing [][]string // passed / error / skipped: one row per control, at the top
@@ -58,7 +75,7 @@ func buildCSV(entries []control.ControlEntry, result *control.AnalysisResult) []
 		status := control.StatusFor(e, result, len(findings))
 
 		if status != control.StatusFailed {
-			nonFailing = append(nonFailing, csvSafeRow([]string{
+			nonFailing = append(nonFailing, row([]string{
 				"",                                 // code
 				"",                                 // fingerprint (no finding)
 				e.ControlName,                      // controlName
@@ -71,7 +88,7 @@ func buildCSV(entries []control.ControlEntry, result *control.AnalysisResult) []
 				"",                                 // url
 				"",                                 // docUrl
 				"",                                 // dismissed (no finding)
-			}))
+			}, ""))
 			continue
 		}
 
@@ -93,7 +110,7 @@ func buildCSV(entries []control.ControlEntry, result *control.AnalysisResult) []
 				line = strconv.Itoa(f.Line)
 			}
 
-			failing = append(failing, csvSafeRow([]string{
+			failing = append(failing, row([]string{
 				f.Code,
 				f.Fingerprint,
 				e.ControlName,
@@ -106,7 +123,7 @@ func buildCSV(entries []control.ControlEntry, result *control.AnalysisResult) []
 				f.URL,
 				"https://getplumber.io/docs/cli/issues/" + f.Code,
 				strconv.FormatBool(f.Dismissed),
-			}))
+			}, strings.Join(f.Policies, ";")))
 		}
 	}
 
@@ -189,9 +206,14 @@ func csvStatusReason(status string, e control.ControlEntry, result *control.Anal
 
 // writeCSVToFile walks the provider's control catalog and writes the per-control
 // CSV posture to filePath.
-func writeCSVToFile(p provider.Provider, result *control.AnalysisResult, conf *configuration.Configuration, filePath string) error {
-	entries := providerControlEntries(p, conf)
-	records := buildCSV(entries, result)
+//
+// runs is non-empty in platform mode, and the catalog is then the resolved
+// policies' own (outputControlEntries), over the policy runs' findings the
+// caller passes in: a control no policy enables has no row, and a local-only
+// finding has none either (spec s5).
+func writeCSVToFile(p provider.Provider, result *control.AnalysisResult, conf *configuration.Configuration, filePath string, runs []policyRun) error {
+	entries, _ := outputControlEntries(p, conf, runs)
+	records := buildCSV(entries, result, len(runs) > 0)
 
 	var buf bytes.Buffer
 	w := csv.NewWriter(&buf)

--- a/cmd/csv_injection_e2e_test.go
+++ b/cmd/csv_injection_e2e_test.go
@@ -100,7 +100,7 @@ func TestCSVInjection_WorkflowFilenameReachesContextColumnEscaped(t *testing.T) 
 		})
 	}
 
-	records := buildCSV(entries, result)
+	records := buildCSV(entries, result, false)
 	const contextCol = 6
 
 	var checked int

--- a/cmd/csv_test.go
+++ b/cmd/csv_test.go
@@ -26,7 +26,7 @@ func TestBuildCSV_ShapeColumnsAndOrdering(t *testing.T) {
 		},
 	}
 
-	records := buildCSV(entries, result)
+	records := buildCSV(entries, result, false)
 
 	wantHeader := []string{"code", "fingerprint", "controlName", "status", "severity", "message", "context", "file", "line", "url", "docUrl", "dismissed"}
 	if len(records) != 4 { // header + cleanControl(passed) + disabledControl(skipped) + actions(failed)
@@ -92,7 +92,7 @@ func TestBuildCSV_CleanRunListsEveryControl(t *testing.T) {
 	}
 	result := &control.AnalysisResult{CiValid: true}
 
-	records := buildCSV(entries, result)
+	records := buildCSV(entries, result, false)
 	if len(records) != 3 { // header + one row per control (NOT header-only)
 		t.Fatalf("records = %d, want 3 (header + one row per control)", len(records))
 	}
@@ -114,7 +114,7 @@ func TestBuildCSV_NonFailingBeforeFailing(t *testing.T) {
 		CiValid:  true,
 		Findings: []opaengine.Finding{{Code: "ISSUE-701", Message: "x"}},
 	}
-	records := buildCSV(entries, result)
+	records := buildCSV(entries, result, false)
 	if records[1][3] != "passed" {
 		t.Errorf("first data row status = %q, want passed (non-failing at top)", records[1][3])
 	}
@@ -132,7 +132,7 @@ func TestBuildCSV_ErrorStatusOnDegradedRun(t *testing.T) {
 		CiValid:         true,
 		DegradedReasons: []string{"3 workflow file(s) could not be fetched"},
 	}
-	records := buildCSV(entries, result)
+	records := buildCSV(entries, result, false)
 	if records[1][3] != "error" {
 		t.Errorf("degraded clean control status = %q, want error", records[1][3])
 	}
@@ -152,7 +152,7 @@ func TestBuildCSV_CodelessFindingSkipped(t *testing.T) {
 			{Code: "ISSUE-701", Message: "kept"}, // kept
 		},
 	}
-	records := buildCSV(entries, result)
+	records := buildCSV(entries, result, false)
 	if len(records) != 2 { // header + 1 kept finding row
 		t.Fatalf("records = %d, want 2 (header + 1 kept finding)", len(records))
 	}
@@ -169,7 +169,7 @@ func TestBuildCSV_LineZeroIsEmptyString(t *testing.T) {
 			{Code: "ISSUE-701", Severity: "high", Message: "no line"},
 		},
 	}
-	records := buildCSV(entries, result)
+	records := buildCSV(entries, result, false)
 	if records[1][8] != "" { // line column
 		t.Errorf("line = %q, want empty string for zero-value Line", records[1][8])
 	}
@@ -189,7 +189,7 @@ func TestBuildCSV_NeutralizesFormulaInjection(t *testing.T) {
 			File:    "+ci.yml",
 		}},
 	}
-	records := buildCSV(entries, result)
+	records := buildCSV(entries, result, false)
 	row := records[1]
 	for _, i := range []int{5, 6, 7} { // message, context, file
 		if row[i] == "" {
@@ -213,7 +213,7 @@ func TestBuildCSV_LeavesOrdinaryValuesUntouched(t *testing.T) {
 		CiValid:  true,
 		Findings: []opaengine.Finding{{Code: "ISSUE-701", Message: "unpinned action", Job: "ci/build"}},
 	}
-	records := buildCSV(entries, result)
+	records := buildCSV(entries, result, false)
 	if records[1][5] != "unpinned action" || records[1][6] != "ci/build" {
 		t.Errorf("ordinary values were modified: %q / %q", records[1][5], records[1][6])
 	}
@@ -278,7 +278,7 @@ func TestBuildCSV_DismissedColumnFollowsTheFinding(t *testing.T) {
 			{Code: "ISSUE-701", Message: "dismissed one", Dismissed: true},
 		},
 	}
-	records := buildCSV(entries, result)
+	records := buildCSV(entries, result, false)
 	if len(records) != 3 { // header + 2 finding rows
 		t.Fatalf("records = %d, want 3 (header + 2 finding rows)", len(records))
 	}
@@ -316,7 +316,7 @@ func TestBuildCSV_NotEvaluableUsesTheControlsOwnReason(t *testing.T) {
 		DegradedReasons: []string{"project variables could not be fetched"},
 		NotEvaluable:    map[string]string{"someControl": "include_attribution_unavailable"},
 	}
-	records := buildCSV(entries, result)
+	records := buildCSV(entries, result, false)
 	if records[1][3] != "error" {
 		t.Fatalf("status = %q, want error", records[1][3])
 	}

--- a/cmd/finalize_findings_test.go
+++ b/cmd/finalize_findings_test.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/control"
+	"github.com/getplumber/plumber/finding/identity"
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
+	"github.com/getplumber/plumber/internal/platform"
+)
+
+// untrustedImageFinding is a fail finding a real run of the shipped default
+// config produces: ISSUE-101 belongs to
+// containerImageMustComeFromAuthorizedSources, which that config enables, and
+// it costs the score real points.
+func untrustedImageFinding() opaengine.Finding {
+	return opaengine.Finding{Code: "ISSUE-101", Severity: "high", Message: "untrusted registry", Job: "build", File: ".gitlab-ci.yml", Line: 4}
+}
+
+// servedDismissalFor builds the dismissed entry the platform would serve for
+// one finding: the identity hash of the finding as it exists AFTER fingerprint
+// stamping, under the current recipe version, keyed by the finding's control.
+// Stamping first is the whole point - the identity reads the fields
+// fingerprinting canonicalizes, so a hash taken before it matches nothing.
+func servedDismissalFor(t *testing.T, f opaengine.Finding) platform.DismissedIssue {
+	t.Helper()
+	stamped := []opaengine.Finding{f}
+	opaengine.StampFingerprints(stamped, "")
+	hash, _, ok := identity.PlatformHash(stamped[0].IdentityInput())
+	if !ok {
+		t.Fatal("the fixture finding has no platform identity, so no served dismissal could ever match it")
+	}
+	return platform.DismissedIssue{
+		IdentityHash:  hash,
+		RecipeVersion: identity.RecipeVersion,
+		ControlType:   control.ControlKeyFor(stamped[0].Code),
+	}
+}
+
+// TestFinalizeFindings_MarksServedDismissalsBeforeAnythingReadsThem pins the
+// single markPlatformDismissedFindings call inside finalizeFindings, between
+// StampFingerprints and buildComplianceSummary. Delete it and the run-level
+// result keeps a served dismissal as a live finding - the artifact writers
+// (JSON, PBOM, SARIF, CSV, OCSF) all read result.Findings, so every one of
+// them would report a dismissed issue as open - and the summary built one line
+// later would score it.
+//
+// This is deliberately a unit test of finalizeFindings rather than of a
+// pipeline: since platform mode's push is assembled from the per-policy runs
+// (which mark dismissals themselves, inside control.ReEvaluateForConfig), no
+// end-to-end test fails any more when this call is removed. It is the only
+// thing standing between a served dismissal and the run-level outputs.
+func TestFinalizeFindings_MarksServedDismissalsBeforeAnythingReadsThem(t *testing.T) {
+	origPrint := printOutput
+	printOutput = false // no terminal output is under test
+	defer func() { printOutput = origPrint }()
+
+	served := servedDismissalFor(t, untrustedImageFinding())
+
+	// confWith builds the run as production does: a run context whose
+	// /context response carries the served dismissed list.
+	confWith := func(t *testing.T, dismissed []platform.DismissedIssue) *configuration.Configuration {
+		t.Helper()
+		conf := configuration.NewDefaultConfiguration()
+		conf.PlumberConfig = testDefaultPlumberConfig(t)
+		conf.PlatformRun = &platform.RunContext{
+			Endpoint: "https://platform.example.com",
+			Context:  &platform.ProjectContext{DismissedIssues: dismissed},
+		}
+		return conf
+	}
+	resultWith := func(findings ...opaengine.Finding) *control.AnalysisResult {
+		return &control.AnalysisResult{CiValid: true, Findings: findings}
+	}
+
+	t.Run("the served finding is marked on the run-level result", func(t *testing.T) {
+		newGateFlagsCmd(t)
+		restore := withPlatformTestEnv(t, "https://platform.example.com", "tok")
+		defer restore()
+
+		result := resultWith(untrustedImageFinding())
+		_ = finalizeFindings(testProvider(t), confWith(t, []platform.DismissedIssue{served}), result)
+
+		if len(result.Findings) != 1 {
+			t.Fatalf("a dismissed finding is never dropped, only marked: got %d findings", len(result.Findings))
+		}
+		if !result.Findings[0].Dismissed {
+			t.Error("the served finding is not marked dismissed: every artifact written from this result would report it as open")
+		}
+	})
+
+	t.Run("an unserved finding stays live", func(t *testing.T) {
+		newGateFlagsCmd(t)
+		restore := withPlatformTestEnv(t, "https://platform.example.com", "tok")
+		defer restore()
+
+		result := resultWith(untrustedImageFinding())
+		_ = finalizeFindings(testProvider(t), confWith(t, nil), result)
+
+		if result.Findings[0].Dismissed {
+			t.Error("a finding the platform did not serve was marked dismissed: the marker must come from the served list alone")
+		}
+	})
+
+	t.Run("the mark precedes the summary, so the score never counts it", func(t *testing.T) {
+		// The platform URL is left UNSET on purpose. It is the ordering
+		// inside finalizeFindings that is under test - mark, THEN
+		// buildComplianceSummary - and platform mode withholds the
+		// run-level score entirely, so there would be no score to inspect.
+		// markPlatformDismissedFindings keys on conf.PlatformRun.Context
+		// alone, never on the flag, so the marking path is the same one.
+		score := func(t *testing.T, dismissed []platform.DismissedIssue, findings ...opaengine.Finding) float64 {
+			t.Helper()
+			newGateFlagsCmd(t)
+			s := finalizeFindings(testProvider(t), confWith(t, dismissed), resultWith(findings...))
+			if s.score == nil {
+				t.Fatal("no score was computed, so this test can say nothing about what it counted")
+			}
+			return s.score.FinalPoints
+		}
+
+		dismissedPoints := score(t, []platform.DismissedIssue{served}, untrustedImageFinding())
+		livePoints := score(t, nil, untrustedImageFinding())
+		cleanPoints := score(t, nil)
+
+		if dismissedPoints <= livePoints {
+			t.Errorf("score = %.1f dismissed vs %.1f live: a dismissed finding must cost nothing (#447: out of the score like not_evaluable)", dismissedPoints, livePoints)
+		}
+		if dismissedPoints != cleanPoints {
+			t.Errorf("score = %.1f with the finding dismissed, %.1f with no such finding at all: the two must agree, or the summary was built before the mark", dismissedPoints, cleanPoints)
+		}
+	})
+}

--- a/cmd/gate_test.go
+++ b/cmd/gate_test.go
@@ -494,7 +494,7 @@ func TestBuildAnalysisJSONReport_GateContract(t *testing.T) {
 
 	decode := func(t *testing.T, s complianceSummary) map[string]any {
 		t.Helper()
-		payload, err := buildAnalysisJSONReport(result, pc, s, params)
+		payload, err := buildAnalysisJSONReport(result, pc, s, params, nil, nil)
 		if err != nil {
 			t.Fatalf("buildAnalysisJSONReport: %v", err)
 		}
@@ -559,7 +559,7 @@ func TestBuildAnalysisJSONReport_EmitsRawPointsUnclamped(t *testing.T) {
 	score := &control.PlumberScoreResult{RawPoints: 0, RawPointsUnclamped: -37.5, Score: "E"}
 	s := complianceSummary{minPoints: 100, score: score, scoreMode: true, controlCount: 1}
 
-	payload, err := buildAnalysisJSONReport(&control.AnalysisResult{CiValid: true}, confWithDebugTrace().PlumberConfig, s, jsonOutputParams{provider: "gitlab"})
+	payload, err := buildAnalysisJSONReport(&control.AnalysisResult{CiValid: true}, confWithDebugTrace().PlumberConfig, s, jsonOutputParams{provider: "gitlab"}, nil, nil)
 	if err != nil {
 		t.Fatalf("buildAnalysisJSONReport: %v", err)
 	}
@@ -677,5 +677,89 @@ func TestFinalizeRun_PlatformModeOrdering(t *testing.T) {
 	var degradedErr *DegradedError
 	if err := finalizeRun(warned, s, gateErr); !errors.As(err, &degradedErr) {
 		t.Fatalf("--fail-warnings outranks the platform gate, got %v", err)
+	}
+}
+
+// Spec s5: in platform mode the JSON report carries one entry per policy and
+// the platform's global score at the top level; never a local-config score.
+// The local gate keys are gone with the local gate they describe, and every
+// finding object inside a policy entry is the one the report already froze
+// (#467: the platform hashes it into a finding's identity), so the policy
+// dimension lives on the entry, never on a finding.
+func TestBuildAnalysisJSONReport_PlatformMode_PerPolicy(t *testing.T) {
+	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	conf := confWithPolicies(t, a)
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+	s := complianceSummary{platformMode: true, scoreMode: true}
+	params := jsonOutputParams{provider: "gitlab"}
+
+	decode := func(t *testing.T, v *platformVerdict) map[string]any {
+		t.Helper()
+		payload, err := buildAnalysisJSONReport(debugTraceResult(), conf.PlumberConfig, s, params, runs, v)
+		if err != nil {
+			t.Fatalf("buildAnalysisJSONReport: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(payload, &m); err != nil {
+			t.Fatalf("report is not valid JSON: %v", err)
+		}
+		return m
+	}
+
+	report := decode(t, &platformVerdict{GlobalScore: &platformScore{Letter: "C", Points: 66}})
+	pols, ok := report["policies"].([]any)
+	if !ok || len(pols) != 1 {
+		t.Fatalf("policies: %#v", report["policies"])
+	}
+	entry, _ := pols[0].(map[string]any)
+	if entry["name"] != "A" || entry["id"] != "policy-A" || entry["enforcement"] != "report" || entry["applied"] != true {
+		t.Fatalf("policy entry: %#v", entry)
+	}
+	if _, present := entry["min_points"]; !present {
+		t.Errorf("min_points must be present (null when the policy sets none): %#v", entry)
+	}
+	score, ok := entry["score"].(map[string]any)
+	if !ok || score["letter"] == "" || score["final_points"] == nil {
+		t.Fatalf("policy score: %#v", entry["score"])
+	}
+	findings, ok := entry["findings"].([]any)
+	if !ok || len(findings) != 1 {
+		t.Fatalf("the policy's own findings must be listed: %#v", entry["findings"])
+	}
+	f, _ := findings[0].(map[string]any)
+	if f["code"] != "ISSUE-203" {
+		t.Fatalf("finding: %#v", f)
+	}
+	// #467 froze the finding object: the policy dimension is carried by the
+	// array entry, so no finding may gain a key naming its policy.
+	for _, k := range []string{"policy", "policies", "policyId", "policy_id"} {
+		if _, present := f[k]; present {
+			t.Errorf("finding object gained the key %q: the pushed bytes are frozen", k)
+		}
+	}
+	global, ok := report["plumberScore"].(map[string]any)
+	if !ok || global["letter"] != "C" || global["points"] != 66.0 {
+		t.Fatalf("plumberScore must be the platform's global score, got %#v", report["plumberScore"])
+	}
+	if report["passed"] != true {
+		t.Errorf("passed = %v, want true: the platform's gate did not block", report["passed"])
+	}
+	for _, k := range []string{"minPoints", "minScore", "threshold"} {
+		if v, present := report[k]; present {
+			t.Errorf("local gate key %q must be absent in platform mode, got %v", k, v)
+		}
+	}
+
+	report2 := decode(t, &platformVerdict{Unavailable: "gate unavailable, letting through"})
+	if _, present := report2["plumberScore"]; present {
+		t.Fatal("no global score from the platform: plumberScore must be omitted, never a local figure")
+	}
+	if report2["passed"] != true {
+		t.Errorf("passed = %v, want true: an unavailable gate lets through", report2["passed"])
+	}
+
+	blocked := decode(t, &platformVerdict{Gate: &platformGate{Evaluated: true, Blocking: true}})
+	if blocked["passed"] != false {
+		t.Errorf("passed = %v, want false: the platform's gate blocked", blocked["passed"])
 	}
 }

--- a/cmd/gate_test.go
+++ b/cmd/gate_test.go
@@ -641,3 +641,41 @@ func TestFinalizeRun_OrderingPriority(t *testing.T) {
 		}
 	})
 }
+
+// Spec s4: in platform mode the local score gate is inert, whatever the flags
+// say; the exit code is the platform's verdict (finalizeRun below).
+func TestGate_PlatformModeIgnoresLocalScoreGates(t *testing.T) {
+	s := complianceSummary{minPoints: 100, minPointsSet: true, minScore: "A", score: scoreWithPoints(0), controlCount: 1, platformMode: true}
+	if err := s.gateErr(); err != nil {
+		t.Fatalf("platform mode must not gate locally, got %v", err)
+	}
+	if !s.passed() {
+		t.Fatal("passed() must follow gateErr()")
+	}
+	if got := s.gateLine(); got != "enforcement comes from the platform's policies" {
+		t.Fatalf("gateLine: %q", got)
+	}
+}
+
+// Spec s4: the degraded exit 3 does not apply in platform mode; the platform's
+// gate decides. --fail-warnings still applies, and outranks the platform error.
+func TestFinalizeRun_PlatformModeOrdering(t *testing.T) {
+	gateErr := &PlatformGateError{Reason: "blocked", Policies: nil}
+	s := complianceSummary{platformMode: true, score: scoreWithPoints(0), controlCount: 1, minPoints: 100, minPointsSet: true}
+	degraded := &control.AnalysisResult{DataCollectionDegraded: true, DegradedReasons: []string{"x"}}
+
+	if err := finalizeRun(degraded, s, nil); err != nil {
+		t.Fatalf("degraded in platform mode must not exit 3, got %v", err)
+	}
+	if err := finalizeRun(degraded, s, gateErr); !errors.Is(err, gateErr) {
+		t.Fatalf("the platform gate error must be returned, got %v", err)
+	}
+	origFail := failWarnings
+	failWarnings = true
+	defer func() { failWarnings = origFail }()
+	warned := &control.AnalysisResult{Warnings: []string{"could not verify"}}
+	var degradedErr *DegradedError
+	if err := finalizeRun(warned, s, gateErr); !errors.As(err, &degradedErr) {
+		t.Fatalf("--fail-warnings outranks the platform gate, got %v", err)
+	}
+}

--- a/cmd/gate_test.go
+++ b/cmd/gate_test.go
@@ -690,6 +690,11 @@ func TestBuildAnalysisJSONReport_PlatformMode_PerPolicy(t *testing.T) {
 	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
 	conf := confWithPolicies(t, a)
 	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+	// A control THIS run could not evaluate. In platform mode the top-level
+	// notEvaluable key is deleted (it is keyed on the local catalog), so the
+	// entry is the only place the mark can reach a machine consumer: without
+	// it a control nobody could check reads as clean.
+	runs[0].Result.MarkNotEvaluable("pipelineMustNotOverrideJobVariables", "raw_config_unavailable")
 	s := complianceSummary{platformMode: true, scoreMode: true}
 	params := jsonOutputParams{provider: "gitlab"}
 
@@ -736,6 +741,13 @@ func TestBuildAnalysisJSONReport_PlatformMode_PerPolicy(t *testing.T) {
 		if _, present := f[k]; present {
 			t.Errorf("finding object gained the key %q: the pushed bytes are frozen", k)
 		}
+	}
+	marks, ok := entry["notEvaluable"].(map[string]any)
+	if !ok || marks["pipelineMustNotOverrideJobVariables"] != "raw_config_unavailable" {
+		t.Fatalf("an applied entry carries its own run's not-evaluable marks: %#v", entry["notEvaluable"])
+	}
+	if _, present := report["notEvaluable"]; present {
+		t.Errorf("the top-level notEvaluable key is the local catalog's and stays absent, got %v", report["notEvaluable"])
 	}
 	global, ok := report["plumberScore"].(map[string]any)
 	if !ok || global["letter"] != "C" || global["points"] != 66.0 {

--- a/cmd/glsast.go
+++ b/cmd/glsast.go
@@ -201,6 +201,19 @@ func buildGLSAST(findings []opaengine.Finding, provider string) glsastReport {
 				Value: info.ControlName,
 			})
 		}
+		// The policies that reported this finding (platform mode, spec s5).
+		// The GitLab schema has no free-form per-vulnerability bag, but
+		// `identifiers` is an open list (it already carries the fingerprint
+		// and the control), so each policy rides there as its own entry. The
+		// PRIMARY identifier is the issue code and stays first: GitLab dedups
+		// vulnerabilities on it, so a policy must never displace it.
+		for _, name := range f.Policies {
+			v.Identifiers = append(v.Identifiers, glsastIdentifier{
+				Type:  "plumber_policy",
+				Name:  "Plumber policy " + name,
+				Value: name,
+			})
+		}
 		// GitLab's Vulnerability Report UI does not render the deprecated
 		// `message` field, so fold the per-finding detail into `description`
 		// where it actually shows up. Keep `message` populated too for

--- a/cmd/no_controls_outputs_test.go
+++ b/cmd/no_controls_outputs_test.go
@@ -494,7 +494,7 @@ func TestPublishAndFinalize_NoControlsSkipsPublishing(t *testing.T) {
 	s := buildComplianceSummary(p, result, conf)
 	var err error
 	stderr := captureStderr(t, func() {
-		err = publishAndFinalize(p, &cobra.Command{}, result, conf, s)
+		err = publishAndFinalize(p, &cobra.Command{}, result, conf, s, nil)
 	})
 	if err != nil {
 		t.Fatalf("--no-controls run must not fail: %v", err)
@@ -533,7 +533,7 @@ func TestPublishAndFinalize_NoControlsSkipsPublishing(t *testing.T) {
 	p2 := &recordingProvider{GitLabProvider: &provider.GitLabProvider{}}
 	conf2 := &configuration.Configuration{PlumberConfig: pc}
 	s2 := buildComplianceSummary(p2, result, conf2)
-	_ = publishAndFinalize(p2, &cobra.Command{}, result, conf2, s2)
+	_ = publishAndFinalize(p2, &cobra.Command{}, result, conf2, s2, nil)
 	if !p2.postCalled {
 		t.Fatal("without --no-controls the post-analysis actions must still run")
 	}
@@ -686,7 +686,7 @@ func TestPublishAndFinalize_NoControlsStillFailsOnDegradedData(t *testing.T) {
 		DegradedReasons:        []string{"merged CI configuration could not be fetched"},
 	}
 
-	err := publishAndFinalize(p, &cobra.Command{}, degraded, conf, buildComplianceSummary(p, degraded, conf))
+	err := publishAndFinalize(p, &cobra.Command{}, degraded, conf, buildComplianceSummary(p, degraded, conf), nil)
 	var incomplete *IncompleteDataError
 	if !errors.As(err, &incomplete) {
 		t.Fatalf("--no-controls must not suppress the degraded-collection failure, got %v", err)
@@ -694,7 +694,7 @@ func TestPublishAndFinalize_NoControlsStillFailsOnDegradedData(t *testing.T) {
 
 	// Mirror: an intact collection exits 0.
 	intact := &control.AnalysisResult{CiValid: true, ProjectPath: "group/project"}
-	if err := publishAndFinalize(p, &cobra.Command{}, intact, conf, buildComplianceSummary(p, intact, conf)); err != nil {
+	if err := publishAndFinalize(p, &cobra.Command{}, intact, conf, buildComplianceSummary(p, intact, conf), nil); err != nil {
 		t.Fatalf("--no-controls on an intact collection must exit 0, got %v", err)
 	}
 }
@@ -846,7 +846,7 @@ func TestPublishAndFinalize_NoControlsFailsOnInvalidCIConfig(t *testing.T) {
 		CiErrors:    []string{"jobs config should contain at least one visible job"},
 	}
 
-	err := publishAndFinalize(p, &cobra.Command{}, invalid, conf, buildComplianceSummary(p, invalid, conf))
+	err := publishAndFinalize(p, &cobra.Command{}, invalid, conf, buildComplianceSummary(p, invalid, conf), nil)
 	var incomplete *IncompleteDataError
 	if !errors.As(err, &incomplete) {
 		t.Fatalf("--no-controls must not exit 0 on an unusable CI config, got %v", err)
@@ -904,7 +904,7 @@ func TestPublishAndFinalize_NoControlsAndMissingCIConfig(t *testing.T) {
 		p := &recordingProvider{GitLabProvider: &provider.GitLabProvider{}}
 		conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
 		result := missing()
-		err := publishAndFinalize(p, &cobra.Command{}, result, conf, buildComplianceSummary(p, result, conf))
+		err := publishAndFinalize(p, &cobra.Command{}, result, conf, buildComplianceSummary(p, result, conf), nil)
 		var incomplete *IncompleteDataError
 		if !errors.As(err, &incomplete) {
 			t.Fatalf("a GitLab project with no CI config has no pipeline to inventory; want IncompleteDataError, got %v", err)
@@ -915,7 +915,7 @@ func TestPublishAndFinalize_NoControlsAndMissingCIConfig(t *testing.T) {
 		p := &provider.GitHubProvider{}
 		conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
 		result := missing()
-		if err := publishAndFinalize(p, nil, result, conf, buildComplianceSummary(p, result, conf)); err != nil {
+		if err := publishAndFinalize(p, nil, result, conf, buildComplianceSummary(p, result, conf), nil); err != nil {
 			t.Fatalf("a CI-less GitHub repo must keep passing (fleet scans), got %v", err)
 		}
 	})
@@ -943,7 +943,7 @@ func TestPublishAndFinalize_NoControlsFailsOnInvalidCIWithoutErrors(t *testing.T
 		ProjectPath: "group/project",
 	}
 
-	err := publishAndFinalize(p, &cobra.Command{}, invalid, conf, buildComplianceSummary(p, invalid, conf))
+	err := publishAndFinalize(p, &cobra.Command{}, invalid, conf, buildComplianceSummary(p, invalid, conf), nil)
 	var incomplete *IncompleteDataError
 	if !errors.As(err, &incomplete) {
 		t.Fatalf("an invalid CI config with no error strings must still fail, got %v", err)

--- a/cmd/no_controls_outputs_test.go
+++ b/cmd/no_controls_outputs_test.go
@@ -613,7 +613,7 @@ func TestCSVAndOCSF_NoControlsDoNotClaimControlsPassed(t *testing.T) {
 	t.Run("csv", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "out.csv")
 		conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
-		if err := writeCSVToFile(p, result, conf, path); err != nil {
+		if err := writeCSVToFile(p, result, conf, path, nil); err != nil {
 			t.Fatalf("write csv: %v", err)
 		}
 		raw, err := os.ReadFile(path)
@@ -637,7 +637,7 @@ func TestCSVAndOCSF_NoControlsDoNotClaimControlsPassed(t *testing.T) {
 	t.Run("ocsf", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "out.ocsf.json")
 		conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
-		if err := writeOCSFToFile(p, result, conf, path); err != nil {
+		if err := writeOCSFToFile(p, result, conf, path, nil); err != nil {
 			t.Fatalf("write ocsf: %v", err)
 		}
 		raw, err := os.ReadFile(path)

--- a/cmd/no_controls_outputs_test.go
+++ b/cmd/no_controls_outputs_test.go
@@ -52,7 +52,7 @@ func TestJSONReport_NoControlsDoesNotClaimControlsPassed(t *testing.T) {
 			conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
 			s := buildComplianceSummary(&provider.GitLabProvider{}, result, conf)
 			params := jsonOutputParams{filePath: path, provider: prov, noControls: conf.NoControls}
-			if err := writeJSONToFile(result, pc, s, params); err != nil {
+			if err := writeJSONToFile(result, pc, s, params, nil, nil); err != nil {
 				t.Fatalf("write json: %v", err)
 			}
 
@@ -110,7 +110,7 @@ func TestJSONReport_ControlsStillReportedByDefault(t *testing.T) {
 
 			conf := &configuration.Configuration{PlumberConfig: pc}
 			s := buildComplianceSummary(&provider.GitLabProvider{}, result, conf)
-			if err := writeJSONToFile(result, pc, s, jsonOutputParams{filePath: path, provider: prov}); err != nil {
+			if err := writeJSONToFile(result, pc, s, jsonOutputParams{filePath: path, provider: prov}, nil, nil); err != nil {
 				t.Fatalf("write json: %v", err)
 			}
 			raw, _ := os.ReadFile(path)
@@ -287,9 +287,9 @@ func TestPBOM_NoControlsDoesNotAssertCompliance(t *testing.T) {
 			conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
 			var err error
 			if tc.cycloneDX {
-				err = tc.provider.WritePBOMCycloneDX(tc.result, conf, path, nil, false)
+				err = tc.provider.WritePBOMCycloneDX(tc.result, conf, path, nil, false, nil)
 			} else {
-				err = tc.provider.WritePBOM(tc.result, conf, path, nil, false)
+				err = tc.provider.WritePBOM(tc.result, conf, path, nil, false, nil)
 			}
 			if err != nil {
 				t.Fatalf("write pbom: %v", err)
@@ -405,7 +405,7 @@ func TestPBOM_ComplianceStillAssertedByDefault(t *testing.T) {
 	pc := noControlsPC(t)
 	path := filepath.Join(t.TempDir(), "pbom.json")
 	conf := &configuration.Configuration{PlumberConfig: pc}
-	if err := (&provider.GitLabProvider{}).WritePBOM(gitLabPBOMFixture(), conf, path, nil, false); err != nil {
+	if err := (&provider.GitLabProvider{}).WritePBOM(gitLabPBOMFixture(), conf, path, nil, false, nil); err != nil {
 		t.Fatalf("write pbom: %v", err)
 	}
 	raw, _ := os.ReadFile(path)
@@ -439,7 +439,7 @@ func TestPBOM_ComplianceStillAssertedByDefault(t *testing.T) {
 	// separate builder. Without this the GitHub half of the suppression
 	// test above could pass by emitting nothing at all.
 	ghPath := filepath.Join(t.TempDir(), "gh-pbom.json")
-	if err := (&provider.GitHubProvider{}).WritePBOM(gitHubPBOMFixture(), &configuration.Configuration{PlumberConfig: pc}, ghPath, nil, false); err != nil {
+	if err := (&provider.GitHubProvider{}).WritePBOM(gitHubPBOMFixture(), &configuration.Configuration{PlumberConfig: pc}, ghPath, nil, false, nil); err != nil {
 		t.Fatalf("write github pbom: %v", err)
 	}
 	ghRaw, _ := os.ReadFile(ghPath)
@@ -724,7 +724,7 @@ func TestSecurityReports_NotWrittenUnderNoControls(t *testing.T) {
 	p := &provider.GitLabProvider{}
 	conf := &configuration.Configuration{PlumberConfig: pc, NoControls: true}
 
-	if err := writeOutputsWithProvider(p, result, conf, buildComplianceSummary(p, result, conf)); err != nil {
+	if err := writeOutputsWithProvider(p, result, conf, buildComplianceSummary(p, result, conf), nil, nil); err != nil {
 		t.Fatalf("write outputs: %v", err)
 	}
 	for _, f := range []string{sarifFile, glsastFile} {
@@ -742,7 +742,7 @@ func TestSecurityReports_NotWrittenUnderNoControls(t *testing.T) {
 
 	// Mirror: without the flag both are written as usual.
 	conf2 := &configuration.Configuration{PlumberConfig: pc}
-	if err := writeOutputsWithProvider(p, result, conf2, buildComplianceSummary(p, result, conf2)); err != nil {
+	if err := writeOutputsWithProvider(p, result, conf2, buildComplianceSummary(p, result, conf2), nil, nil); err != nil {
 		t.Fatalf("write outputs: %v", err)
 	}
 	for _, f := range []string{sarifFile, glsastFile} {

--- a/cmd/ocsf.go
+++ b/cmd/ocsf.go
@@ -49,6 +49,11 @@ type ocsfComplianceFinding struct {
 	Remediation *ocsfRemediation `json:"remediation,omitempty"`
 	Resources   []ocsfResource   `json:"resources,omitempty"`
 	Unmapped    map[string]any   `json:"unmapped,omitempty"`
+	// Policies names the platform policies this control was evaluated under
+	// (spec s5). Emitted only in platform mode, where a record has no meaning
+	// without it: the same control can be evaluated by several policies, each
+	// under its own configuration. Absent from every standalone record.
+	Policies []string `json:"policies,omitempty"`
 }
 
 // ocsfResource is an OCSF Resource Details object naming the analyzed code
@@ -151,7 +156,10 @@ func ocsfProductVersion() string {
 // stamps), so an empty findings list is never silently a pass: a control that
 // could not be verified is Warning, an intentionally skipped one is Other. now
 // and correlationUID are injected so tests are deterministic.
-func buildOCSF(entries []control.ControlEntry, result *control.AnalysisResult, providerName string, now int64, correlationUID string) []ocsfComplianceFinding {
+// policiesByControl is nil outside platform mode; in it, it maps a control
+// name to the policies that had it evaluated, and every record carries its
+// own entry.
+func buildOCSF(entries []control.ControlEntry, result *control.AnalysisResult, providerName string, now int64, correlationUID string, policiesByControl map[string][]string) []ocsfComplianceFinding {
 	byControl := control.FindingsByControl(result.Findings)
 	product := ocsfProduct{Name: "Plumber", VendorName: "getplumber", Version: ocsfProductVersion(), URL: "https://getplumber.io"}
 
@@ -209,6 +217,7 @@ func buildOCSF(entries []control.ControlEntry, result *control.AnalysisResult, p
 			ev.Unmapped = ocsfFailUnmapped(findings)
 		}
 		ev.Resources = resources
+		ev.Policies = policiesByControl[e.ControlName]
 
 		events = append(events, ev)
 	}
@@ -395,9 +404,12 @@ func ocsfScanUID(result *control.AnalysisResult, now int64) string {
 // evaluation status onto an OCSF Compliance Finding, and writes the JSON array
 // to filePath. Provider-agnostic: every control is listed with an explicit
 // status, so the file is never empty and absence never reads as a pass.
-func writeOCSFToFile(p provider.Provider, result *control.AnalysisResult, conf *configuration.Configuration, filePath string) error {
-	entries := providerControlEntries(p, conf)
+// runs is non-empty in platform mode: the records are then the resolved
+// policies' controls over the policy runs' findings, each naming its policies
+// (spec s5). Outside it, nothing changes.
+func writeOCSFToFile(p provider.Provider, result *control.AnalysisResult, conf *configuration.Configuration, filePath string, runs []policyRun) error {
+	entries, policiesByControl := outputControlEntries(p, conf, runs)
 	now := time.Now().UTC().UnixMilli()
-	events := buildOCSF(entries, result, p.Name(), now, ocsfScanUID(result, now))
+	events := buildOCSF(entries, result, p.Name(), now, ocsfScanUID(result, now), policiesByControl)
 	return writeOCSFEvents(events, filePath)
 }

--- a/cmd/ocsf_provenance_test.go
+++ b/cmd/ocsf_provenance_test.go
@@ -25,7 +25,7 @@ func TestOCSFCarriesAnalyzedCommitResource(t *testing.T) {
 	conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t)}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "out.ocsf.json")
-	if err := writeOCSFToFile(&providerPkg.GitLabProvider{}, result, conf, path); err != nil {
+	if err := writeOCSFToFile(&providerPkg.GitLabProvider{}, result, conf, path, nil); err != nil {
 		t.Fatalf("write ocsf: %v", err)
 	}
 	raw, _ := os.ReadFile(path)
@@ -63,7 +63,7 @@ func TestOCSFResourcePartialProvenanceBoundaries(t *testing.T) {
 		t.Helper()
 		conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t)}
 		path := filepath.Join(t.TempDir(), "out.ocsf.json")
-		if err := writeOCSFToFile(&providerPkg.GitLabProvider{}, result, conf, path); err != nil {
+		if err := writeOCSFToFile(&providerPkg.GitLabProvider{}, result, conf, path, nil); err != nil {
 			t.Fatalf("write ocsf: %v", err)
 		}
 		raw, _ := os.ReadFile(path)
@@ -112,7 +112,7 @@ func TestOCSFOmitsResourceWhenNoProvenance(t *testing.T) {
 	conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t)}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "out.ocsf.json")
-	if err := writeOCSFToFile(&providerPkg.GitLabProvider{}, result, conf, path); err != nil {
+	if err := writeOCSFToFile(&providerPkg.GitLabProvider{}, result, conf, path, nil); err != nil {
 		t.Fatalf("write ocsf: %v", err)
 	}
 	raw, _ := os.ReadFile(path)

--- a/cmd/ocsf_test.go
+++ b/cmd/ocsf_test.go
@@ -24,7 +24,7 @@ func TestBuildOCSF_FindingFingerprint(t *testing.T) {
 			{Code: "ISSUE-701", Message: "x", Fingerprint: "deadbeefcafef00d"},
 		},
 	}
-	events := buildOCSF(entries, result, "github", 1, "s")
+	events := buildOCSF(entries, result, "github", 1, "s", nil)
 	recs, ok := events[0].Unmapped["plumber_findings"].([]map[string]any)
 	if !ok || len(recs) != 1 {
 		t.Fatalf("plumber_findings = %v", events[0].Unmapped["plumber_findings"])
@@ -47,7 +47,7 @@ func TestBuildOCSF_DismissedMarkerFollowsTheFinding(t *testing.T) {
 			{Code: "ISSUE-701", Message: "dismissed one", Dismissed: true},
 		},
 	}
-	events := buildOCSF(entries, result, "github", 1, "s")
+	events := buildOCSF(entries, result, "github", 1, "s", nil)
 	recs, ok := events[0].Unmapped["plumber_findings"].([]map[string]any)
 	if !ok || len(recs) != 2 {
 		t.Fatalf("plumber_findings = %v, want 2 records", events[0].Unmapped["plumber_findings"])
@@ -83,7 +83,7 @@ func TestBuildOCSF_FailingControl(t *testing.T) {
 		},
 	}
 
-	events := buildOCSF(entries, result, "github", 1754179200000, "scan-1")
+	events := buildOCSF(entries, result, "github", 1754179200000, "scan-1", nil)
 	if len(events) != 1 {
 		t.Fatalf("events = %d, want 1", len(events))
 	}
@@ -131,7 +131,7 @@ func TestBuildOCSF_PassingControlIsListed(t *testing.T) {
 	}
 	result := &control.AnalysisResult{CiValid: true}
 
-	events := buildOCSF(entries, result, "github", 1, "s")
+	events := buildOCSF(entries, result, "github", 1, "s", nil)
 	if len(events) != 1 {
 		t.Fatalf("events = %d, want 1 (passing controls are listed)", len(events))
 	}
@@ -156,7 +156,7 @@ func TestBuildOCSF_DegradedCleanControlIsWarning(t *testing.T) {
 		DegradedReasons: []string{"3 workflow file(s) could not be fetched"},
 	}
 
-	events := buildOCSF(entries, result, "github", 1, "s")
+	events := buildOCSF(entries, result, "github", 1, "s", nil)
 	if events[0].Compliance.StatusID != 2 || events[0].Compliance.Status != "Warning" {
 		t.Errorf("degraded clean control status = %q/%d, want Warning/2 (must NOT be Pass)", events[0].Compliance.Status, events[0].Compliance.StatusID)
 	}
@@ -171,7 +171,7 @@ func TestBuildOCSF_SkippedControlIsOther(t *testing.T) {
 	}
 	result := &control.AnalysisResult{CiValid: true}
 
-	events := buildOCSF(entries, result, "github", 1, "s")
+	events := buildOCSF(entries, result, "github", 1, "s", nil)
 	if events[0].Compliance.StatusID != 99 || events[0].Compliance.Status != "Skipped" {
 		t.Errorf("skipped control status = %q/%d, want Skipped/99", events[0].Compliance.Status, events[0].Compliance.StatusID)
 	}
@@ -187,7 +187,7 @@ func TestBuildOCSF_EveryControlEmitted(t *testing.T) {
 		CiValid:  true,
 		Findings: []opaengine.Finding{{Code: "ISSUE-701", Message: "x"}},
 	}
-	events := buildOCSF(entries, result, "github", 1, "s")
+	events := buildOCSF(entries, result, "github", 1, "s", nil)
 	if len(events) != 3 {
 		t.Fatalf("events = %d, want 3 (one per control, none omitted)", len(events))
 	}
@@ -202,7 +202,7 @@ func TestWriteOCSFEvents_RoundTrip(t *testing.T) {
 		CiValid:  true,
 		Findings: []opaengine.Finding{{Code: "ISSUE-701", Severity: "high", Message: "unpinned"}},
 	}
-	events := buildOCSF(entries, result, "github", 1754179200000, "scan-1")
+	events := buildOCSF(entries, result, "github", 1754179200000, "scan-1", nil)
 
 	path := t.TempDir() + "/out.ocsf.json"
 	if err := writeOCSFEvents(events, path); err != nil {
@@ -264,7 +264,7 @@ func TestBuildOCSF_MultiCodeRequirements(t *testing.T) {
 	}
 	result := &control.AnalysisResult{CiValid: true}
 
-	events := buildOCSF(entries, result, "gitlab", 1, "s")
+	events := buildOCSF(entries, result, "gitlab", 1, "s", nil)
 	if len(events) != 1 {
 		t.Fatalf("events = %d, want 1", len(events))
 	}
@@ -279,7 +279,7 @@ func TestBuildOCSF_FindingTypes(t *testing.T) {
 	entries := []control.ControlEntry{{ControlName: "someControl", DisplayName: "X"}}
 	result := &control.AnalysisResult{CiValid: true}
 
-	events := buildOCSF(entries, result, "github", 1, "s")
+	events := buildOCSF(entries, result, "github", 1, "s", nil)
 	got := events[0].FindingInfo.Types
 	want := []string{"CI/CD Security", "Supply Chain", "Security"}
 	if !reflect.DeepEqual(got, want) {
@@ -305,7 +305,7 @@ func TestBuildOCSF_NotEvaluableUsesTheControlsOwnReason(t *testing.T) {
 		NotEvaluable:    map[string]string{"someControl": "include_attribution_unavailable"},
 	}
 
-	events := buildOCSF(entries, result, "gitlab", 1, "s")
+	events := buildOCSF(entries, result, "gitlab", 1, "s", nil)
 	details := strings.Join(events[0].Compliance.StatusDetails, " | ")
 	if !strings.Contains(details, "include_attribution_unavailable") {
 		t.Errorf("status_details %q must carry the control's own reason", details)

--- a/cmd/platform_artifacts_test.go
+++ b/cmd/platform_artifacts_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/getplumber/plumber/control"
 	opaengine "github.com/getplumber/plumber/internal/engine/opa"
 	"github.com/getplumber/plumber/internal/platform"
+	"github.com/getplumber/plumber/pbom"
 	providerPkg "github.com/getplumber/plumber/provider"
 )
 
@@ -95,9 +96,13 @@ func debugTraceFinding() opaengine.Finding {
 func withArtifactFiles(t *testing.T) (dir string) {
 	t.Helper()
 	dir = t.TempDir()
-	origOutput, origCSV, origOCSF, origPBOM := outputFile, csvFile, ocsfFile, pbomFile
-	t.Cleanup(func() { outputFile, csvFile, ocsfFile, pbomFile = origOutput, origCSV, origOCSF, origPBOM })
-	outputFile, csvFile, ocsfFile, pbomFile = "", "", "", ""
+	origOutput, origCSV, origOCSF := outputFile, csvFile, ocsfFile
+	origPBOM, origCycloneDX := pbomFile, pbomCycloneDXFile
+	t.Cleanup(func() {
+		outputFile, csvFile, ocsfFile = origOutput, origCSV, origOCSF
+		pbomFile, pbomCycloneDXFile = origPBOM, origCycloneDX
+	})
+	outputFile, csvFile, ocsfFile, pbomFile, pbomCycloneDXFile = "", "", "", "", ""
 	return dir
 }
 
@@ -394,6 +399,180 @@ func TestWritePBOM_PlatformMode_ImageVerdictFollowsThePolicies(t *testing.T) {
 	t.Run("no policy enabling them means no claim at all", func(t *testing.T) {
 		assertKeys(t, onlyImage(t, debugTracePolicyYAML, nil), nil, nil)
 	})
+}
+
+// Spec s5: the PBOM and CycloneDX platform block is one entry per resolved
+// policy plus the platform's own global score. This is the MAPPING (the pbom
+// package tests build pb.Policies by hand and only assert the rendering), so
+// a swap here - the raw points instead of the rounded final ones, a score on
+// a run that evaluated nothing, the wrong enforcement - would ship a wrong
+// per-policy verdict inside the artifact with every other test green.
+func TestPlatformPBOMSummary_MapsEachRunAndTheGlobalScore(t *testing.T) {
+	// 66.6 ROUNDS to 67, the same rounding the push and the badge apply.
+	applied := scoredRun("Prod", "id-prod", "block", "C", 66.6)
+	unapplied := unappliedRun("Later", "id-later", reasonTreeNotApplied)
+
+	t.Run("an applied run carries its score, an un-applied one carries none", func(t *testing.T) {
+		got := platformPBOMSummary([]policyRun{applied, unapplied},
+			&platformVerdict{GlobalScore: &platformScore{Letter: "B", Points: 83}})
+
+		if got == nil || len(got.Policies) != 2 {
+			t.Fatalf("one entry per resolved policy: %#v", got)
+		}
+		first := got.Policies[0]
+		if first.Name != "Prod" || first.Enforcement != "block" || first.Score != "C" || !first.Applied || first.Reason != "" {
+			t.Errorf("the applied policy's entry is its own verdict: %#v", first)
+		}
+		if first.FinalPoints == nil || *first.FinalPoints != 67 {
+			t.Errorf("finalPoints are the run's ROUNDED final points: %#v", first.FinalPoints)
+		}
+		second := got.Policies[1]
+		if second.Name != "Later" || second.Enforcement != "report" || second.Applied || second.Reason != reasonTreeNotApplied {
+			t.Errorf("an un-applied policy is listed with its reason: %#v", second)
+		}
+		if second.Score != "" || second.FinalPoints != nil {
+			t.Errorf("a run that evaluated nothing has no score, not a zero one: %#v", second)
+		}
+		if got.GlobalScore == nil || *got.GlobalScore != (pbom.PlatformGlobalScore{Letter: "B", Points: 83}) {
+			t.Errorf("the global score is the platform's own: %#v", got.GlobalScore)
+		}
+	})
+
+	t.Run("no global score in the push response is no global score in the document", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			v    *platformVerdict
+		}{
+			{"a nil verdict", nil},
+			{"a verdict that carried none", &platformVerdict{Gate: &platformGate{Evaluated: true}}},
+		} {
+			got := platformPBOMSummary([]policyRun{applied}, tc.v)
+			if got == nil || got.GlobalScore != nil {
+				t.Errorf("%s must leave platformGlobalScore out rather than publish a zero: %#v", tc.name, got)
+			}
+		}
+	})
+
+	// Outside platform mode there are no runs, and the summary is nil so the
+	// standalone document is byte-identical to what it always was.
+	t.Run("no runs is no platform block at all", func(t *testing.T) {
+		if got := platformPBOMSummary(nil, &platformVerdict{GlobalScore: &platformScore{Letter: "B", Points: 83}}); got != nil {
+			t.Errorf("a standalone document gains nothing: %#v", got)
+		}
+	})
+}
+
+// The same mapping through the WRITERS: what a --pbom / --pbom-cyclonedx run
+// actually puts on disk after a push, rather than what the builder returns.
+func TestPlatformFlow_PBOMCarriesThePolicyScoresAndGlobalScore(t *testing.T) {
+	newGateFlagsCmd(t)
+	origPrint := printOutput
+	printOutput = false
+	defer func() { printOutput = origPrint }()
+
+	dir := withArtifactFiles(t)
+	pbomFile = filepath.Join(dir, "pbom.json")
+	pbomCycloneDXFile = filepath.Join(dir, "pbom.cdx.json")
+
+	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	// A tree the CLI cannot apply: the run is NOT applied, which is the entry
+	// shape a hand-built fixture never produces on this path.
+	broken := policyWithTree("Broken", "pipelineMustNotEnableDebugTrace", `{"enabled":true,"forbiddenVariables":"not-a-list"}`)
+	conf := confWithPolicies(t, a, broken)
+
+	var pushed []byte
+	srv := pushServer(t, 200, `{"gate":{"evaluated":true,"blocking":false,"policies":[]},"global_score":{"letter":"B","points":83}}`, &pushed)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok")
+	defer restore()
+
+	var err error
+	_ = captureStderr(t, func() {
+		err = presentResultWithProvider(testProvider(t), nil, debugTraceResult(), conf)
+	})
+	if err != nil {
+		t.Fatalf("the gate does not block: want exit 0, got %v", err)
+	}
+
+	raw, readErr := os.ReadFile(pbomFile)
+	if readErr != nil {
+		t.Fatalf("read the pbom: %v", readErr)
+	}
+	var bom struct {
+		Policies []struct {
+			Name        string `json:"name"`
+			Enforcement string `json:"enforcement"`
+			Score       string `json:"score"`
+			FinalPoints *int   `json:"finalPoints"`
+			Applied     bool   `json:"applied"`
+			Reason      string `json:"reason"`
+		} `json:"policies"`
+		PlatformGlobalScore *struct {
+			Letter string `json:"letter"`
+			Points int    `json:"points"`
+		} `json:"platformGlobalScore"`
+		PlumberScore any `json:"plumberScore"`
+	}
+	if err := json.Unmarshal(raw, &bom); err != nil {
+		t.Fatalf("the pbom is not valid JSON: %v", err)
+	}
+	if len(bom.Policies) != 2 {
+		t.Fatalf("one entry per resolved policy: %#v", bom.Policies)
+	}
+	applied := bom.Policies[0]
+	if applied.Name != "A" || applied.Enforcement != "report" || !applied.Applied {
+		t.Errorf("the applied policy's entry: %#v", applied)
+	}
+	if applied.Score == "" || applied.FinalPoints == nil {
+		t.Errorf("an applied policy carries the score its own run produced: %#v", applied)
+	}
+	unapplied := bom.Policies[1]
+	if unapplied.Name != "Broken" || unapplied.Applied {
+		t.Fatalf("the second policy must be the un-applied one: %#v", unapplied)
+	}
+	if unapplied.Score != "" || unapplied.FinalPoints != nil || unapplied.Reason == "" {
+		t.Errorf("an un-applied policy carries its reason and no score: %#v", unapplied)
+	}
+	if bom.PlatformGlobalScore == nil || bom.PlatformGlobalScore.Letter != "B" || bom.PlatformGlobalScore.Points != 83 {
+		t.Errorf("platformGlobalScore is the push response's own: %#v", bom.PlatformGlobalScore)
+	}
+	if bom.PlumberScore != nil {
+		t.Errorf("there is no run-level score in platform mode: %#v", bom.PlumberScore)
+	}
+
+	// The CycloneDX writer renders the same block as metadata properties, and
+	// nothing else on this path exercises it in platform mode.
+	cdxRaw, readErr := os.ReadFile(pbomCycloneDXFile)
+	if readErr != nil {
+		t.Fatalf("read the cyclonedx pbom: %v", readErr)
+	}
+	var cdx struct {
+		Metadata struct {
+			Properties []struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			} `json:"properties"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(cdxRaw, &cdx); err != nil {
+		t.Fatalf("the cyclonedx pbom is not valid JSON: %v", err)
+	}
+	props := map[string]string{}
+	for _, p := range cdx.Metadata.Properties {
+		props[p.Name] = p.Value
+	}
+	if props["plumber:platform-global-score"] != "B" || props["plumber:platform-global-points"] != "83" {
+		t.Errorf("the platform's global score must reach CycloneDX: %#v", props)
+	}
+	if props["plumber:policy:A:enforcement"] != "report" || props["plumber:policy:A:score"] == "" {
+		t.Errorf("the applied policy's properties: %#v", props)
+	}
+	if _, present := props["plumber:policy:Broken:score"]; present {
+		t.Errorf("an un-applied policy has no score property, only its enforcement: %#v", props)
+	}
+	if props["plumber:policy:Broken:enforcement"] != "report" {
+		t.Errorf("an un-applied policy is still listed: %#v", props)
+	}
 }
 
 func pbomImages(t *testing.T, path string) []map[string]any {

--- a/cmd/platform_artifacts_test.go
+++ b/cmd/platform_artifacts_test.go
@@ -618,3 +618,88 @@ func contains(haystack []string, needle string) bool {
 	}
 	return false
 }
+
+// The JSON report lists EVERY resolved policy, unlike the push, and an
+// un-applied one is listed with a null score and null findings. A zero score
+// or an empty findings array there would render a policy the CLI could not
+// evaluate as a clean verdict, and dropping the entry (which is what
+// buildPolicyResults does, deliberately) would make an assigned policy vanish
+// from the run's own account. The PBOM has this covered by
+// TestPlatformFlow_PBOMCarriesThePolicyScoresAndGlobalScore; this is the
+// report's own.
+func TestBuildAnalysisJSONReport_PlatformMode_UnappliedPolicyCarriesNoVerdict(t *testing.T) {
+	applied := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	wantMinPoints := 80
+	applied.MinPoints = &wantMinPoints
+	// A tree the CLI cannot apply: evaluatePlatformPolicies produces the real
+	// un-applied run shape rather than a hand-built one.
+	broken := policyWithTree("Broken", "pipelineMustNotEnableDebugTrace", `{"enabled":true,"forbiddenVariables":"not-a-list"}`)
+	conf := confWithPolicies(t, applied, broken)
+
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+
+	payload, err := buildAnalysisJSONReport(debugTraceResult(), conf.PlumberConfig,
+		complianceSummary{platformMode: true, scoreMode: true},
+		jsonOutputParams{provider: "gitlab"}, runs, nil)
+	if err != nil {
+		t.Fatalf("buildAnalysisJSONReport: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(payload, &report); err != nil {
+		t.Fatalf("the report is not valid JSON: %v", err)
+	}
+	list, ok := report["policies"].([]any)
+	if !ok || len(list) != 2 {
+		t.Fatalf("one entry per resolved policy, applied or not: %#v", report["policies"])
+	}
+	byName := map[string]map[string]any{}
+	for _, e := range list {
+		entry, ok := e.(map[string]any)
+		if !ok {
+			t.Fatalf("a policy entry is an object: %#v", e)
+		}
+		name, _ := entry["name"].(string)
+		byName[name] = entry
+	}
+
+	a, ok := byName["A"]
+	if !ok {
+		t.Fatalf("the applied policy is missing: %#v", byName)
+	}
+	if a["applied"] != true {
+		t.Errorf("policy A was evaluated: %#v", a)
+	}
+	if _, isScore := a["score"].(map[string]any); !isScore {
+		t.Errorf("an applied policy carries the score its own run produced: %#v", a["score"])
+	}
+	if findings, isList := a["findings"].([]any); !isList || len(findings) == 0 {
+		t.Errorf("an applied policy carries its own findings: %#v", a["findings"])
+	}
+	// The min_points value path: every other report test covers only the null
+	// case, so a mapping that dropped the value would stay green.
+	if a["min_points"] != float64(wantMinPoints) {
+		t.Errorf("min_points is the policy's own threshold, want %d, got %#v", wantMinPoints, a["min_points"])
+	}
+
+	b, ok := byName["Broken"]
+	if !ok {
+		t.Fatalf("an un-applied policy is still listed, the push is what omits it: %#v", byName)
+	}
+	if b["applied"] != false {
+		t.Errorf("the broken tree could not be applied: %#v", b)
+	}
+	score, present := b["score"]
+	if !present || score != nil {
+		t.Errorf("an un-applied policy carries a null score, never a zero one: %#v", score)
+	}
+	findings, present := b["findings"]
+	if !present || findings != nil {
+		t.Errorf("an un-applied policy carries null findings, never an empty list: %#v", findings)
+	}
+	if reason, _ := b["reason"].(string); reason == "" {
+		t.Errorf("an un-applied entry says why it was not evaluated: %#v", b["reason"])
+	}
+	if b["min_points"] != nil {
+		t.Errorf("this policy sets no min_points, so the key is null: %#v", b["min_points"])
+	}
+}

--- a/cmd/platform_artifacts_test.go
+++ b/cmd/platform_artifacts_test.go
@@ -56,6 +56,23 @@ gitlab:
       enabled: true
 `
 
+// The two image controls are INDEPENDENT, and enforcing tag pinning without a
+// registry allowlist (or the reverse) is the common split. These two policies
+// declare exactly one of them each.
+const forbiddenTagOnlyPolicyYAML = `version: "2.0"
+gitlab:
+  controls:
+    containerImageMustNotUseForbiddenTags:
+      enabled: true
+`
+
+const authorizedSourceOnlyPolicyYAML = `version: "2.0"
+gitlab:
+  controls:
+    containerImageMustComeFromAuthorizedSources:
+      enabled: true
+`
+
 // localOnlyFinding is a finding the LOCAL configuration produced and no policy
 // reported: it must not reach any platform-mode artifact.
 func localOnlyFinding() opaengine.Finding {
@@ -317,29 +334,13 @@ func TestWritePBOM_PlatformMode_ImageVerdictFollowsThePolicies(t *testing.T) {
 		Code: string(control.CodeImageForbiddenTag), Message: "latest tag", Job: "build", Fingerprint: "img",
 	}
 
-	t.Run("a policy that enables the image controls carries the union's verdict", func(t *testing.T) {
+	// onlyImage writes the platform-mode PBOM for one policy declaring the
+	// given configuration and returns the single inventory image's entry.
+	onlyImage := func(t *testing.T, policyYAML string, findings []opaengine.Finding) map[string]any {
+		t.Helper()
 		dir := withArtifactFiles(t)
 		pbomFile = filepath.Join(dir, "pbom.json")
-		runs := []policyRun{handMadePolicyRun(t, "Images", imagePolicyYAML, []opaengine.Finding{imageFinding})}
-		conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t)}
-
-		if err := writeOutputsWithProvider(&providerPkg.GitLabProvider{}, gitLabPBOMFixture(), conf,
-			complianceSummary{platformMode: true, scoreMode: true}, runs, nil); err != nil {
-			t.Fatalf("write outputs: %v", err)
-		}
-		images := pbomImages(t, pbomFile)
-		if len(images) != 1 {
-			t.Fatalf("images: %#v", images)
-		}
-		if images[0]["forbiddenTag"] != true {
-			t.Errorf("the policy reported a forbidden tag on this image: %#v", images[0])
-		}
-	})
-
-	t.Run("no policy enabling them means no claim at all", func(t *testing.T) {
-		dir := withArtifactFiles(t)
-		pbomFile = filepath.Join(dir, "pbom.json")
-		runs := []policyRun{handMadePolicyRun(t, "A", debugTracePolicyYAML, nil)}
+		runs := []policyRun{handMadePolicyRun(t, "Images", policyYAML, findings)}
 		conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t)}
 
 		if err := writeOutputsWithProvider(&providerPkg.GitLabProvider{}, gitLabPBOMFixture(), conf,
@@ -350,11 +351,48 @@ func TestWritePBOM_PlatformMode_ImageVerdictFollowsThePolicies(t *testing.T) {
 		if len(images) != 1 {
 			t.Fatalf("the inventory itself must survive: %#v", images)
 		}
-		for _, k := range []string{"forbiddenTag", "authorized"} {
-			if v, present := images[0][k]; present {
-				t.Errorf("no policy evaluated the image controls, so %q must be absent, got %v", k, v)
+		return images[0]
+	}
+
+	// assertKeys checks each per-image boolean against what the policy asked
+	// for: want is the expected value, and a nil want means the key must be
+	// absent entirely (the tri-state "not assessed").
+	assertKeys := func(t *testing.T, img map[string]any, forbiddenTag, authorized any) {
+		t.Helper()
+		for _, k := range []struct {
+			name string
+			want any
+		}{{"forbiddenTag", forbiddenTag}, {"authorized", authorized}} {
+			got, present := img[k.name]
+			if k.want == nil {
+				if present {
+					t.Errorf("no policy evaluated the control behind %q, so it must be absent, got %v", k.name, got)
+				}
+				continue
+			}
+			if !present || got != k.want {
+				t.Errorf("%q = %v (present %v), want %v: %#v", k.name, got, present, k.want, img)
 			}
 		}
+	}
+
+	t.Run("a policy that enables both image controls carries the union's verdict", func(t *testing.T) {
+		assertKeys(t, onlyImage(t, imagePolicyYAML, []opaengine.Finding{imageFinding}), true, true)
+	})
+
+	// The two controls are independent claims. A policy pinning tags says
+	// nothing about the registry an image comes from, so "authorized" is a
+	// verdict nobody produced and must not be published.
+	t.Run("only the forbidden-tag control claims only the forbidden tag", func(t *testing.T) {
+		assertKeys(t, onlyImage(t, forbiddenTagOnlyPolicyYAML, []opaengine.Finding{imageFinding}), true, nil)
+	})
+
+	t.Run("only the authorized-source control claims only the source", func(t *testing.T) {
+		assertKeys(t, onlyImage(t, authorizedSourceOnlyPolicyYAML, nil), nil, true)
+	})
+
+	t.Run("no policy enabling them means no claim at all", func(t *testing.T) {
+		assertKeys(t, onlyImage(t, debugTracePolicyYAML, nil), nil, nil)
 	})
 }
 

--- a/cmd/platform_artifacts_test.go
+++ b/cmd/platform_artifacts_test.go
@@ -92,18 +92,30 @@ func withArtifactFiles(t *testing.T) (dir string) {
 func TestBuildAnalysisJSONReport_PlatformMode_NoLocalControlBlocks(t *testing.T) {
 	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
 	conf := confWithPolicies(t, a)
+	// The fixture has to CARRY a not-evaluable mark for the assertion below to
+	// mean anything: debugTraceResult() sets none, the field is omitempty, and
+	// an assertion that an absent key is absent holds whether or not the report
+	// removes it (the re-review finding).
+	collected := debugTraceResult()
+	collected.MarkNotEvaluable("pipelineMustNotOverrideJobVariables", "raw_config_unavailable")
 	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
 
-	payload, err := buildAnalysisJSONReport(debugTraceResult(), conf.PlumberConfig,
-		complianceSummary{platformMode: true, scoreMode: true}, jsonOutputParams{provider: "gitlab"},
-		runs, &platformVerdict{GlobalScore: &platformScore{Letter: "C", Points: 66}})
-	if err != nil {
-		t.Fatalf("buildAnalysisJSONReport: %v", err)
+	decode := func(t *testing.T, s complianceSummary, runs []policyRun, v *platformVerdict) map[string]any {
+		t.Helper()
+		payload, err := buildAnalysisJSONReport(collected, conf.PlumberConfig, s,
+			jsonOutputParams{provider: "gitlab"}, runs, v)
+		if err != nil {
+			t.Fatalf("buildAnalysisJSONReport: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(payload, &m); err != nil {
+			t.Fatalf("the report is not valid JSON: %v", err)
+		}
+		return m
 	}
-	var report map[string]any
-	if err := json.Unmarshal(payload, &report); err != nil {
-		t.Fatalf("the report is not valid JSON: %v", err)
-	}
+
+	report := decode(t, complianceSummary{platformMode: true, scoreMode: true}, runs,
+		&platformVerdict{GlobalScore: &platformScore{Letter: "C", Points: 66}})
 
 	if report["platformMode"] != true {
 		t.Errorf("platformMode must say why the local blocks are absent, got %v", report["platformMode"])
@@ -117,11 +129,20 @@ func TestBuildAnalysisJSONReport_PlatformMode_NoLocalControlBlocks(t *testing.T)
 		}
 	}
 	if _, present := report["notEvaluable"]; present {
-		t.Error("notEvaluable is a per-control verdict of the local evaluation and must be absent")
+		t.Errorf("notEvaluable is a per-control verdict of the local evaluation and must be absent, got %v", report["notEvaluable"])
 	}
 	// The per-policy view is what replaces them.
 	if pols, ok := report["policies"].([]any); !ok || len(pols) != 1 {
 		t.Fatalf("policies: %#v", report["policies"])
+	}
+
+	// The SAME collected result, reported standalone, keeps the mark. That is
+	// what makes the assertion above a difference the platform branch creates
+	// rather than a property of the fixture.
+	standalone := decode(t, complianceSummary{scoreMode: true, controlCount: 1}, nil, nil)
+	marks, ok := standalone["notEvaluable"].(map[string]any)
+	if !ok || marks["pipelineMustNotOverrideJobVariables"] != "raw_config_unavailable" {
+		t.Fatalf("a standalone report keeps the run's not-evaluable marks, got %#v", standalone["notEvaluable"])
 	}
 }
 

--- a/cmd/platform_artifacts_test.go
+++ b/cmd/platform_artifacts_test.go
@@ -1,0 +1,382 @@
+package cmd
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/control"
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
+	"github.com/getplumber/plumber/internal/platform"
+	providerPkg "github.com/getplumber/plumber/provider"
+)
+
+// The ruling behind this file (review of task 6): in platform mode EVERY
+// output derives from the resolved policies, not only the score keys. A local
+// per-control verdict in the JSON report, the CSV or the OCSF feed is the same
+// wrong verdict the mode exists to remove (QUESTIONS row 44).
+
+// handMadePolicyRun builds an applied run directly, so a test can pick both
+// the configuration a policy declares and the findings it reported without
+// going through a Rego evaluation of a crafted pipeline.
+func handMadePolicyRun(t *testing.T, name, configYAML string, findings []opaengine.Finding) policyRun {
+	t.Helper()
+	pc, _, _, err := configuration.LoadPlumberConfigFromBytes([]byte(configYAML), "test policy "+name)
+	if err != nil {
+		t.Fatalf("load the policy configuration: %v", err)
+	}
+	points := 66.0
+	return policyRun{
+		Policies: []platform.Policy{{ID: "policy-" + name, Name: name, Enforcement: platform.EnforcementReport}},
+		Config:   pc,
+		Result:   &control.AnalysisResult{CiValid: true, Findings: findings},
+		Score:    &control.PlumberScoreResult{Score: "C", FinalPoints: points},
+		Applied:  true,
+	}
+}
+
+const debugTracePolicyYAML = `version: "2.0"
+gitlab:
+  controls:
+    pipelineMustNotEnableDebugTrace:
+      enabled: true
+      forbiddenVariables: ["CI_DEBUG_TRACE"]
+`
+
+const imagePolicyYAML = `version: "2.0"
+gitlab:
+  controls:
+    containerImageMustNotUseForbiddenTags:
+      enabled: true
+    containerImageMustComeFromAuthorizedSources:
+      enabled: true
+`
+
+// localOnlyFinding is a finding the LOCAL configuration produced and no policy
+// reported: it must not reach any platform-mode artifact.
+func localOnlyFinding() opaengine.Finding {
+	return opaengine.Finding{
+		Code: "ISSUE-901", Message: "local only", Job: "build",
+		File: ".gitlab-ci.yml", Fingerprint: "local-only",
+	}
+}
+
+// debugTraceFinding is the finding a policy reported.
+func debugTraceFinding() opaengine.Finding {
+	return opaengine.Finding{
+		Code: string(control.CodeDebugTraceEnabled), Message: "CI_DEBUG_TRACE is enabled", Job: "build",
+		File: ".gitlab-ci.yml", Line: 4, Fingerprint: "policy-finding",
+	}
+}
+
+// withArtifactFiles points the artifact flags at a temp directory for the
+// duration of one test and restores them after.
+func withArtifactFiles(t *testing.T) (dir string) {
+	t.Helper()
+	dir = t.TempDir()
+	origOutput, origCSV, origOCSF, origPBOM := outputFile, csvFile, ocsfFile, pbomFile
+	t.Cleanup(func() { outputFile, csvFile, ocsfFile, pbomFile = origOutput, origCSV, origOCSF, origPBOM })
+	outputFile, csvFile, ocsfFile, pbomFile = "", "", "", ""
+	return dir
+}
+
+// Spec s5 + the review ruling: the JSON report of a platform-mode run carries
+// the per-policy view and nothing built from the local configuration. The
+// legacy per-control *Result blocks and plumberConfig describe the local
+// catalog under the local policy file, so both are omitted, and platformMode
+// says why they are gone.
+func TestBuildAnalysisJSONReport_PlatformMode_NoLocalControlBlocks(t *testing.T) {
+	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	conf := confWithPolicies(t, a)
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+
+	payload, err := buildAnalysisJSONReport(debugTraceResult(), conf.PlumberConfig,
+		complianceSummary{platformMode: true, scoreMode: true}, jsonOutputParams{provider: "gitlab"},
+		runs, &platformVerdict{GlobalScore: &platformScore{Letter: "C", Points: 66}})
+	if err != nil {
+		t.Fatalf("buildAnalysisJSONReport: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(payload, &report); err != nil {
+		t.Fatalf("the report is not valid JSON: %v", err)
+	}
+
+	if report["platformMode"] != true {
+		t.Errorf("platformMode must say why the local blocks are absent, got %v", report["platformMode"])
+	}
+	if _, present := report["plumberConfig"]; present {
+		t.Error("plumberConfig names the LOCAL configuration as the author of a verdict the platform's policies produced")
+	}
+	for k := range report {
+		if strings.HasSuffix(k, "Result") {
+			t.Errorf("legacy per-control block %q is the local catalog's verdict and must be absent", k)
+		}
+	}
+	if _, present := report["notEvaluable"]; present {
+		t.Error("notEvaluable is a per-control verdict of the local evaluation and must be absent")
+	}
+	// The per-policy view is what replaces them.
+	if pols, ok := report["policies"].([]any); !ok || len(pols) != 1 {
+		t.Fatalf("policies: %#v", report["policies"])
+	}
+}
+
+// A standalone report keeps every one of those keys.
+func TestBuildAnalysisJSONReport_StandaloneKeepsTheLocalBlocks(t *testing.T) {
+	payload, err := buildAnalysisJSONReport(debugTraceResult(), confWithDebugTrace().PlumberConfig,
+		complianceSummary{scoreMode: true, controlCount: 1}, jsonOutputParams{provider: "gitlab"}, nil, nil)
+	if err != nil {
+		t.Fatalf("buildAnalysisJSONReport: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(payload, &report); err != nil {
+		t.Fatalf("the report is not valid JSON: %v", err)
+	}
+	if _, present := report["plumberConfig"]; !present {
+		t.Error("a standalone report keeps plumberConfig")
+	}
+	if _, present := report["platformMode"]; present {
+		t.Error("platformMode must be absent outside platform mode")
+	}
+	blocks := 0
+	for k := range report {
+		if strings.HasSuffix(k, "Result") {
+			blocks++
+		}
+	}
+	if blocks == 0 {
+		t.Error("a standalone report keeps its per-control *Result blocks")
+	}
+}
+
+// The CSV of a platform-mode run reports the policies' findings and their
+// controls, never the local catalog's, and names the policies each finding
+// belongs to in a trailing column.
+func TestWriteCSV_PlatformMode_OnlyThePoliciesFindings(t *testing.T) {
+	dir := withArtifactFiles(t)
+	csvFile = filepath.Join(dir, "out.csv")
+
+	base := &control.AnalysisResult{CiValid: true, ProjectPath: "grp/app", Findings: []opaengine.Finding{localOnlyFinding()}}
+	runs := []policyRun{handMadePolicyRun(t, "A", debugTracePolicyYAML, []opaengine.Finding{debugTraceFinding()})}
+	conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t)}
+
+	if err := writeOutputsWithProvider(&providerPkg.GitLabProvider{}, base, conf,
+		complianceSummary{platformMode: true, scoreMode: true}, runs, nil); err != nil {
+		t.Fatalf("write outputs: %v", err)
+	}
+
+	raw, err := os.ReadFile(csvFile)
+	if err != nil {
+		t.Fatalf("read the csv: %v", err)
+	}
+	records, err := csv.NewReader(strings.NewReader(string(raw))).ReadAll()
+	if err != nil {
+		t.Fatalf("the csv does not parse: %v", err)
+	}
+	header := records[0]
+	if header[len(header)-1] != "policies" {
+		t.Fatalf("the last column must be policies, got %v", header)
+	}
+	var codes, controls, policyCells []string
+	for _, r := range records[1:] {
+		codes = append(codes, r[0])
+		controls = append(controls, r[2])
+		policyCells = append(policyCells, r[len(r)-1])
+	}
+	if !contains(codes, string(control.CodeDebugTraceEnabled)) {
+		t.Errorf("the policy's finding is missing from the csv: %v", records)
+	}
+	if contains(codes, "ISSUE-901") {
+		t.Errorf("a local-only finding reached the csv: %v", records)
+	}
+	if contains(controls, "branchMustBeProtected") {
+		t.Errorf("the local catalog leaked into the csv: no policy enables branchMustBeProtected: %v", controls)
+	}
+	if !contains(policyCells, "A") {
+		t.Errorf("the finding row must name its policies: %v", records)
+	}
+}
+
+// A standalone CSV keeps its exact columns: no policies column at all.
+func TestWriteCSV_StandaloneHasNoPoliciesColumn(t *testing.T) {
+	dir := withArtifactFiles(t)
+	csvFile = filepath.Join(dir, "out.csv")
+	conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t)}
+
+	if err := writeOutputsWithProvider(&providerPkg.GitLabProvider{}, &control.AnalysisResult{CiValid: true}, conf,
+		complianceSummary{scoreMode: true}, nil, nil); err != nil {
+		t.Fatalf("write outputs: %v", err)
+	}
+	raw, err := os.ReadFile(csvFile)
+	if err != nil {
+		t.Fatalf("read the csv: %v", err)
+	}
+	if strings.Contains(strings.SplitN(string(raw), "\n", 2)[0], "policies") {
+		t.Errorf("the standalone csv header must be unchanged, got %q", strings.SplitN(string(raw), "\n", 2)[0])
+	}
+}
+
+// The OCSF feed of a platform-mode run: the policies' controls and findings,
+// each record naming the policies it was evaluated under.
+func TestWriteOCSF_PlatformMode_OnlyThePoliciesFindings(t *testing.T) {
+	dir := withArtifactFiles(t)
+	ocsfFile = filepath.Join(dir, "out.ocsf.json")
+
+	base := &control.AnalysisResult{CiValid: true, ProjectPath: "grp/app", Findings: []opaengine.Finding{localOnlyFinding()}}
+	runs := []policyRun{handMadePolicyRun(t, "A", debugTracePolicyYAML, []opaengine.Finding{debugTraceFinding()})}
+	conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t)}
+
+	if err := writeOutputsWithProvider(&providerPkg.GitLabProvider{}, base, conf,
+		complianceSummary{platformMode: true, scoreMode: true}, runs, nil); err != nil {
+		t.Fatalf("write outputs: %v", err)
+	}
+
+	raw, err := os.ReadFile(ocsfFile)
+	if err != nil {
+		t.Fatalf("read the ocsf feed: %v", err)
+	}
+	body := string(raw)
+	if !strings.Contains(body, "pipelineMustNotEnableDebugTrace") {
+		t.Errorf("the policy's control is missing from the ocsf feed:\n%s", body)
+	}
+	if strings.Contains(body, "branchMustBeProtected") {
+		t.Errorf("the local catalog leaked into the ocsf feed:\n%s", body)
+	}
+	if strings.Contains(body, "ISSUE-901") {
+		t.Errorf("a local-only finding reached the ocsf feed:\n%s", body)
+	}
+	var records []struct {
+		Policies   []string `json:"policies"`
+		Compliance struct {
+			Control string `json:"control"`
+		} `json:"compliance"`
+	}
+	if err := json.Unmarshal(raw, &records); err != nil {
+		t.Fatalf("the ocsf feed is not valid JSON: %v", err)
+	}
+	if len(records) == 0 {
+		t.Fatal("the policy's controls must produce records")
+	}
+	for _, r := range records {
+		if len(r.Policies) != 1 || r.Policies[0] != "A" {
+			t.Errorf("record for %q must name the policies it was evaluated under, got %v", r.Compliance.Control, r.Policies)
+		}
+	}
+}
+
+// A standalone OCSF record carries no policies key.
+func TestWriteOCSF_StandaloneHasNoPoliciesKey(t *testing.T) {
+	dir := withArtifactFiles(t)
+	ocsfFile = filepath.Join(dir, "out.ocsf.json")
+	conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t)}
+
+	if err := writeOutputsWithProvider(&providerPkg.GitLabProvider{}, &control.AnalysisResult{CiValid: true}, conf,
+		complianceSummary{scoreMode: true}, nil, nil); err != nil {
+		t.Fatalf("write outputs: %v", err)
+	}
+	raw, err := os.ReadFile(ocsfFile)
+	if err != nil {
+		t.Fatalf("read the ocsf feed: %v", err)
+	}
+	if strings.Contains(string(raw), `"policies"`) {
+		t.Errorf("the standalone ocsf feed must be unchanged")
+	}
+}
+
+// The PBOM's per-image booleans are a positive claim ("this image is
+// authorized"). In platform mode they may only state what a policy actually
+// evaluated: the union's verdict when a policy enables the image controls,
+// and NOTHING when none does.
+func TestWritePBOM_PlatformMode_ImageVerdictFollowsThePolicies(t *testing.T) {
+	imageFinding := opaengine.Finding{
+		Code: string(control.CodeImageForbiddenTag), Message: "latest tag", Job: "build", Fingerprint: "img",
+	}
+
+	t.Run("a policy that enables the image controls carries the union's verdict", func(t *testing.T) {
+		dir := withArtifactFiles(t)
+		pbomFile = filepath.Join(dir, "pbom.json")
+		runs := []policyRun{handMadePolicyRun(t, "Images", imagePolicyYAML, []opaengine.Finding{imageFinding})}
+		conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t)}
+
+		if err := writeOutputsWithProvider(&providerPkg.GitLabProvider{}, gitLabPBOMFixture(), conf,
+			complianceSummary{platformMode: true, scoreMode: true}, runs, nil); err != nil {
+			t.Fatalf("write outputs: %v", err)
+		}
+		images := pbomImages(t, pbomFile)
+		if len(images) != 1 {
+			t.Fatalf("images: %#v", images)
+		}
+		if images[0]["forbiddenTag"] != true {
+			t.Errorf("the policy reported a forbidden tag on this image: %#v", images[0])
+		}
+	})
+
+	t.Run("no policy enabling them means no claim at all", func(t *testing.T) {
+		dir := withArtifactFiles(t)
+		pbomFile = filepath.Join(dir, "pbom.json")
+		runs := []policyRun{handMadePolicyRun(t, "A", debugTracePolicyYAML, nil)}
+		conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t)}
+
+		if err := writeOutputsWithProvider(&providerPkg.GitLabProvider{}, gitLabPBOMFixture(), conf,
+			complianceSummary{platformMode: true, scoreMode: true}, runs, nil); err != nil {
+			t.Fatalf("write outputs: %v", err)
+		}
+		images := pbomImages(t, pbomFile)
+		if len(images) != 1 {
+			t.Fatalf("the inventory itself must survive: %#v", images)
+		}
+		for _, k := range []string{"forbiddenTag", "authorized"} {
+			if v, present := images[0][k]; present {
+				t.Errorf("no policy evaluated the image controls, so %q must be absent, got %v", k, v)
+			}
+		}
+	})
+}
+
+func pbomImages(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read the pbom: %v", err)
+	}
+	var bom struct {
+		ContainerImages []map[string]any `json:"containerImages"`
+	}
+	if err := json.Unmarshal(raw, &bom); err != nil {
+		t.Fatalf("the pbom is not valid JSON: %v", err)
+	}
+	return bom.ContainerImages
+}
+
+// Two findings sharing a fingerprint but sitting on different lines are two
+// alerts, not one: the fingerprint is deliberately line-independent, so it
+// cannot be the whole identity of a security-report row.
+func TestPlatformUnionResult_KeepsFindingsThatDifferByLine(t *testing.T) {
+	first := debugTraceFinding()
+	second := debugTraceFinding()
+	second.Line = 42
+	runs := []policyRun{handMadePolicyRun(t, "A", debugTracePolicyYAML, []opaengine.Finding{first, second})}
+
+	union := platformUnionResult(&control.AnalysisResult{CiValid: true}, runs)
+
+	if len(union.Findings) != 2 {
+		t.Fatalf("two lines are two findings, got %d", len(union.Findings))
+	}
+	doc := buildSARIF(union.Findings, ".plumber.yaml", "gitlab")
+	if len(doc.Runs[0].Results) != 2 {
+		t.Fatalf("SARIF results = %d, want 2", len(doc.Runs[0].Results))
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/platform_artifacts_test.go
+++ b/cmd/platform_artifacts_test.go
@@ -154,8 +154,20 @@ func TestBuildAnalysisJSONReport_PlatformMode_NoLocalControlBlocks(t *testing.T)
 		t.Errorf("notEvaluable is a per-control verdict of the local evaluation and must be absent, got %v", report["notEvaluable"])
 	}
 	// The per-policy view is what replaces them.
-	if pols, ok := report["policies"].([]any); !ok || len(pols) != 1 {
+	pols, ok := report["policies"].([]any)
+	if !ok || len(pols) != 1 {
 		t.Fatalf("policies: %#v", report["policies"])
+	}
+	// The entry's notEvaluable is always an object (a stable shape for a
+	// parser), and it holds THIS run's marks: the local result's mark asserted
+	// absent above must not reach it through the back door either.
+	entry, _ := pols[0].(map[string]any)
+	entryMarks, isObject := entry["notEvaluable"].(map[string]any)
+	if !isObject {
+		t.Fatalf("an applied policy entry carries a notEvaluable object, empty when the run marked nothing: %#v", entry["notEvaluable"])
+	}
+	if _, leaked := entryMarks["pipelineMustNotOverrideJobVariables"]; leaked {
+		t.Errorf("the LOCAL evaluation's not-evaluable mark must not reach a policy entry: %#v", entryMarks)
 	}
 
 	// The SAME collected result, reported standalone, keeps the mark. That is
@@ -722,6 +734,14 @@ func TestBuildAnalysisJSONReport_PlatformMode_UnappliedPolicyCarriesNoVerdict(t 
 	conf := confWithPolicies(t, applied, broken)
 
 	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+	// The applied run could not evaluate one of its controls: its entry has to
+	// carry the mark, and the un-applied entry has to carry a null for it,
+	// exactly as it does for score and findings.
+	for i := range runs {
+		if runs[i].Applied {
+			runs[i].Result.MarkNotEvaluable("pipelineMustNotOverrideJobVariables", "raw_config_unavailable")
+		}
+	}
 
 	payload, err := buildAnalysisJSONReport(debugTraceResult(), conf.PlumberConfig,
 		complianceSummary{platformMode: true, scoreMode: true},
@@ -760,6 +780,10 @@ func TestBuildAnalysisJSONReport_PlatformMode_UnappliedPolicyCarriesNoVerdict(t 
 	if findings, isList := a["findings"].([]any); !isList || len(findings) == 0 {
 		t.Errorf("an applied policy carries its own findings: %#v", a["findings"])
 	}
+	marks, isObject := a["notEvaluable"].(map[string]any)
+	if !isObject || marks["pipelineMustNotOverrideJobVariables"] != "raw_config_unavailable" {
+		t.Errorf("an applied policy carries its own run's not-evaluable marks: %#v", a["notEvaluable"])
+	}
 	// The min_points value path: every other report test covers only the null
 	// case, so a mapping that dropped the value would stay green.
 	if a["min_points"] != float64(wantMinPoints) {
@@ -783,6 +807,10 @@ func TestBuildAnalysisJSONReport_PlatformMode_UnappliedPolicyCarriesNoVerdict(t 
 	}
 	if reason, _ := b["reason"].(string); reason == "" {
 		t.Errorf("an un-applied entry says why it was not evaluated: %#v", b["reason"])
+	}
+	notEvaluable, present := b["notEvaluable"]
+	if !present || notEvaluable != nil {
+		t.Errorf("an un-applied policy carries a null notEvaluable, like its score and findings: %#v", notEvaluable)
 	}
 	if b["min_points"] != nil {
 		t.Errorf("this policy sets no min_points, so the key is null: %#v", b["min_points"])

--- a/cmd/platform_artifacts_test.go
+++ b/cmd/platform_artifacts_test.go
@@ -57,6 +57,15 @@ gitlab:
       enabled: true
 `
 
+// dockerInDockerPolicyYAML is a SECOND single-control policy, so a test can
+// give one policy run a not-evaluable mark and keep another run healthy.
+const dockerInDockerPolicyYAML = `version: "2.0"
+gitlab:
+  controls:
+    pipelineMustNotUseDockerInDocker:
+      enabled: true
+`
+
 // The two image controls are INDEPENDENT, and enforcing tag pinning without a
 // registry allowlist (or the reverse) is the common split. These two policies
 // declare exactly one of them each.
@@ -294,6 +303,131 @@ func TestWriteCSV_PlatformMode_SharedControlNamesBothPolicies(t *testing.T) {
 	}
 	if !strings.Contains(policiesCell, "A") || !strings.Contains(policiesCell, "B") {
 		t.Fatalf("a control two policy runs both enable must name both in the csv, got %q", policiesCell)
+	}
+}
+
+// platformUnionResult swaps the not-evaluable marks the CSV and OCSF turn into
+// a per-control status: the collected result's LOCAL marks are dropped and the
+// applied runs' own marks put in their place. Both halves matter, and neither
+// was covered: without the repopulation a control a policy could not evaluate
+// renders as a clean pass, and without the reset a local mark contradicts spec
+// s5 by deciding a platform-mode control's status.
+func TestWriteCSV_PlatformMode_NotEvaluableComesFromTheRuns(t *testing.T) {
+	dir := withArtifactFiles(t)
+	csvFile = filepath.Join(dir, "out.csv")
+
+	degraded := handMadePolicyRun(t, "A", debugTracePolicyYAML, nil)
+	degraded.Result.MarkNotEvaluable("pipelineMustNotEnableDebugTrace", "policy_lane_unavailable")
+	healthy := handMadePolicyRun(t, "B", dockerInDockerPolicyYAML, nil)
+	// The LOCAL evaluation could not evaluate the control the OTHER policy
+	// enables. Its mark must not decide that control's platform-mode status.
+	base := &control.AnalysisResult{CiValid: true, ProjectPath: "grp/app"}
+	base.MarkNotEvaluable("pipelineMustNotUseDockerInDocker", "local_mark_must_not_appear")
+	conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t)}
+
+	if err := writeOutputsWithProvider(&providerPkg.GitLabProvider{}, base, conf,
+		complianceSummary{platformMode: true, scoreMode: true},
+		[]policyRun{degraded, healthy}, nil); err != nil {
+		t.Fatalf("write outputs: %v", err)
+	}
+
+	raw, err := os.ReadFile(csvFile)
+	if err != nil {
+		t.Fatalf("read the csv: %v", err)
+	}
+	records, err := csv.NewReader(strings.NewReader(string(raw))).ReadAll()
+	if err != nil {
+		t.Fatalf("the csv does not parse: %v", err)
+	}
+	byControl := map[string][]string{}
+	for _, r := range records[1:] {
+		byControl[r[2]] = r
+	}
+	marked, ok := byControl["pipelineMustNotEnableDebugTrace"]
+	if !ok {
+		t.Fatalf("the policy's control has no row: %v", records)
+	}
+	if marked[3] != control.StatusError {
+		t.Errorf("a control the policy run could not evaluate is %q, want %q: %v", marked[3], control.StatusError, marked)
+	}
+	if !strings.Contains(marked[5], "policy_lane_unavailable") {
+		t.Errorf("the row must carry the POLICY run's reason, got %q", marked[5])
+	}
+	clean, ok := byControl["pipelineMustNotUseDockerInDocker"]
+	if !ok {
+		t.Fatalf("the second policy's control has no row: %v", records)
+	}
+	if clean[3] == control.StatusError {
+		t.Errorf("no policy run marked this control, the LOCAL mark must not make it an error: %v", clean)
+	}
+	if strings.Contains(string(raw), "local_mark_must_not_appear") {
+		t.Errorf("the local evaluation's not-evaluable reason reached the platform-mode csv:\n%s", raw)
+	}
+}
+
+// The OCSF half of the same swap: the record's compliance status and its
+// status_details come from the policy run's mark, never the local one.
+func TestWriteOCSF_PlatformMode_NotEvaluableComesFromTheRuns(t *testing.T) {
+	dir := withArtifactFiles(t)
+	ocsfFile = filepath.Join(dir, "out.ocsf.json")
+
+	degraded := handMadePolicyRun(t, "A", debugTracePolicyYAML, nil)
+	degraded.Result.MarkNotEvaluable("pipelineMustNotEnableDebugTrace", "policy_lane_unavailable")
+	healthy := handMadePolicyRun(t, "B", dockerInDockerPolicyYAML, nil)
+	base := &control.AnalysisResult{CiValid: true, ProjectPath: "grp/app"}
+	base.MarkNotEvaluable("pipelineMustNotUseDockerInDocker", "local_mark_must_not_appear")
+	conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t)}
+
+	if err := writeOutputsWithProvider(&providerPkg.GitLabProvider{}, base, conf,
+		complianceSummary{platformMode: true, scoreMode: true},
+		[]policyRun{degraded, healthy}, nil); err != nil {
+		t.Fatalf("write outputs: %v", err)
+	}
+
+	raw, err := os.ReadFile(ocsfFile)
+	if err != nil {
+		t.Fatalf("read the ocsf feed: %v", err)
+	}
+	var records []struct {
+		Compliance struct {
+			Control       string   `json:"control"`
+			Status        string   `json:"status"`
+			StatusDetails []string `json:"status_details"`
+		} `json:"compliance"`
+	}
+	if err := json.Unmarshal(raw, &records); err != nil {
+		t.Fatalf("the ocsf feed is not valid JSON: %v", err)
+	}
+	seen := map[string]struct {
+		status  string
+		details string
+	}{}
+	for _, r := range records {
+		seen[r.Compliance.Control] = struct {
+			status  string
+			details string
+		}{r.Compliance.Status, strings.Join(r.Compliance.StatusDetails, " | ")}
+	}
+	marked, ok := seen["pipelineMustNotEnableDebugTrace"]
+	if !ok {
+		t.Fatalf("the policy's control has no record:\n%s", raw)
+	}
+	// OCSF maps the error status onto its Warning enum ("could not verify").
+	if marked.status != "Warning" {
+		t.Errorf("a control the policy run could not evaluate is %q, want Warning", marked.status)
+	}
+	if !strings.Contains(marked.details, "policy_lane_unavailable") {
+		t.Errorf("status_details must carry the POLICY run's reason, got %q", marked.details)
+	}
+	clean, ok := seen["pipelineMustNotUseDockerInDocker"]
+	if !ok {
+		t.Fatalf("the second policy's control has no record:\n%s", raw)
+	}
+	if clean.status != "Pass" {
+		t.Errorf("no policy run marked this control, the LOCAL mark must not move it off Pass: %#v", clean)
+	}
+	if strings.Contains(string(raw), "local_mark_must_not_appear") {
+		t.Errorf("the local evaluation's not-evaluable reason reached the ocsf feed:\n%s", raw)
 	}
 }
 

--- a/cmd/platform_artifacts_test.go
+++ b/cmd/platform_artifacts_test.go
@@ -244,6 +244,47 @@ func TestWriteCSV_PlatformMode_OnlyThePoliciesFindings(t *testing.T) {
 	}
 }
 
+// Review comment 3985437498: every test above reaches the CSV writer with a
+// single policy run. twoPolicyRuns evaluates TWO runs that both enable the
+// debug-trace control; the shared control's finding row must still name
+// both policies, not just the one whose run outputControlEntries saw last.
+func TestWriteCSV_PlatformMode_SharedControlNamesBothPolicies(t *testing.T) {
+	dir := withArtifactFiles(t)
+	csvFile = filepath.Join(dir, "out.csv")
+
+	runs := twoPolicyRuns(t)
+	base := &control.AnalysisResult{CiValid: true, ProjectPath: "grp/app"}
+	conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t)}
+
+	if err := writeOutputsWithProvider(&providerPkg.GitLabProvider{}, base, conf,
+		complianceSummary{platformMode: true, scoreMode: true}, runs, nil); err != nil {
+		t.Fatalf("write outputs: %v", err)
+	}
+
+	raw, err := os.ReadFile(csvFile)
+	if err != nil {
+		t.Fatalf("read the csv: %v", err)
+	}
+	records, err := csv.NewReader(strings.NewReader(string(raw))).ReadAll()
+	if err != nil {
+		t.Fatalf("the csv does not parse: %v", err)
+	}
+	var policiesCell string
+	found := false
+	for _, r := range records[1:] {
+		if r[2] == "pipelineMustNotEnableDebugTrace" {
+			found = true
+			policiesCell = r[len(r)-1]
+		}
+	}
+	if !found {
+		t.Fatalf("the shared control's row is missing from the csv: %v", records)
+	}
+	if !strings.Contains(policiesCell, "A") || !strings.Contains(policiesCell, "B") {
+		t.Fatalf("a control two policy runs both enable must name both in the csv, got %q", policiesCell)
+	}
+}
+
 // A standalone CSV keeps its exact columns: no policies column at all.
 func TestWriteCSV_StandaloneHasNoPoliciesColumn(t *testing.T) {
 	dir := withArtifactFiles(t)
@@ -308,6 +349,50 @@ func TestWriteOCSF_PlatformMode_OnlyThePoliciesFindings(t *testing.T) {
 		if len(r.Policies) != 1 || r.Policies[0] != "A" {
 			t.Errorf("record for %q must name the policies it was evaluated under, got %v", r.Compliance.Control, r.Policies)
 		}
+	}
+}
+
+// Review comment 3985437498: same gap as the CSV test above, for the OCSF
+// feed. twoPolicyRuns's two runs both enable the debug-trace control, so its
+// record's policies array must name both, in /context order.
+func TestWriteOCSF_PlatformMode_SharedControlNamesBothPolicies(t *testing.T) {
+	dir := withArtifactFiles(t)
+	ocsfFile = filepath.Join(dir, "out.ocsf.json")
+
+	runs := twoPolicyRuns(t)
+	base := &control.AnalysisResult{CiValid: true, ProjectPath: "grp/app"}
+	conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t)}
+
+	if err := writeOutputsWithProvider(&providerPkg.GitLabProvider{}, base, conf,
+		complianceSummary{platformMode: true, scoreMode: true}, runs, nil); err != nil {
+		t.Fatalf("write outputs: %v", err)
+	}
+
+	raw, err := os.ReadFile(ocsfFile)
+	if err != nil {
+		t.Fatalf("read the ocsf feed: %v", err)
+	}
+	var records []struct {
+		Policies   []string `json:"policies"`
+		Compliance struct {
+			Control string `json:"control"`
+		} `json:"compliance"`
+	}
+	if err := json.Unmarshal(raw, &records); err != nil {
+		t.Fatalf("the ocsf feed is not valid JSON: %v", err)
+	}
+	found := false
+	for _, r := range records {
+		if r.Compliance.Control != "pipelineMustNotEnableDebugTrace" {
+			continue
+		}
+		found = true
+		if len(r.Policies) != 2 || r.Policies[0] != "A" || r.Policies[1] != "B" {
+			t.Fatalf("a control two policy runs both enable must name both, in /context order, got %v", r.Policies)
+		}
+	}
+	if !found {
+		t.Fatalf("the shared control's record is missing from the ocsf feed")
 	}
 }
 

--- a/cmd/platform_eval.go
+++ b/cmd/platform_eval.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/control"
+	defaultconfig "github.com/getplumber/plumber/defaultConfig"
+	"github.com/getplumber/plumber/internal/platform"
+	providerPkg "github.com/getplumber/plumber/provider"
+)
+
+// policyRun is one evaluated control configuration and every resolved policy
+// that shares it (platform mode, spec 2026-09-10-cli-platform-mode-policies-
+// only s2). It is THE product of a platform-mode run: the log renderer, the
+// artifact writers, the badge and MR comment, and the push all read it, so
+// they can never disagree about what a policy found.
+type policyRun struct {
+	// Policies is every resolved policy in this fingerprint group, in
+	// /context order.
+	Policies []platform.Policy
+
+	// Config is the configuration that was evaluated, nil when Applied is
+	// false.
+	Config *configuration.PlumberConfig
+
+	// Result is the scoped result (findings, not-evaluable marks) and Score
+	// the formula over it. Both nil when Applied is false: a run that was
+	// not evaluated has no verdict, and inventing an empty one would read
+	// as a clean pass.
+	Result *control.AnalysisResult
+	Score  *control.PlumberScoreResult
+
+	// Applied is false when nothing was evaluated for this group; Reason
+	// then says why. Reason is also set on an APPLIED run when the empty
+	// set is what was evaluated (reasonNoControls), which is a fact about
+	// the policy rather than a failure.
+	Applied bool
+	Reason  string
+
+	// Derived marks the "[Plumber default]" placeholder, evaluated under the
+	// embedded default configuration (R1). It is not a real policies row, so
+	// it is pushed name-only.
+	Derived bool
+}
+
+// Names joins the group's policy names in /context order, for the section
+// header.
+func (r policyRun) Names() string {
+	names := make([]string, 0, len(r.Policies))
+	for _, p := range r.Policies {
+		names = append(names, p.Name)
+	}
+	return strings.Join(names, ", ")
+}
+
+// The reasons a policy run carries. They are operator-facing prose, and the
+// two "not applied" ones are also what keeps such a policy out of the push:
+// a policy the CLI could not evaluate is absent from the results array,
+// never a clean entry.
+const (
+	reasonNoControls     = "declares no controls"
+	reasonNoPipeline     = "no pipeline retained for re-evaluation"
+	reasonTreeNotApplied = "control tree could not be applied"
+)
+
+// evaluatePlatformPolicies evaluates the collected result once per distinct
+// control configuration among the resolved policies. It never reads a local
+// configuration: a real policy's tree is the configuration (R2: no tree means
+// an empty set), the derived placeholder evaluates the embedded default (R1),
+// an unreadable tree is not evaluated (R3), and a result with no retained IR
+// cannot be re-evaluated (R6).
+//
+// Standalone mode resolves no policies, so this evaluates nothing and the
+// push keeps its own single locally-named entry (buildPlatformPush).
+func evaluatePlatformPolicies(p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult) []policyRun {
+	policies := platformRunOf(conf).Policies()
+	if len(policies) == 0 {
+		return nil
+	}
+
+	groups := map[string]*policyRun{}
+	order := []*policyRun{}
+	for _, pol := range policies {
+		cfg, derived, reason := configForPlatformPolicy(p.Name(), pol)
+		// Policies are grouped by what they EVALUATE, so two policies
+		// agreeing on a configuration are evaluated once and can never
+		// disagree about the answer. A policy that resolved no
+		// configuration groups by its reason instead, which keeps two
+		// unrelated failures from being reported as one.
+		key := "reason:" + reason
+		switch {
+		case derived:
+			key = "derived-default"
+		case cfg != nil:
+			key = configFingerprint(cfg)
+		}
+		if run, ok := groups[key]; ok {
+			run.Policies = append(run.Policies, pol)
+			continue
+		}
+
+		run := &policyRun{Policies: []platform.Policy{pol}, Config: cfg, Derived: derived, Reason: reason}
+		if cfg != nil {
+			scoped, score, ok := control.ReEvaluateForConfig(result, conf, p.Name(), cfg)
+			if !ok {
+				// No retained IR: there is nothing to evaluate this
+				// configuration against, and an empty verdict would read
+				// as a policy that found nothing wrong.
+				run.Config, run.Reason = nil, reasonNoPipeline
+			} else {
+				// ReEvaluateForConfig already stamps fingerprints, marks
+				// platform-dismissed findings and marks unconfigured
+				// controls on the scoped result. Source-location
+				// annotation is the one step of the run-level path it does
+				// not repeat, and the per-policy render prints locations,
+				// so annotate here (same linker, same order).
+				newLocationLinker(conf, scoped, p.Name()).Annotate(scoped.Findings)
+				run.Result, run.Score, run.Applied = scoped, &score, true
+			}
+		}
+		groups[key] = run
+		order = append(order, run)
+	}
+
+	out := make([]policyRun, 0, len(order))
+	for _, r := range order {
+		out = append(out, *r)
+	}
+	return out
+}
+
+// configForPlatformPolicy resolves the configuration one resolved policy is
+// evaluated under, with no local fallback anywhere:
+//   - the derived placeholder (not a real policies row): the embedded default
+//     configuration, derived=true (R1);
+//   - a real policy with no declared control: an empty v2 configuration,
+//     reason "declares no controls" (R2). An empty set is what the policy
+//     says, and evaluating it honestly is the answer - reading the local
+//     file instead would report a verdict the policy never asked for;
+//   - a real policy whose tree cannot be applied: nil, with the reason (R3).
+func configForPlatformPolicy(provider string, pol platform.Policy) (cfg *configuration.PlumberConfig, derived bool, reason string) {
+	if !pol.IsReal() {
+		pc, _, _, err := configuration.LoadPlumberConfigFromBytes(defaultconfig.Get(), "embedded default")
+		if err != nil {
+			return nil, true, fmt.Sprintf("%s (%v)", reasonTreeNotApplied, err)
+		}
+		return pc, true, ""
+	}
+	if !pol.DeclaresAnyControl() {
+		pc, _, _, err := configuration.LoadPlumberConfigFromBytes([]byte(emptyPolicyConfigYAML), "empty policy")
+		if err != nil {
+			return nil, false, fmt.Sprintf("%s (%v)", reasonTreeNotApplied, err)
+		}
+		return pc, false, reasonNoControls
+	}
+	pc, err := policyConfigFromTree(provider, pol)
+	if err != nil {
+		return nil, false, fmt.Sprintf("%s (%v)", reasonTreeNotApplied, err)
+	}
+	return pc, false, ""
+}
+
+// emptyPolicyConfigYAML is the configuration a policy declaring no control is
+// evaluated under: the schema version and nothing else. It is a real
+// configuration rather than a nil one, so the run is applied and reports an
+// honest empty verdict.
+const emptyPolicyConfigYAML = "version: \"" + policyConfigVersion + "\"\n"

--- a/cmd/platform_eval_test.go
+++ b/cmd/platform_eval_test.go
@@ -1,0 +1,172 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/control"
+	"github.com/getplumber/plumber/internal/ir"
+	"github.com/getplumber/plumber/internal/platform"
+)
+
+// debugTraceControlConfig is the debug-trace control as a policy declares it.
+// The control is a no-op unless forbiddenVariables is populated (see
+// policies/debug_trace.rego), and an enabled control with no substantive
+// field is marked not_evaluable by MarkUnconfiguredControls - so "enabled"
+// alone would evaluate to nothing and prove nothing here.
+const debugTraceControlConfig = `{"enabled":true,"forbiddenVariables":["CI_DEBUG_TRACE"]}`
+
+// policyWithTree builds a real resolved policy declaring exactly one control
+// with the given stored config, the shape /context serves.
+func policyWithTree(name, controlType, config string) platform.Policy {
+	pol := treePolicy(name, platform.PolicyControl{
+		ControlType: controlType,
+		Config:      json.RawMessage(config),
+	})
+	// treePolicy stamps one shared id; distinct ids here keep the pushed
+	// entries distinguishable when several policies are in play.
+	pol.ID = "policy-" + name
+	return pol
+}
+
+// derivedDefaultPolicy is the platform's derived "[Plumber default]"
+// placeholder, exactly as /context serves it for an unassigned project: the
+// nil uuid, report-only, and no control tree at all. internal/platform has no
+// constructor for it - it is served, never built CLI-side - so the literal
+// lives here, matching internal/platform's own contract fixtures.
+func derivedDefaultPolicy() platform.Policy {
+	return platform.Policy{ID: platform.NilUUID, Name: "[Plumber default]", Enforcement: platform.EnforcementReport}
+}
+
+// debugTraceResult is a collected GitLab run whose RETAINED IR carries one
+// job setting CI_DEBUG_TRACE=true: re-evaluating it under a config that
+// enables the debug-trace control produces a finding, and under one that does
+// not, none. That contrast is what makes a per-policy verdict observable.
+func debugTraceResult() *control.AnalysisResult {
+	return &control.AnalysisResult{
+		CiValid:     true,
+		ProjectPath: "grp/app",
+		Pipeline: &ir.NormalizedPipeline{
+			Provider:      ir.ProviderGitLab,
+			ProjectPath:   "grp/app",
+			DefaultBranch: "main",
+			Jobs: []ir.Job{{
+				Name:       "build",
+				OriginFile: ".gitlab-ci.yml",
+				Variables:  map[string]string{"CI_DEBUG_TRACE": "true"},
+			}},
+		},
+	}
+}
+
+// Two policies with byte-identical control trees share one evaluation and one
+// section; a third with a different tree gets its own. Order follows /context.
+func TestEvaluatePlatformPolicies_GroupsByFingerprintInContextOrder(t *testing.T) {
+	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	b := policyWithTree("B", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	c := policyWithTree("C", "pipelineMustNotUseDockerInDocker", `{"enabled":true}`)
+	conf := confWithPolicies(t, a, b, c)
+	result := debugTraceResult()
+
+	runs := evaluatePlatformPolicies(testProvider(t), conf, result)
+
+	if len(runs) != 2 {
+		t.Fatalf("want 2 runs (A+B shared, C alone), got %d", len(runs))
+	}
+	if runs[0].Names() != "A, B" || runs[1].Names() != "C" {
+		t.Fatalf("names: %q / %q", runs[0].Names(), runs[1].Names())
+	}
+	if !runs[0].Applied || runs[0].Score == nil || runs[0].Result == nil {
+		t.Fatalf("shared run must be applied with a scoped result and score: %+v", runs[0])
+	}
+	if runs[0].Score.Score == "A" {
+		t.Fatalf("A+B enable the debug-trace control and the IR carries a finding: score must not be A")
+	}
+	if runs[1].Score == nil || runs[1].Score.Score != "A" {
+		t.Fatalf("C enables only docker-in-docker, no finding: want A, got %+v", runs[1].Score)
+	}
+}
+
+// R2: a real policy declaring no controls evaluates an empty set: applied,
+// zero findings, A/100, and says so.
+func TestEvaluatePlatformPolicies_NoControlsDeclared_EvaluatesEmptySet(t *testing.T) {
+	p := platform.Policy{ID: "11111111-1111-1111-1111-111111111111", Name: "Empty", Enforcement: platform.EnforcementReport}
+	conf := confWithPolicies(t, p)
+
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+
+	if len(runs) != 1 || !runs[0].Applied || runs[0].Reason != reasonNoControls {
+		t.Fatalf("want one applied run with the declares-no-controls reason, got %+v", runs)
+	}
+	if len(runs[0].Result.Findings) != 0 || runs[0].Score.Score != "A" {
+		t.Fatalf("empty set must yield no findings and A, got %d findings, %s", len(runs[0].Result.Findings), runs[0].Score.Score)
+	}
+}
+
+// R3: an unreadable tree is not applied, not scored, and not pushed.
+func TestEvaluatePlatformPolicies_UnreadableTree_NotApplied(t *testing.T) {
+	bad := policyWithTree("Bad", "pipelineMustNotEnableDebugTrace", `{"enabled": not-json`)
+	conf := confWithPolicies(t, bad)
+
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+
+	if len(runs) != 1 || runs[0].Applied || runs[0].Score != nil {
+		t.Fatalf("want one un-applied run, got %+v", runs)
+	}
+	if !strings.HasPrefix(runs[0].Reason, reasonTreeNotApplied) {
+		t.Fatalf("reason: %q", runs[0].Reason)
+	}
+	entries := buildPolicyResults(runs, testProvider(t), conf)
+	if len(entries) != 0 {
+		t.Fatalf("an un-applied policy must not be pushed, got %d entries", len(entries))
+	}
+}
+
+// R1: the derived placeholder evaluates the embedded default, never a local
+// file.
+func TestEvaluatePlatformPolicies_DerivedPlaceholder_UsesEmbeddedDefault(t *testing.T) {
+	conf := confWithPolicies(t, derivedDefaultPolicy())
+	// A local config that enables NOTHING must not influence the run.
+	conf.PlumberConfig = &configuration.PlumberConfig{Version: "2.0"}
+
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+
+	if len(runs) != 1 || !runs[0].Applied || !runs[0].Derived {
+		t.Fatalf("want one applied derived run, got %+v", runs)
+	}
+	if runs[0].Score.Score == "A" {
+		t.Fatal("the embedded default enables the debug-trace control, so the finding must count: got A")
+	}
+}
+
+// R6: no retained IR means nothing can be re-evaluated.
+func TestEvaluatePlatformPolicies_NoRetainedPipeline_NotApplied(t *testing.T) {
+	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	conf := confWithPolicies(t, a)
+
+	runs := evaluatePlatformPolicies(testProvider(t), conf, &control.AnalysisResult{CiValid: true})
+
+	if len(runs) != 1 || runs[0].Applied || runs[0].Reason != reasonNoPipeline {
+		t.Fatalf("got %+v", runs)
+	}
+}
+
+// Standalone mode has no resolved policy set, so there is nothing to
+// evaluate per policy: the push takes its own local route instead.
+func TestEvaluatePlatformPolicies_StandaloneEvaluatesNothing(t *testing.T) {
+	for name, conf := range map[string]*configuration.Configuration{
+		"nil conf":        nil,
+		"no platform run": {},
+		"context fetch failed": {
+			PlatformRun: &platform.RunContext{Endpoint: "https://p.example.com"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult()); len(runs) != 0 {
+				t.Fatalf("standalone must evaluate no policy run, got %+v", runs)
+			}
+		})
+	}
+}

--- a/cmd/platform_flow_test.go
+++ b/cmd/platform_flow_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -268,5 +270,65 @@ func TestPlatformFlow_DegradedIsPushedNotExit3(t *testing.T) {
 	}
 	if !strings.Contains(string(pushed), `"degraded":true`) {
 		t.Fatalf("the push must carry collection.degraded: %s", pushed)
+	}
+}
+
+// Spec s5 end to end: with --output set, the file a platform-mode run leaves
+// behind carries one entry per policy and the PLATFORM's global score. It is
+// the ordering that makes this reachable: the artifacts are written after the
+// push, because before it there is no score that may be written at all.
+func TestPlatformFlow_OutputFileCarriesThePoliciesAndTheGlobalScore(t *testing.T) {
+	newGateFlagsCmd(t)
+	origOutput := outputFile
+	defer func() { outputFile = origOutput }()
+	outputFile = filepath.Join(t.TempDir(), "analysis.json")
+
+	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	prod := policyWithTree("Prod", "pipelineMustNotUseDockerInDocker", `{"enabled":true}`)
+	prod.Enforcement = platform.EnforcementBlock
+	conf := confWithPolicies(t, a, prod)
+	var pushed []byte
+	srv := pushServer(t, 200, `{"gate":{"evaluated":true,"blocking":false,"policies":[{"id":"`+a.ID+`","name":"A","enforcement":"report","blocking":false,"live_fail_count":0}]},"global_score":{"letter":"B","points":83}}`, &pushed)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok")
+	defer restore()
+
+	var err error
+	_ = captureStdoutAll(t, func() {
+		_ = captureStderr(t, func() { err = presentResultWithProvider(testProvider(t), nil, debugTraceResult(), conf) })
+	})
+	if err != nil {
+		t.Fatalf("want the platform's non-blocking verdict (exit 0), got %v", err)
+	}
+	if len(pushed) == 0 {
+		t.Fatal("the push must happen before the artifacts are written")
+	}
+
+	raw, readErr := os.ReadFile(outputFile)
+	if readErr != nil {
+		t.Fatalf("read the report: %v", readErr)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(raw, &report); err != nil {
+		t.Fatalf("the report is not valid JSON: %v", err)
+	}
+	policies, ok := report["policies"].([]any)
+	if !ok || len(policies) != 2 {
+		t.Fatalf("policies: %#v", report["policies"])
+	}
+	names := []string{}
+	for _, p := range policies {
+		entry, _ := p.(map[string]any)
+		names = append(names, entry["name"].(string))
+	}
+	if names[0] != "A" || names[1] != "Prod" {
+		t.Fatalf("policy entries = %v, want [A Prod] in /context order", names)
+	}
+	score, ok := report["plumberScore"].(map[string]any)
+	if !ok || score["letter"] != "B" || score["points"] != 83.0 {
+		t.Fatalf("plumberScore must be the platform's global score, got %#v", report["plumberScore"])
+	}
+	if _, present := report["minPoints"]; present {
+		t.Error("no local gate ran, so no local gate key may be written")
 	}
 }

--- a/cmd/platform_flow_test.go
+++ b/cmd/platform_flow_test.go
@@ -1,0 +1,195 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/internal/platform"
+)
+
+// pushServer answers the push with the given body and records the request.
+func pushServer(t *testing.T, status int, body string, got *[]byte) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		*got = b
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// Spec s2-s4 end to end: two policies, one blocking; the log carries both
+// sections and the verdict; the exit is the platform's; the push carries
+// exactly the two policy entries and no local one.
+func TestPlatformFlow_TwoPoliciesOneBlocking(t *testing.T) {
+	newGateFlagsCmd(t)
+	origPrint := printOutput
+	printOutput = true
+	defer func() { printOutput = origPrint }()
+	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	prod := policyWithTree("Prod", "pipelineMustNotUseDockerInDocker", `{"enabled":true}`)
+	prod.Enforcement = platform.EnforcementBlock
+	eighty := 80
+	prod.MinPoints = &eighty
+	conf := confWithPolicies(t, a, prod)
+	var pushed []byte
+	srv := pushServer(t, 200, `{"gate":{"evaluated":true,"blocking":true,"policies":[{"id":"`+a.ID+`","name":"A","enforcement":"report","blocking":false,"live_fail_count":1},{"id":"`+prod.ID+`","name":"Prod","enforcement":"block","blocking":true,"live_fail_count":0}]},"global_score":{"letter":"B","points":83}}`, &pushed)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok")
+	defer restore()
+
+	var err error
+	out := captureStdoutAll(t, func() {
+		_ = captureStderr(t, func() {
+			err = presentResultWithProvider(testProvider(t), nil, debugTraceResult(), conf)
+		})
+	})
+	var gateErr *PlatformGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("exit must be the platform's blocking verdict, got %v", err)
+	}
+	assertContains(t, out, "== Policy: A  [report]")
+	assertContains(t, out, "== Policy: Prod  [block, min_points 80]")
+	assertContains(t, out, "== Platform verdict")
+	assertContains(t, out, "Global score (platform): B  83 / 100 pts")
+	assertContains(t, out, "Exit 1: Prod blocks")
+	// The local Summary block is the whole thing platform mode replaces: its
+	// Status line and the gate sentence beside it ("... required ≥ 100 pts")
+	// are the only two strings that carry a LOCAL verdict. The bare word
+	// "required" is not usable as the marker: it is also part of two control
+	// display names ("Pipeline must include required components") that a
+	// policy section legitimately lists.
+	if strings.Contains(out, "  Status: ") || strings.Contains(out, "required ≥") {
+		t.Fatal("the local gate line must not be printed in platform mode")
+	}
+	var push struct {
+		Results []struct {
+			Policy   string `json:"policy"`
+			PolicyID string `json:"policy_id"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(pushed, &push); err != nil || len(push.Results) != 2 || push.Results[0].Policy != "A" || push.Results[1].Policy != "Prod" {
+		t.Fatalf("push results: %s (err %v)", pushed, err)
+	}
+	// The gate the renderer explained is keyed on ids, and so is the push:
+	// if the two sets ever diverge the verdict block would attribute one
+	// policy's numbers to another. Same ids, same order.
+	for i, want := range []string{a.ID, prod.ID} {
+		if push.Results[i].PolicyID != want {
+			t.Errorf("pushed result %d has policy_id %q, want the gated policy's own id %q", i, push.Results[i].PolicyID, want)
+		}
+	}
+}
+
+// Spec s4: zero policies (context failed) evaluates nothing, prints the notice,
+// exits 0, and never pushes.
+func TestPlatformFlow_NoPolicies_NothingEvaluatedNoPush(t *testing.T) {
+	newGateFlagsCmd(t)
+	origPrint := printOutput
+	printOutput = true
+	defer func() { printOutput = origPrint }()
+	conf := configuration.NewDefaultConfiguration()
+	conf.PlumberConfig = testDefaultPlumberConfig(t)
+	conf.PlatformRun = &platform.RunContext{Endpoint: "https://platform.example.com", ProjectPath: "g/p", ContextErr: errors.New("dial tcp: connection refused")}
+	pushed := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { pushed = true }))
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok")
+	defer restore()
+
+	var err error
+	out := captureStdoutAll(t, func() {
+		_ = captureStderr(t, func() { err = presentResultWithProvider(testProvider(t), nil, debugTraceResult(), conf) })
+	})
+	if err != nil {
+		t.Fatalf("want exit 0, got %v", err)
+	}
+	assertContains(t, out, "no policy resolved for g/p (dial tcp: connection refused), nothing evaluated, exit 0")
+	if strings.Contains(out, "Plumber Score") || pushed {
+		t.Fatalf("nothing may be evaluated or pushed: banner=%v pushed=%v", strings.Contains(out, "Plumber Score"), pushed)
+	}
+}
+
+// Spec s1: a local threshold and a local file change nothing but the notices.
+func TestPlatformFlow_LocalThresholdIgnored(t *testing.T) {
+	newGateFlagsCmd(t)
+	minPointsSet, minPoints = true, 100
+	a := policyWithTree("A", "pipelineMustNotUseDockerInDocker", `{"enabled":true}`) // no finding under this policy
+	conf := confWithPolicies(t, a)
+	var pushed []byte
+	srv := pushServer(t, 200, `{"gate":{"evaluated":true,"blocking":false,"policies":[{"id":"`+a.ID+`","name":"A","enforcement":"report","blocking":false,"live_fail_count":0}]},"global_score":{"letter":"A","points":100}}`, &pushed)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok")
+	defer restore()
+	var err error
+	_ = captureStdoutAll(t, func() {
+		_ = captureStderr(t, func() { err = presentResultWithProvider(testProvider(t), nil, debugTraceResult(), conf) })
+	})
+	if err != nil {
+		t.Fatalf("the debug-trace finding is not in policy A and min-points is inert: want exit 0, got %v", err)
+	}
+}
+
+// The GitLab entry point, with collection stubbed: everything after p.Run is
+// the production path (#467's stubRunProvider in cmd/platform_push_test.go).
+// Same two policies as above; asserts the same verdict and the same push.
+func TestPlatformFlow_RunWithProvider_TwoPolicies(t *testing.T) {
+	newGateFlagsCmd(t)
+	origPrint := printOutput
+	printOutput = true
+	defer func() { printOutput = origPrint }()
+	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	prod := policyWithTree("Prod", "pipelineMustNotUseDockerInDocker", `{"enabled":true}`)
+	prod.Enforcement = platform.EnforcementBlock
+	conf := confWithPolicies(t, a, prod)
+	var pushed []byte
+	srv := pushServer(t, 200, `{"gate":{"evaluated":true,"blocking":true,"policies":[{"id":"`+a.ID+`","name":"A","enforcement":"report","blocking":false,"live_fail_count":1},{"id":"`+prod.ID+`","name":"Prod","enforcement":"block","blocking":true,"live_fail_count":0}]},"global_score":{"letter":"B","points":83}}`, &pushed)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok")
+	defer restore()
+	var err error
+	out := captureStdoutAll(t, func() {
+		_ = captureStderr(t, func() {
+			err = runWithProvider(stubRunProvider{Provider: testProvider(t), result: debugTraceResult()}, nil, conf, nil, nil)
+		})
+	})
+	var gateErr *PlatformGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("exit must be the platform's blocking verdict, got %v", err)
+	}
+	assertContains(t, out, "== Policy: Prod  [block]")
+	assertContains(t, out, "Exit 1: Prod blocks")
+	if !strings.Contains(string(pushed), `"policy":"Prod"`) {
+		t.Fatalf("push must carry the Prod entry: %s", pushed)
+	}
+}
+
+// Spec s4 + ruling: a degraded collection is pushed and the verdict decides.
+func TestPlatformFlow_DegradedIsPushedNotExit3(t *testing.T) {
+	newGateFlagsCmd(t)
+	a := policyWithTree("A", "pipelineMustNotUseDockerInDocker", `{"enabled":true}`)
+	conf := confWithPolicies(t, a)
+	result := debugTraceResult()
+	result.DataCollectionDegraded, result.DegradedReasons = true, []string{"merged CI fetch failed"}
+	var pushed []byte
+	srv := pushServer(t, 200, `{"gate":{"evaluated":true,"blocking":false,"policies":[]}}`, &pushed)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok")
+	defer restore()
+	var err error
+	_ = captureStdoutAll(t, func() {
+		_ = captureStderr(t, func() { err = presentResultWithProvider(testProvider(t), nil, result, conf) })
+	})
+	if err != nil {
+		t.Fatalf("degraded in platform mode: want the platform's non-blocking verdict (exit 0), got %v", err)
+	}
+	if !strings.Contains(string(pushed), `"degraded":true`) {
+		t.Fatalf("the push must carry collection.degraded: %s", pushed)
+	}
+}

--- a/cmd/platform_flow_test.go
+++ b/cmd/platform_flow_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/control"
 	"github.com/getplumber/plumber/internal/platform"
 )
 
@@ -168,6 +169,82 @@ func TestPlatformFlow_RunWithProvider_TwoPolicies(t *testing.T) {
 	if !strings.Contains(string(pushed), `"policy":"Prod"`) {
 		t.Fatalf("push must carry the Prod entry: %s", pushed)
 	}
+}
+
+// --no-controls is inventory-only and evaluates nothing under ANY mode, so it
+// keeps today's sequence even under --platform: the artifacts are still
+// written and publishAndFinalize's no-controls guards still run. Routing it
+// down the platform branch instead would return from runPlatformMode on a
+// zero-policy run and skip both - a CI-less project would exit 0 with no
+// inventory and no diagnosis.
+func TestPlatformFlow_NoControlsKeepsTheInventoryGuardsUnderPlatform(t *testing.T) {
+	origPrint, origNoControls := printOutput, noControls
+	printOutput = true
+	defer func() { printOutput, noControls = origPrint, origNoControls }()
+
+	// conf.PlatformRun resolves nothing, which is what makes the bug
+	// reachable: with a policy the platform branch would push instead.
+	newConf := func(t *testing.T) *configuration.Configuration {
+		t.Helper()
+		conf := configuration.NewDefaultConfiguration()
+		conf.PlumberConfig = testDefaultPlumberConfig(t)
+		conf.NoControls = true
+		conf.PlatformRun = &platform.RunContext{Endpoint: "https://platform.example.com", ProjectPath: "g/p", ContextErr: errors.New("dial tcp: connection refused")}
+		return conf
+	}
+
+	t.Run("an unusable CI still fails with IncompleteDataError and pushes nothing", func(t *testing.T) {
+		newGateFlagsCmd(t)
+		noControls = true
+		pushed := false
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { pushed = true }))
+		defer srv.Close()
+		restore := withPlatformTestEnv(t, srv.URL, "tok")
+		defer restore()
+
+		var err error
+		_ = captureStdoutAll(t, func() {
+			_ = captureStderr(t, func() {
+				err = presentResultWithProvider(testProvider(t), nil, &control.AnalysisResult{CiMissing: true}, newConf(t))
+			})
+		})
+
+		var incomplete *IncompleteDataError
+		if !errors.As(err, &incomplete) {
+			t.Fatalf("err = %v, want *IncompleteDataError: a --no-controls run over a CI-less project must not exit 0 with an empty inventory", err)
+		}
+		if pushed {
+			t.Fatal("a --no-controls run publishes nothing, platform push included")
+		}
+	})
+
+	t.Run("a usable CI inventories, evaluates nothing and pushes nothing", func(t *testing.T) {
+		newGateFlagsCmd(t)
+		noControls = true
+		pushed := false
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { pushed = true }))
+		defer srv.Close()
+		restore := withPlatformTestEnv(t, srv.URL, "tok")
+		defer restore()
+
+		var err error
+		out := captureStdoutAll(t, func() {
+			_ = captureStderr(t, func() {
+				err = presentResultWithProvider(testProvider(t), nil, debugTraceResult(), newConf(t))
+			})
+		})
+
+		if err != nil {
+			t.Fatalf("err = %v, want nil: an inventory run over a valid CI succeeds", err)
+		}
+		if pushed {
+			t.Fatal("a --no-controls run publishes nothing, platform push included")
+		}
+		if strings.Contains(out, "== Policy") {
+			t.Fatalf("--no-controls evaluated nothing, so no policy section may be rendered:\n%s", out)
+		}
+		assertContains(t, out, "no controls requested, nothing to score")
+	})
 }
 
 // Spec s4 + ruling: a degraded collection is pushed and the verdict decides.

--- a/cmd/platform_flow_test.go
+++ b/cmd/platform_flow_test.go
@@ -332,3 +332,107 @@ func TestPlatformFlow_OutputFileCarriesThePoliciesAndTheGlobalScore(t *testing.T
 		t.Error("no local gate ran, so no local gate key may be written")
 	}
 }
+
+// The collection-truth diagnostics are facts about what was collected, not a
+// verdict, so platform mode keeps every one of them: CI configuration errors
+// explain why an inventory is thin, and the tier caveats explain why a
+// control could not be checked on this GitLab plan. Dropping them turned a
+// diagnosable run into a silent one (spec s3 renders today's control blocks;
+// these are part of that report).
+func TestPlatformFlow_CollectionDiagnosticsAreStillPrinted(t *testing.T) {
+	newGateFlagsCmd(t)
+	origPrint := printOutput
+	printOutput = true
+	defer func() { printOutput = origPrint }()
+	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	conf := confWithPolicies(t, a)
+	result := debugTraceResult()
+	result.CiErrors = []string{"boom"}
+	result.ApprovalRulesTierCaveat = true
+	result.MRApprovalSettingsTierCaveat = true
+	result.MRSettingsPremiumCaveatFields = []string{"mergeTrainsEnabled"}
+	result.SecurityPolicyTierCaveat = true
+	var pushed []byte
+	srv := pushServer(t, 200, `{"gate":{"evaluated":true,"blocking":false,"policies":[]}}`, &pushed)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok")
+	defer restore()
+
+	var err error
+	out := captureStdoutAll(t, func() {
+		_ = captureStderr(t, func() { err = presentResultWithProvider(testProvider(t), nil, result, conf) })
+	})
+
+	if err != nil {
+		t.Fatalf("the gate did not block: want exit 0, got %v", err)
+	}
+	assertContains(t, out, "CI configuration errors:")
+	assertContains(t, out, "boom")
+	assertContains(t, out, "MR approval rules are a GitLab Premium/Ultimate feature.")
+	assertContains(t, out, "MR approval settings are a GitLab Premium/Ultimate feature.")
+	assertContains(t, out, "mergeTrainsEnabled")
+	assertContains(t, out, "Security policies are a GitLab Ultimate feature")
+}
+
+// Spec s4: --fail-warnings is one of the two exit sources platform mode
+// keeps, and a run that resolved no policy is no exception. Returning a bare
+// nil there made the opt-in silently inert on exactly the runs (an
+// unreachable platform, an unassigned project) where the warnings are the
+// only thing the operator has left.
+func TestPlatformFlow_NoPolicies_FailWarningsStillDecidesTheExit(t *testing.T) {
+	newGateFlagsCmd(t)
+	origPrint, origFail := printOutput, failWarnings
+	printOutput = true
+	defer func() { printOutput, failWarnings = origPrint, origFail }()
+
+	newConf := func(t *testing.T) *configuration.Configuration {
+		t.Helper()
+		conf := configuration.NewDefaultConfiguration()
+		conf.PlumberConfig = testDefaultPlumberConfig(t)
+		conf.PlatformRun = &platform.RunContext{
+			Endpoint:    "https://platform.example.com",
+			ProjectPath: "g/p",
+			ContextErr:  errors.New("dial tcp: connection refused"),
+		}
+		return conf
+	}
+	run := func(t *testing.T, warnings []string) error {
+		t.Helper()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("a run that resolved no policy must never push")
+		}))
+		defer srv.Close()
+		restore := withPlatformTestEnv(t, srv.URL, "tok")
+		defer restore()
+		result := debugTraceResult()
+		result.Warnings = warnings
+		var err error
+		_ = captureStdoutAll(t, func() {
+			_ = captureStderr(t, func() { err = presentResultWithProvider(testProvider(t), nil, result, newConf(t)) })
+		})
+		return err
+	}
+
+	t.Run("warnings exist", func(t *testing.T) {
+		failWarnings = true
+		err := run(t, []string{"could not verify the default branch"})
+		var degraded *DegradedError
+		if !errors.As(err, &degraded) {
+			t.Fatalf("err = %v, want a *DegradedError: --fail-warnings is a data-quality opt-in, not a score gate", err)
+		}
+	})
+
+	t.Run("no warnings still exits 0", func(t *testing.T) {
+		failWarnings = true
+		if err := run(t, nil); err != nil {
+			t.Fatalf("err = %v, want nil: nothing was evaluated and there is nothing to warn about", err)
+		}
+	})
+
+	t.Run("without the opt-in nothing fails", func(t *testing.T) {
+		failWarnings = false
+		if err := run(t, []string{"could not verify the default branch"}); err != nil {
+			t.Fatalf("err = %v, want nil: warnings alone never fail a run", err)
+		}
+	})
+}

--- a/cmd/platform_gate.go
+++ b/cmd/platform_gate.go
@@ -53,6 +53,16 @@ type platformVerdict struct {
 	Unavailable string
 }
 
+// platformGatePassed is the platform-mode answer to "did this run pass": the
+// gate did not block. Every fail-open case (no push, no verdict, an old
+// platform, an unevaluated gate) passes, which is invariant 5's let-through
+// stated once for every consumer that reports a verdict - the JSON report's
+// `passed`, the MR comment's status line - so none of them can invent a
+// stricter reading than the exit code's.
+func platformGatePassed(v *platformVerdict) bool {
+	return v == nil || v.Gate == nil || !v.Gate.Blocking
+}
+
 // PlatformGateError reports that the platform's post-push gate evaluation
 // blocked this run: one or more policies has live-monitoring failures the
 // operator configured as blocking. It is a verdict on the project, exactly

--- a/cmd/platform_gate.go
+++ b/cmd/platform_gate.go
@@ -126,7 +126,9 @@ func platformGatePolicyDescriptions(policies []platformGatePolicy) []string {
 //
 //   - a body that does not parse as JSON, or one that parses but carries no
 //     "gate" key at all: an old platform. Fail open with the unavailable
-//     line, the verdict's Gate nil and Unavailable set.
+//     line, the verdict's Gate nil and Unavailable set. A body that DID parse
+//     still hands back the global score it carried: the gate is missing, the
+//     score the badge and the comment publish is not.
 //   - evaluated:false: the platform's own explicit fail-open (nothing
 //     configured to gate this project, a snapshot not yet collected,
 //     etc). Fail open, logging the platform's own reason; the verdict still
@@ -143,14 +145,35 @@ func platformGatePolicyDescriptions(policies []platformGatePolicy) []string {
 //     as the *returned* error, but the line already reached the log).
 func evaluatePlatformGate(body []byte) (*platformVerdict, error) {
 	var resp platformPushResponse
-	if err := json.Unmarshal(body, &resp); err != nil || resp.Gate == nil {
+	err := json.Unmarshal(body, &resp)
+	if err != nil && resp.Gate != nil {
+		// encoding/json fills every field it CAN decode and reports the one
+		// it could not, so a gate that decoded cleanly beside an unreadable
+		// sibling is still the platform's verdict. Discarding it turned a
+		// block into a fail-open over a field the gate never reads (the
+		// review finding; platformScore.UnmarshalJSON removes the common
+		// cause, this keeps the rest from costing the verdict). The partial
+		// decode is said out loud rather than swallowed.
+		scoreWarn(fmt.Sprintf("the platform's push response was only partially decoded (%v); using the gate verdict it did carry", err))
+		err = nil
+	}
+	if err != nil || resp.Gate == nil {
 		// A 2xx-accepted push whose body carries no usable gate verdict: an
 		// older platform that predates the gate, or a mangled body. The
 		// platform is UP and the push LANDED, so this is the no-verdict
 		// line, never the alertable "unavailable" sentence (see the
 		// constants' doc comment below).
 		scoreWarn(platformGateNoVerdictLine)
-		return &platformVerdict{Unavailable: platformGateNoVerdictLine}, nil
+		v := &platformVerdict{Unavailable: platformGateNoVerdictLine}
+		if err == nil {
+			// The body parsed, it just carried no gate. Whatever else it did
+			// send is still the platform's own: the global score is what the
+			// badge, the merge-request comment and the JSON top level
+			// publish, and dropping it made them say "score unavailable" for
+			// a platform that had just sent one.
+			v.GlobalScore = resp.GlobalScore
+		}
+		return v, nil
 	}
 	gate := resp.Gate
 

--- a/cmd/platform_gate.go
+++ b/cmd/platform_gate.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -31,14 +32,16 @@ type platformGate struct {
 	Policies  []platformGatePolicy `json:"policies"`
 }
 
-// platformPushResponse is the shape decoded from a 2xx push response body.
-// Gate is a pointer so a response with no "gate" key (an old platform) is
-// distinguishable from an evaluated gate. GlobalScore is the platform's own
-// displayed score for the run (PushAccepted.global_score: the average of the
-// policies' FINAL points, letter from that average), nil when absent.
-type platformPushResponse struct {
-	Gate        *platformGate  `json:"gate"`
-	GlobalScore *platformScore `json:"global_score"`
+// platformPushResponseEnvelope is the first stage of decoding a 2xx push
+// response body: both blocks are held as raw JSON so each can be decoded on
+// its own terms. The gate decides the exit code and is decoded strictly right
+// after; the global score (PushAccepted.global_score: the average of the
+// policies' FINAL points, letter from that average) is display data and is
+// decoded tolerantly. An absent key and a null one are both "the platform
+// sent nothing here" - see isAbsentJSON.
+type platformPushResponseEnvelope struct {
+	Gate        json.RawMessage `json:"gate"`
+	GlobalScore json.RawMessage `json:"global_score"`
 }
 
 // platformVerdict is what a push produced, for every consumer after the push:
@@ -114,6 +117,47 @@ func platformGatePolicyDescriptions(policies []platformGatePolicy) []string {
 	return out
 }
 
+// platformGateNoVerdict is the single no-verdict fail-open: a 2xx push whose
+// body carried no usable gate (an old platform, a body that is not JSON, a
+// gate that did not decode). It prints one line, carries whatever global
+// score the body did yield, and returns a nil error - the let-through
+// invariant 5 requires, stated in plain words rather than passed silently.
+// detail, when present, names which part failed; the alertable sentence is
+// deliberately NOT used here (see the constants below).
+func platformGateNoVerdict(detail string, score *platformScore) (*platformVerdict, error) {
+	line := platformGateNoVerdictLine
+	if detail != "" {
+		line += " (" + detail + ")"
+	}
+	scoreWarn(line)
+	return &platformVerdict{GlobalScore: score, Unavailable: line}, nil
+}
+
+// decodePlatformGlobalScore decodes the response's global_score with
+// platformScore's tolerant unmarshaller. This is display data - the badge
+// letter, the comment headline, the JSON top-level score - never a verdict,
+// so a shape it cannot read costs the score alone: nil, one line, and the
+// gate beside it is untouched. Absent and null are simply "no score", which
+// is a routine state and says nothing.
+func decodePlatformGlobalScore(raw json.RawMessage) *platformScore {
+	if isAbsentJSON(raw) {
+		return nil
+	}
+	var score platformScore
+	if err := json.Unmarshal(raw, &score); err != nil {
+		scoreWarn(fmt.Sprintf("the platform's global score could not be decoded (%v); this run reports no global score", err))
+		return nil
+	}
+	return &score
+}
+
+// isAbsentJSON reports whether a raw field is missing or JSON null, the two
+// spellings of "the platform sent nothing here".
+func isAbsentJSON(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null"))
+}
+
 // evaluatePlatformGate parses a successful push response's gate block and
 // decides the platform-gate outcome for this run, returning a *platformVerdict
 // alongside the error for every consumer downstream of the push (the
@@ -124,11 +168,13 @@ func platformGatePolicyDescriptions(policies []platformGatePolicy) []string {
 // (platformGateFailOpenLine), so an old platform that has never heard of
 // gates behaves identically to one that is temporarily down:
 //
-//   - a body that does not parse as JSON, or one that parses but carries no
-//     "gate" key at all: an old platform. Fail open with the unavailable
-//     line, the verdict's Gate nil and Unavailable set. A body that DID parse
-//     still hands back the global score it carried: the gate is missing, the
-//     score the badge and the comment publish is not.
+//   - a body that does not parse as JSON, one that carries no "gate" key at
+//     all (an old platform), or one whose gate block does not decode: no
+//     verdict. Fail open with the no-verdict line, the verdict's Gate nil and
+//     Unavailable set (naming the decode failure when there was one). A body
+//     that DID parse still hands back the global score it carried: the gate
+//     is missing, the score the badge and the comment publish is not. A gate
+//     is never PARTIALLY decoded - see the two-stage decode below.
 //   - evaluated:false: the platform's own explicit fail-open (nothing
 //     configured to gate this project, a snapshot not yet collected,
 //     etc). Fail open, logging the platform's own reason; the verdict still
@@ -144,38 +190,42 @@ func platformGatePolicyDescriptions(policies []platformGatePolicy) []string {
 //     returned error (a local score-gate failure outranks it and discards it
 //     as the *returned* error, but the line already reached the log).
 func evaluatePlatformGate(body []byte) (*platformVerdict, error) {
-	var resp platformPushResponse
-	err := json.Unmarshal(body, &resp)
-	if err != nil && resp.Gate != nil {
-		// encoding/json fills every field it CAN decode and reports the one
-		// it could not, so a gate that decoded cleanly beside an unreadable
-		// sibling is still the platform's verdict. Discarding it turned a
-		// block into a fail-open over a field the gate never reads (the
-		// review finding; platformScore.UnmarshalJSON removes the common
-		// cause, this keeps the rest from costing the verdict). The partial
-		// decode is said out loud rather than swallowed.
-		scoreWarn(fmt.Sprintf("the platform's push response was only partially decoded (%v); using the gate verdict it did carry", err))
-		err = nil
+	// Two stages, and the split is the whole point. The gate is the run's
+	// exit code and is decoded STRICTLY; the global score is display data and
+	// is decoded tolerantly. Doing both in one pass is what broke: encoding/
+	// json leaves a mistyped field at its zero value and keeps going, so
+	// "blocking":"true" handed back a fully-formed gate with Blocking false
+	// and a blocking verdict silently became exit 0. No amount of tolerance
+	// may ever be able to soften a verdict, so tolerance is not applied to
+	// the gate at all.
+	var envelope platformPushResponseEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		// The body is not JSON at all: nothing in it can be trusted, so
+		// nothing is carried out of it.
+		return platformGateNoVerdict("", nil)
 	}
-	if err != nil || resp.Gate == nil {
-		// A 2xx-accepted push whose body carries no usable gate verdict: an
-		// older platform that predates the gate, or a mangled body. The
-		// platform is UP and the push LANDED, so this is the no-verdict
-		// line, never the alertable "unavailable" sentence (see the
-		// constants' doc comment below).
-		scoreWarn(platformGateNoVerdictLine)
-		v := &platformVerdict{Unavailable: platformGateNoVerdictLine}
-		if err == nil {
-			// The body parsed, it just carried no gate. Whatever else it did
-			// send is still the platform's own: the global score is what the
-			// badge, the merge-request comment and the JSON top level
-			// publish, and dropping it made them say "score unavailable" for
-			// a platform that had just sent one.
-			v.GlobalScore = resp.GlobalScore
-		}
-		return v, nil
+
+	// Decoded first so every fail-open path below can still carry it: the
+	// gate is missing, the score the badge and the comment publish is not.
+	score := decodePlatformGlobalScore(envelope.GlobalScore)
+
+	if isAbsentJSON(envelope.Gate) {
+		// A 2xx-accepted push whose body carries no gate at all: an older
+		// platform that predates it. The platform is UP and the push LANDED,
+		// so this is the no-verdict line, never the alertable "unavailable"
+		// sentence (see the constants' doc comment below).
+		return platformGateNoVerdict("", score)
 	}
-	gate := resp.Gate
+
+	var decoded platformGate
+	if err := json.Unmarshal(envelope.Gate, &decoded); err != nil {
+		// A gate whose own fields did not decode is NOT a verdict. It is not
+		// partially one either: a half-decoded gate reads as "evaluated,
+		// not blocking", which is the one answer this CLI must never invent.
+		// Drop it and fail open honestly, saying which half failed.
+		return platformGateNoVerdict(fmt.Sprintf("the gate block did not decode: %v", err), score)
+	}
+	gate := &decoded
 
 	if !gate.Evaluated {
 		msg := "platform gate not evaluated"
@@ -183,11 +233,11 @@ func evaluatePlatformGate(body []byte) (*platformVerdict, error) {
 			msg += ": " + gate.Reason
 		}
 		scoreWarn(msg)
-		return &platformVerdict{Gate: gate, GlobalScore: resp.GlobalScore, Unavailable: msg}, nil
+		return &platformVerdict{Gate: gate, GlobalScore: score, Unavailable: msg}, nil
 	}
 
 	if !gate.Blocking {
-		return &platformVerdict{Gate: gate, GlobalScore: resp.GlobalScore}, nil
+		return &platformVerdict{Gate: gate, GlobalScore: score}, nil
 	}
 
 	blocking := make([]platformGatePolicy, 0, len(gate.Policies))
@@ -205,7 +255,7 @@ func evaluatePlatformGate(body []byte) (*platformVerdict, error) {
 	// placeholder - never a bare "BLOCKED: " with nothing after the colon
 	// (PR-review finding).
 	fmt.Fprintf(os.Stderr, "✗ platform gate BLOCKED: %s\n", platformGateDetail(blocking, gate.Reason))
-	return &platformVerdict{Gate: gate, GlobalScore: resp.GlobalScore}, &PlatformGateError{Reason: gate.Reason, Policies: blocking}
+	return &platformVerdict{Gate: gate, GlobalScore: score}, &PlatformGateError{Reason: gate.Reason, Policies: blocking}
 }
 
 // The two EXACT fail-open sentences the spec requires (see

--- a/cmd/platform_gate.go
+++ b/cmd/platform_gate.go
@@ -32,11 +32,25 @@ type platformGate struct {
 }
 
 // platformPushResponse is the shape decoded from a 2xx push response body.
-// Gate is a pointer so a response with no "gate" key at all (an old
-// platform that predates gate evaluation) is distinguishable from one that
-// evaluated the gate - see evaluatePlatformGate.
+// Gate is a pointer so a response with no "gate" key (an old platform) is
+// distinguishable from an evaluated gate. GlobalScore is the platform's own
+// displayed score for the run (PushAccepted.global_score: the average of the
+// policies' FINAL points, letter from that average), nil when absent.
 type platformPushResponse struct {
-	Gate *platformGate `json:"gate"`
+	Gate        *platformGate  `json:"gate"`
+	GlobalScore *platformScore `json:"global_score"`
+}
+
+// platformVerdict is what a push produced, for every consumer after the push:
+// the renderer's "Platform verdict" block, the badge and MR comment headline,
+// the JSON top-level score, and finalizeRun's exit code (through the error
+// evaluatePlatformGate returns beside it). Unavailable is the fail-open
+// reason when no usable gate came back (old platform, unparseable body); Gate
+// is nil in that case.
+type platformVerdict struct {
+	Gate        *platformGate
+	GlobalScore *platformScore
+	Unavailable string
 }
 
 // PlatformGateError reports that the platform's post-push gate evaluation
@@ -91,27 +105,33 @@ func platformGatePolicyDescriptions(policies []platformGatePolicy) []string {
 }
 
 // evaluatePlatformGate parses a successful push response's gate block and
-// decides the platform-gate outcome for this run. Every fail-open path
-// prints exactly one line and returns nil - never an error - matching the
-// same "unavailable-class" sentence the transport/non-2xx failures use
+// decides the platform-gate outcome for this run, returning a *platformVerdict
+// alongside the error for every consumer downstream of the push (the
+// renderer's "Platform verdict" block, the badge, the MR comment, the JSON
+// top-level score). Every fail-open path prints exactly one line and returns
+// a non-nil verdict with a nil error - never an error - matching the same
+// "unavailable-class" sentence the transport/non-2xx failures use
 // (platformGateFailOpenLine), so an old platform that has never heard of
 // gates behaves identically to one that is temporarily down:
 //
 //   - a body that does not parse as JSON, or one that parses but carries no
 //     "gate" key at all: an old platform. Fail open with the unavailable
-//     line.
+//     line, the verdict's Gate nil and Unavailable set.
 //   - evaluated:false: the platform's own explicit fail-open (nothing
 //     configured to gate this project, a snapshot not yet collected,
-//     etc). Fail open, logging the platform's own reason.
-//   - blocking:false: nothing to do, the run proceeds.
+//     etc). Fail open, logging the platform's own reason; the verdict still
+//     carries the decoded Gate and GlobalScore, with Unavailable set to the
+//     same reason.
+//   - blocking:false: nothing to do, the run proceeds; the verdict carries
+//     the decoded Gate and GlobalScore, Unavailable empty.
 //   - blocking:true: a *PlatformGateError naming every blocking policy
-//     (gate.policies filtered to Blocking==true) is returned, and the
-//     same detail is printed to stderr here - the job-log line - so it
-//     reaches the operator regardless of what finalizeRun's precedence
-//     ultimately does with the returned error (a local score-gate failure
-//     outranks it and discards it as the *returned* error, but the line
-//     already reached the log).
-func evaluatePlatformGate(body []byte) error {
+//     (gate.policies filtered to Blocking==true) is returned alongside the
+//     same verdict (Gate and GlobalScore decoded), and the same detail is
+//     printed to stderr here - the job-log line - so it reaches the operator
+//     regardless of what finalizeRun's precedence ultimately does with the
+//     returned error (a local score-gate failure outranks it and discards it
+//     as the *returned* error, but the line already reached the log).
+func evaluatePlatformGate(body []byte) (*platformVerdict, error) {
 	var resp platformPushResponse
 	if err := json.Unmarshal(body, &resp); err != nil || resp.Gate == nil {
 		// A 2xx-accepted push whose body carries no usable gate verdict: an
@@ -120,7 +140,7 @@ func evaluatePlatformGate(body []byte) error {
 		// line, never the alertable "unavailable" sentence (see the
 		// constants' doc comment below).
 		scoreWarn(platformGateNoVerdictLine)
-		return nil
+		return &platformVerdict{Unavailable: platformGateNoVerdictLine}, nil
 	}
 	gate := resp.Gate
 
@@ -130,11 +150,11 @@ func evaluatePlatformGate(body []byte) error {
 			msg += ": " + gate.Reason
 		}
 		scoreWarn(msg)
-		return nil
+		return &platformVerdict{Gate: gate, GlobalScore: resp.GlobalScore, Unavailable: msg}, nil
 	}
 
 	if !gate.Blocking {
-		return nil
+		return &platformVerdict{Gate: gate, GlobalScore: resp.GlobalScore}, nil
 	}
 
 	blocking := make([]platformGatePolicy, 0, len(gate.Policies))
@@ -152,7 +172,7 @@ func evaluatePlatformGate(body []byte) error {
 	// placeholder - never a bare "BLOCKED: " with nothing after the colon
 	// (PR-review finding).
 	fmt.Fprintf(os.Stderr, "✗ platform gate BLOCKED: %s\n", platformGateDetail(blocking, gate.Reason))
-	return &PlatformGateError{Reason: gate.Reason, Policies: blocking}
+	return &platformVerdict{Gate: gate, GlobalScore: resp.GlobalScore}, &PlatformGateError{Reason: gate.Reason, Policies: blocking}
 }
 
 // The two EXACT fail-open sentences the spec requires (see

--- a/cmd/platform_gate_test.go
+++ b/cmd/platform_gate_test.go
@@ -456,3 +456,114 @@ func TestFinalizeRun_LocalGateAndPlatformGateBothPresent(t *testing.T) {
 		t.Fatalf("finalizeRun (platform mode) = %v (%T), want the platform *PlatformGateError", platformFinalErr, platformFinalErr)
 	}
 }
+
+// The platform's own score is a number, not an integer: global_score.points
+// comes back as 60.5 and letter can be null. Decoding it into an int made
+// encoding/json return an UnmarshalTypeError for a field the gate does not
+// need, and the whole verdict was thrown away with it - a blocking gate
+// silently became a fail-open, on the one path that is now the ONLY source
+// of a non-zero exit in platform mode (spec s4).
+func TestEvaluatePlatformGate_TolerantGlobalScoreKeepsTheGate(t *testing.T) {
+	body := `{"gate":{"evaluated":true,"blocking":true,"policies":[{"id":"p1","name":"Prod","enforcement":"block","blocking":true,"live_fail_count":2}]},"global_score":{"letter":null,"points":60.5}}`
+
+	var v *platformVerdict
+	var err error
+	_ = captureStderr(t, func() { v, err = evaluatePlatformGate([]byte(body)) })
+
+	var gateErr *PlatformGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("evaluatePlatformGate = %v, want the blocking *PlatformGateError: a field the gate does not read must not discard the verdict", err)
+	}
+	if v == nil || v.Gate == nil || !v.Gate.Blocking {
+		t.Fatalf("the gate must survive a fractional global score: %+v", v)
+	}
+	// math.Round, the same rounding platformScoreFrom applies on the way out:
+	// 60.5 rounds up to 61.
+	if v.GlobalScore == nil || v.GlobalScore.Points != 61 || v.GlobalScore.Letter != "" {
+		t.Fatalf("global_score = %+v, want points 61 (math.Round of 60.5) and no letter", v.GlobalScore)
+	}
+}
+
+// A null global_score beside a gate is a routine state (the platform has no
+// score for this run yet): the gate is the verdict and stays.
+func TestEvaluatePlatformGate_NullGlobalScoreKeepsTheGate(t *testing.T) {
+	body := `{"gate":{"evaluated":true,"blocking":false,"policies":[]},"global_score":null}`
+
+	v, err := evaluatePlatformGate([]byte(body))
+
+	if err != nil {
+		t.Fatalf("a non-blocking gate must not error: %v", err)
+	}
+	if v == nil || v.Gate == nil || v.Gate.Evaluated != true {
+		t.Fatalf("the gate must survive a null global score: %+v", v)
+	}
+	if v.GlobalScore != nil {
+		t.Fatalf("global_score = %+v, want nil: null is not a score", v.GlobalScore)
+	}
+}
+
+// A body that parsed but carries no gate (an older platform) still carries
+// whatever else it did send. The score is what the badge, the merge-request
+// comment and the JSON top level publish, and throwing it away made them say
+// "score unavailable" for a platform that had just sent one.
+func TestEvaluatePlatformGate_NoGateStillCarriesTheGlobalScore(t *testing.T) {
+	body := `{"global_score":{"letter":"C","points":66}}`
+
+	var v *platformVerdict
+	var err error
+	out := captureStderr(t, func() { v, err = evaluatePlatformGate([]byte(body)) })
+
+	if err != nil {
+		t.Fatalf("no gate must fail open: %v", err)
+	}
+	if v == nil || v.Gate != nil {
+		t.Fatalf("Gate must be nil when the body carries none: %+v", v)
+	}
+	if v.Unavailable != platformGateNoVerdictLine {
+		t.Fatalf("Unavailable = %q, want the no-verdict line", v.Unavailable)
+	}
+	if v.GlobalScore == nil || v.GlobalScore.Letter != "C" || v.GlobalScore.Points != 66 {
+		t.Fatalf("global_score = %+v, want the decoded C/66", v.GlobalScore)
+	}
+	if !strings.Contains(out, platformGateNoVerdictLine) {
+		t.Errorf("stderr = %q, want the no-verdict line", out)
+	}
+}
+
+// A body that does not parse at all carries nothing: no gate, no score, and
+// no invented one.
+func TestEvaluatePlatformGate_UnparseableBodyCarriesNoScore(t *testing.T) {
+	var v *platformVerdict
+	var err error
+	_ = captureStderr(t, func() { v, err = evaluatePlatformGate([]byte("not json")) })
+
+	if err != nil {
+		t.Fatalf("an unparseable body must fail open: %v", err)
+	}
+	if v == nil || v.Gate != nil || v.GlobalScore != nil || v.Unavailable == "" {
+		t.Fatalf("want Gate nil, GlobalScore nil and a reason, got %+v", v)
+	}
+}
+
+// The belt-and-braces half of the same finding: whatever future field shape
+// makes encoding/json return an error, a gate that DID decode beside it is
+// still the platform's verdict, and the partial decode is reported rather
+// than swallowed.
+func TestEvaluatePlatformGate_PartialDecodeKeepsADecodedGate(t *testing.T) {
+	body := `{"gate":{"evaluated":true,"blocking":true,"reason":"live failures","policies":[]},"global_score":"not-an-object"}`
+
+	var v *platformVerdict
+	var err error
+	out := captureStderr(t, func() { v, err = evaluatePlatformGate([]byte(body)) })
+
+	var gateErr *PlatformGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("evaluatePlatformGate = %v, want the blocking *PlatformGateError", err)
+	}
+	if v == nil || v.Gate == nil || !v.Gate.Blocking {
+		t.Fatalf("a decoded gate must survive an undecodable sibling field: %+v", v)
+	}
+	if !strings.Contains(out, "partially decoded") {
+		t.Errorf("stderr = %q, want the partial-decode line: a body this CLI could only half read is worth saying out loud", out)
+	}
+}

--- a/cmd/platform_gate_test.go
+++ b/cmd/platform_gate_test.go
@@ -545,12 +545,45 @@ func TestEvaluatePlatformGate_UnparseableBodyCarriesNoScore(t *testing.T) {
 	}
 }
 
-// The belt-and-braces half of the same finding: whatever future field shape
-// makes encoding/json return an error, a gate that DID decode beside it is
-// still the platform's verdict, and the partial decode is reported rather
-// than swallowed.
-func TestEvaluatePlatformGate_PartialDecodeKeepsADecodedGate(t *testing.T) {
-	body := `{"gate":{"evaluated":true,"blocking":true,"reason":"live failures","policies":[]},"global_score":"not-an-object"}`
+// A gate whose OWN fields did not decode is not a verdict, and must never be
+// read as a passing one. encoding/json leaves a mistyped field at its zero
+// value and keeps going, so "blocking":"true" produced a fully-formed gate
+// with Blocking false: a blocking verdict silently became exit 0. The gate is
+// decoded strictly - any error drops it - and the run fails open honestly
+// instead (invariant 5: a let-through that says so, never a fake verdict).
+func TestEvaluatePlatformGate_MalformedGateIsDroppedNotReadAsPassing(t *testing.T) {
+	body := `{"gate":{"evaluated":true,"blocking":"true","policies":[{"id":"p1","name":"Prod","enforcement":"block","blocking":true,"live_fail_count":2}]},"global_score":{"letter":"C","points":66}}`
+
+	var v *platformVerdict
+	var err error
+	out := captureStderr(t, func() { v, err = evaluatePlatformGate([]byte(body)) })
+
+	if err != nil {
+		t.Fatalf("evaluatePlatformGate = %v, want nil: an undecodable gate fails open", err)
+	}
+	if v == nil || v.Gate != nil {
+		t.Fatalf("Gate = %+v, want nil: a half-decoded gate must never be carried", v)
+	}
+	if !platformGatePassed(v) {
+		t.Fatal("a dropped gate is a let-through, not a block")
+	}
+	if v.Unavailable == "" || !strings.Contains(v.Unavailable, "did not decode") {
+		t.Fatalf("Unavailable = %q, want it to say the gate did not decode", v.Unavailable)
+	}
+	if !strings.Contains(out, platformGateNoVerdictLine) || !strings.Contains(out, "did not decode") {
+		t.Errorf("stderr = %q, want the no-verdict line naming the gate decode failure", out)
+	}
+	// The score is a separate field and still decoded fine.
+	if v.GlobalScore == nil || v.GlobalScore.Letter != "C" {
+		t.Errorf("global_score = %+v, want the decoded C/66: only the gate was malformed", v.GlobalScore)
+	}
+}
+
+// The mirror image: a well-formed gate beside a global score that cannot be
+// read. Tolerance applies to the score ONLY, and it means dropping the score,
+// never inventing one: the verdict is the platform's and is returned intact.
+func TestEvaluatePlatformGate_UndecodableGlobalScoreDropsOnlyTheScore(t *testing.T) {
+	body := `{"gate":{"evaluated":true,"blocking":true,"reason":"live failures","policies":[{"id":"p1","name":"Prod","enforcement":"block","blocking":true,"live_fail_count":2}]},"global_score":{"letter":"C","points":"sixty"}}`
 
 	var v *platformVerdict
 	var err error
@@ -558,12 +591,32 @@ func TestEvaluatePlatformGate_PartialDecodeKeepsADecodedGate(t *testing.T) {
 
 	var gateErr *PlatformGateError
 	if !errors.As(err, &gateErr) {
-		t.Fatalf("evaluatePlatformGate = %v, want the blocking *PlatformGateError", err)
+		t.Fatalf("evaluatePlatformGate = %v, want the blocking *PlatformGateError: the gate is well-formed", err)
 	}
 	if v == nil || v.Gate == nil || !v.Gate.Blocking {
-		t.Fatalf("a decoded gate must survive an undecodable sibling field: %+v", v)
+		t.Fatalf("the gate must survive an unreadable global score: %+v", v)
 	}
-	if !strings.Contains(out, "partially decoded") {
-		t.Errorf("stderr = %q, want the partial-decode line: a body this CLI could only half read is worth saying out loud", out)
+	if v.GlobalScore != nil {
+		t.Fatalf("global_score = %+v, want nil: points that are not a number are not a score, and 0 would be a lie", v.GlobalScore)
+	}
+	if !strings.Contains(out, "global score could not be decoded") {
+		t.Errorf("stderr = %q, want the dropped-score line", out)
+	}
+}
+
+// A non-object gate (a shape this CLI predates entirely) is the same case as
+// a mistyped field: no verdict, fail open, and the score beside it survives.
+func TestEvaluatePlatformGate_NonObjectGateFailsOpen(t *testing.T) {
+	var v *platformVerdict
+	var err error
+	_ = captureStderr(t, func() {
+		v, err = evaluatePlatformGate([]byte(`{"gate":"blocked","global_score":{"letter":"A","points":100}}`))
+	})
+
+	if err != nil || v == nil || v.Gate != nil {
+		t.Fatalf("want a fail-open verdict with no gate, got %+v err %v", v, err)
+	}
+	if v.GlobalScore == nil || v.GlobalScore.Points != 100 {
+		t.Fatalf("global_score = %+v, want the decoded A/100", v.GlobalScore)
 	}
 }

--- a/cmd/platform_gate_test.go
+++ b/cmd/platform_gate_test.go
@@ -46,7 +46,7 @@ func TestMaybePushPlatform_GateBlockingFailsWithPolicyDetail(t *testing.T) {
 
 	var err error
 	out := captureStderr(t, func() {
-		err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
 	})
 
 	var gateErr *PlatformGateError
@@ -82,7 +82,7 @@ func TestMaybePushPlatform_GateBlockingWithoutPolicyDetailStillNamesTheReason(t 
 
 	var err error
 	out := captureStderr(t, func() {
-		err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
 	})
 
 	var gateErr *PlatformGateError
@@ -138,7 +138,7 @@ func TestMaybePushPlatform_GateBlockingWithoutAnyDetailStaysHonest(t *testing.T)
 
 	var err error
 	out := captureStderr(t, func() {
-		err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
 	})
 	var gateErr *PlatformGateError
 	if !errors.As(err, &gateErr) {
@@ -156,7 +156,7 @@ func TestMaybePushPlatform_GatePassingDoesNotFail(t *testing.T) {
 	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
 	defer restore()
 
-	if err := maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil); err != nil {
 		t.Fatalf("maybePushPlatform = %v, want nil: a non-blocking gate must not fail the run", err)
 	}
 }
@@ -172,7 +172,7 @@ func TestMaybePushPlatform_GateNotEvaluatedFailsOpenWithReason(t *testing.T) {
 
 	var err error
 	out := captureStderr(t, func() {
-		err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
 	})
 	if err != nil {
 		t.Fatalf("maybePushPlatform = %v, want nil: evaluated:false must fail open", err)
@@ -196,7 +196,7 @@ func TestMaybePushPlatform_MissingGateKeyFailsOpenAsNoVerdict(t *testing.T) {
 
 	var err error
 	out := captureStderr(t, func() {
-		err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
 	})
 	if err != nil {
 		t.Fatalf("maybePushPlatform = %v, want nil: a missing gate key must fail open", err)
@@ -219,7 +219,7 @@ func TestMaybePushPlatform_UnparseableBodyFailsOpenAsNoVerdict(t *testing.T) {
 
 	var err error
 	out := captureStderr(t, func() {
-		err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
 	})
 	if err != nil {
 		t.Fatalf("maybePushPlatform = %v, want nil: an unparseable body must fail open", err)
@@ -260,7 +260,7 @@ func TestMaybePushPlatform_ClassDistinguishedFailOpenSentences(t *testing.T) {
 
 			var err error
 			out := captureStderr(t, func() {
-				err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+				_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
 			})
 			if err != nil {
 				t.Fatalf("maybePushPlatform = %v, want nil: a remote push failure must never fail the run", err)
@@ -281,7 +281,7 @@ func TestMaybePushPlatform_ClassDistinguishedFailOpenSentences(t *testing.T) {
 
 		var err error
 		out := captureStderr(t, func() {
-			err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+			_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
 		})
 		if err != nil {
 			t.Fatalf("maybePushPlatform = %v, want nil: a transport failure must never fail the run", err)
@@ -321,7 +321,7 @@ func TestMaybePushPlatform_ClassDistinguishedFailOpenSentences(t *testing.T) {
 
 		var err error
 		out := captureStderr(t, func() {
-			err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+			_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
 		})
 		if err != nil {
 			t.Fatalf("maybePushPlatform = %v, want nil: a 2xx body-read failure must never fail the run", err)
@@ -347,12 +347,50 @@ func TestMaybePushPlatform_SuccessLineUnchangedOnPassingGate(t *testing.T) {
 	defer restore()
 
 	out := captureStderr(t, func() {
-		if err := maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil); err != nil {
+		if _, err := maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil); err != nil {
 			t.Fatalf("maybePushPlatform: %v", err)
 		}
 	})
 	if !strings.Contains(out, "✓ Results pushed to the platform:") {
 		t.Errorf("stderr = %q, want the unchanged push-success line", out)
+	}
+}
+
+// The push response carries the platform's global score beside the gate; the
+// renderer, the badge and the JSON top level read it, so it must be decoded
+// with the gate, and an absent key must stay nil (an older platform), never 0.
+func TestEvaluatePlatformGate_ReturnsVerdictWithGlobalScore(t *testing.T) {
+	body := `{"gate":{"evaluated":true,"blocking":false,"policies":[{"id":"p1","name":"Baseline","enforcement":"report","blocking":false,"live_fail_count":2}]},"global_score":{"letter":"B","points":83}}`
+	v, err := evaluatePlatformGate([]byte(body))
+	if err != nil {
+		t.Fatalf("non-blocking verdict must not error: %v", err)
+	}
+	if v == nil || v.Gate == nil || v.Gate.Evaluated != true || len(v.Gate.Policies) != 1 {
+		t.Fatalf("gate not decoded: %+v", v)
+	}
+	if v.GlobalScore == nil || v.GlobalScore.Letter != "B" || v.GlobalScore.Points != 83 {
+		t.Fatalf("global_score: want B/83, got %+v", v.GlobalScore)
+	}
+
+	noScore := `{"gate":{"evaluated":true,"blocking":false,"policies":[]}}`
+	v2, err := evaluatePlatformGate([]byte(noScore))
+	if err != nil || v2.GlobalScore != nil {
+		t.Fatalf("absent global_score must decode nil, got %+v err %v", v2.GlobalScore, err)
+	}
+
+	blocking := `{"gate":{"evaluated":true,"blocking":true,"policies":[{"id":"p2","name":"Prod","enforcement":"block","blocking":true,"live_fail_count":1}]},"global_score":{"letter":"C","points":60}}`
+	v3, err := evaluatePlatformGate([]byte(blocking))
+	var gateErr *PlatformGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("blocking verdict must return *PlatformGateError, got %v", err)
+	}
+	if v3 == nil || v3.GlobalScore == nil || v3.GlobalScore.Letter != "C" {
+		t.Fatalf("a blocking verdict still carries the decoded response: %+v", v3)
+	}
+
+	v4, err := evaluatePlatformGate([]byte("not json"))
+	if err != nil || v4 == nil || v4.Gate != nil || v4.Unavailable == "" {
+		t.Fatalf("unparseable body: want a verdict with Gate nil and an Unavailable reason, got %+v err %v", v4, err)
 	}
 }
 
@@ -386,7 +424,7 @@ func TestFinalizeRun_LocalGateAndPlatformGateBothPresent(t *testing.T) {
 
 	var platformErr error
 	out := captureStderr(t, func() {
-		platformErr = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		_, platformErr = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
 	})
 	var gotGateErr *PlatformGateError
 	if !errors.As(platformErr, &gotGateErr) {

--- a/cmd/platform_gate_test.go
+++ b/cmd/platform_gate_test.go
@@ -445,4 +445,14 @@ func TestFinalizeRun_LocalGateAndPlatformGateBothPresent(t *testing.T) {
 	// Both messages are present: the local gate's message via the returned
 	// error (the primary exit reason), and the platform gate's job-log line
 	// already on stderr from the maybePushPlatform call above.
+
+	// Spec s4: in platform mode the local gate is inert, so the platform gate
+	// error is what comes back instead of the local ScoreGateError above.
+	platformModeGate := failingGate
+	platformModeGate.platformMode = true
+	platformFinalErr := finalizeRun(result, platformModeGate, platformErr)
+	var gotPlatformGateErr *PlatformGateError
+	if !errors.As(platformFinalErr, &gotPlatformGateErr) {
+		t.Fatalf("finalizeRun (platform mode) = %v (%T), want the platform *PlatformGateError", platformFinalErr, platformFinalErr)
+	}
 }

--- a/cmd/platform_gate_test.go
+++ b/cmd/platform_gate_test.go
@@ -46,7 +46,7 @@ func TestMaybePushPlatform_GateBlockingFailsWithPolicyDetail(t *testing.T) {
 
 	var err error
 	out := captureStderr(t, func() {
-		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil, nil)
 	})
 
 	var gateErr *PlatformGateError
@@ -82,7 +82,7 @@ func TestMaybePushPlatform_GateBlockingWithoutPolicyDetailStillNamesTheReason(t 
 
 	var err error
 	out := captureStderr(t, func() {
-		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil, nil)
 	})
 
 	var gateErr *PlatformGateError
@@ -138,7 +138,7 @@ func TestMaybePushPlatform_GateBlockingWithoutAnyDetailStaysHonest(t *testing.T)
 
 	var err error
 	out := captureStderr(t, func() {
-		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil, nil)
 	})
 	var gateErr *PlatformGateError
 	if !errors.As(err, &gateErr) {
@@ -156,7 +156,7 @@ func TestMaybePushPlatform_GatePassingDoesNotFail(t *testing.T) {
 	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
 	defer restore()
 
-	if _, err := maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil, nil); err != nil {
 		t.Fatalf("maybePushPlatform = %v, want nil: a non-blocking gate must not fail the run", err)
 	}
 }
@@ -172,7 +172,7 @@ func TestMaybePushPlatform_GateNotEvaluatedFailsOpenWithReason(t *testing.T) {
 
 	var err error
 	out := captureStderr(t, func() {
-		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil, nil)
 	})
 	if err != nil {
 		t.Fatalf("maybePushPlatform = %v, want nil: evaluated:false must fail open", err)
@@ -196,7 +196,7 @@ func TestMaybePushPlatform_MissingGateKeyFailsOpenAsNoVerdict(t *testing.T) {
 
 	var err error
 	out := captureStderr(t, func() {
-		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil, nil)
 	})
 	if err != nil {
 		t.Fatalf("maybePushPlatform = %v, want nil: a missing gate key must fail open", err)
@@ -219,7 +219,7 @@ func TestMaybePushPlatform_UnparseableBodyFailsOpenAsNoVerdict(t *testing.T) {
 
 	var err error
 	out := captureStderr(t, func() {
-		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil, nil)
 	})
 	if err != nil {
 		t.Fatalf("maybePushPlatform = %v, want nil: an unparseable body must fail open", err)
@@ -260,7 +260,7 @@ func TestMaybePushPlatform_ClassDistinguishedFailOpenSentences(t *testing.T) {
 
 			var err error
 			out := captureStderr(t, func() {
-				_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+				_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil, nil)
 			})
 			if err != nil {
 				t.Fatalf("maybePushPlatform = %v, want nil: a remote push failure must never fail the run", err)
@@ -281,7 +281,7 @@ func TestMaybePushPlatform_ClassDistinguishedFailOpenSentences(t *testing.T) {
 
 		var err error
 		out := captureStderr(t, func() {
-			_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+			_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil, nil)
 		})
 		if err != nil {
 			t.Fatalf("maybePushPlatform = %v, want nil: a transport failure must never fail the run", err)
@@ -321,7 +321,7 @@ func TestMaybePushPlatform_ClassDistinguishedFailOpenSentences(t *testing.T) {
 
 		var err error
 		out := captureStderr(t, func() {
-			_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+			_, err = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil, nil)
 		})
 		if err != nil {
 			t.Fatalf("maybePushPlatform = %v, want nil: a 2xx body-read failure must never fail the run", err)
@@ -347,7 +347,7 @@ func TestMaybePushPlatform_SuccessLineUnchangedOnPassingGate(t *testing.T) {
 	defer restore()
 
 	out := captureStderr(t, func() {
-		if _, err := maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil); err != nil {
+		if _, err := maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil, nil); err != nil {
 			t.Fatalf("maybePushPlatform: %v", err)
 		}
 	})
@@ -424,7 +424,7 @@ func TestFinalizeRun_LocalGateAndPlatformGateBothPresent(t *testing.T) {
 
 	var platformErr error
 	out := captureStderr(t, func() {
-		_, platformErr = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil)
+		_, platformErr = maybePushPlatform(testProvider(t), gateConf(t), &control.AnalysisResult{}, nil, nil)
 	})
 	var gotGateErr *PlatformGateError
 	if !errors.As(platformErr, &gotGateErr) {

--- a/cmd/platform_mode.go
+++ b/cmd/platform_mode.go
@@ -11,6 +11,28 @@ import (
 	providerPkg "github.com/getplumber/plumber/provider"
 )
 
+// platformPolicyMode reports whether this run's verdict comes from the
+// platform's policies rather than from a local configuration. It is
+// continueRun's own routing condition, stated once: --platform configured AND
+// --no-controls not asked for.
+//
+// The --no-controls half matters. That run evaluates nothing under any mode
+// and takes the standalone branch, so its output must keep saying which local
+// configuration was loaded; only a run that actually goes down the platform
+// branch may claim the platform's policies produced it.
+//
+// It exists for the surfaces that render BEFORE the mode is engaged (the run
+// header, the config loader's zero-config notice), which have no policy runs
+// to inspect and would otherwise describe a configuration the verdict never
+// used.
+func platformPolicyMode(noControlsRun bool) bool {
+	if noControlsRun {
+		return false
+	}
+	push, _ := effectivePlatformPush()
+	return push
+}
+
 // setupPlatformMode resolves everything platform mode needs BEFORE
 // collection begins, and returns the run context to hang on conf. It
 // returns nil when --platform is not set, which is the CLI's default and

--- a/cmd/platform_mode.go
+++ b/cmd/platform_mode.go
@@ -204,6 +204,13 @@ func reportPlatformMode(rc *platform.RunContext) {
 // left on screen is an ordinary-looking verdict produced WITHOUT the
 // project's policies — the one outcome someone must not walk away with by
 // accident. Repeating it last costs a line and removes that failure mode.
+//
+// It is a backstop rather than the primary notice now: a platform-mode run
+// whose context never arrived resolves no policy, and runPlatformMode reports
+// that run through renderNothingEvaluated - its whole report, one line - and
+// returns before this publish tail. The line stays because any future path
+// that DOES reach the tail without an engaged context must not do so
+// silently.
 func reportPlatformOutcome(rc *platform.RunContext) {
 	if !rc.Active() || rc.Engaged() {
 		return
@@ -214,6 +221,6 @@ func reportPlatformOutcome(rc *platform.RunContext) {
 	}
 	fmt.Fprintf(os.Stderr,
 		"⚠️  platform mode did NOT engage (%s).\n"+
-			"    This run used local collection and the local config only: none of the project's platform policies were applied.\n",
+			"    This run evaluated nothing: none of the project's platform policies could be resolved.\n",
 		reason)
 }

--- a/cmd/platform_mode_test.go
+++ b/cmd/platform_mode_test.go
@@ -271,10 +271,10 @@ func TestPlatformAnalyzedSha(t *testing.T) {
 	})
 }
 
-// TestReportPlatformOutcome covers the end-of-run line. A full report is over
-// a hundred lines, so the pre-collection warning scrolls off screen and what
-// remains is an ordinary-looking verdict produced without the project's
-// policies. Repeating it last is what stops someone acting on that.
+// TestReportPlatformOutcome covers the end-of-run line. It is the backstop
+// for a run that reaches the publish tail with no context: it must name the
+// cause and say what the run therefore evaluated - nothing - rather than
+// letting a reader assume a local fallback produced the report above it.
 func TestReportPlatformOutcome(t *testing.T) {
 	t.Run("standalone prints nothing", func(t *testing.T) {
 		if out := captureStderr(t, func() { reportPlatformOutcome(nil) }); strings.TrimSpace(out) != "" {
@@ -295,7 +295,7 @@ func TestReportPlatformOutcome(t *testing.T) {
 		for _, want := range []string{
 			"did NOT engage",             // that it happened
 			"not the attributed project", // the underlying cause, verbatim
-			"policies were applied",      // what it cost the run
+			"evaluated nothing",          // what it cost the run
 		} {
 			if !strings.Contains(out, want) {
 				t.Fatalf("output missing %q:\n%s", want, out)

--- a/cmd/platform_notices.go
+++ b/cmd/platform_notices.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/getplumber/plumber/configuration"
+)
+
+// platformModeNotices prints, once, what platform mode makes inert (spec s1):
+// a local configuration file that was read, and every local threshold that
+// was supplied. Returns the lines for tests. Silent outside platform mode and
+// on a default component run (no file, no threshold set).
+func platformModeNotices(conf *configuration.Configuration) []string {
+	on, endpoint := effectivePlatformPush()
+	if !on {
+		return nil
+	}
+	var lines []string
+	if conf != nil && localConfigFileWasRead(conf) {
+		lines = append(lines, fmt.Sprintf("  linked to %s: local %s ignored, policies come from the platform", endpoint, conf.ConfigFilePath))
+	}
+	for _, f := range []struct {
+		name string
+		set  bool
+	}{
+		{"--min-points", minPointsSet},
+		{"--min-score", minScore != ""},
+		{"--threshold", thresholdSet},
+	} {
+		if f.set {
+			lines = append(lines, fmt.Sprintf("  %s ignored: enforcement comes from the platform's policies", f.name))
+		}
+	}
+	for _, l := range lines {
+		fmt.Fprintln(os.Stderr, l)
+	}
+	return lines
+}
+
+// localConfigFileWasRead reports whether conf's PlumberConfig came from a file
+// on disk rather than the embedded default. ConfigFilePath is the field
+// configuration.Configuration carries for this (see its doc comment);
+// builtinDefaultConfigSource is the existing sentinel a zero-config run
+// stamps there instead of a real path (cmd/platform_push.go's
+// platformPolicyNameFor treats it the same way).
+func localConfigFileWasRead(conf *configuration.Configuration) bool {
+	path := strings.TrimSpace(conf.ConfigFilePath)
+	return path != "" && path != builtinDefaultConfigSource
+}

--- a/cmd/platform_notices_test.go
+++ b/cmd/platform_notices_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+)
+
+// Spec s1: a present local config and any local threshold are ignored in
+// platform mode, each with one line; nothing is printed when none is set.
+func TestPlatformModeNotices(t *testing.T) {
+	newGateFlagsCmd(t)
+	origURL := platformURL
+	platformURL = "https://platform.example.com"
+	defer func() { platformURL = origURL }()
+
+	conf := configuration.NewDefaultConfiguration()
+	conf.ConfigFilePath = ""
+	if lines := platformModeNotices(conf); len(lines) != 0 {
+		t.Fatalf("nothing set: want no notice, got %v", lines)
+	}
+
+	conf.ConfigFilePath = ".plumber.yaml"
+	minPointsSet, minScore, thresholdSet = true, "B", false
+	lines := platformModeNotices(conf)
+	want := []string{
+		"  linked to https://platform.example.com: local .plumber.yaml ignored, policies come from the platform",
+		"  --min-points ignored: enforcement comes from the platform's policies",
+		"  --min-score ignored: enforcement comes from the platform's policies",
+	}
+	if strings.Join(lines, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("got\n%s\nwant\n%s", strings.Join(lines, "\n"), strings.Join(want, "\n"))
+	}
+
+	platformURL = platformSentinelURL
+	if lines := platformModeNotices(conf); len(lines) != 0 {
+		t.Fatalf("sentinel URL is not platform mode: got %v", lines)
+	}
+}

--- a/cmd/platform_outputs.go
+++ b/cmd/platform_outputs.go
@@ -4,9 +4,11 @@ import (
 	"math"
 	"strconv"
 
+	"github.com/getplumber/plumber/configuration"
 	"github.com/getplumber/plumber/control"
 	opaengine "github.com/getplumber/plumber/internal/engine/opa"
 	"github.com/getplumber/plumber/pbom"
+	providerPkg "github.com/getplumber/plumber/provider"
 )
 
 // This file turns the evaluated policy runs and the platform's verdict into
@@ -121,6 +123,83 @@ func platformPBOMSummary(runs []policyRun, v *platformVerdict) *pbom.PlatformSum
 	return out
 }
 
+// outputControlEntries returns the control entries the per-control artifacts
+// (CSV, OCSF) describe, and, in platform mode, the policies each control was
+// evaluated under.
+//
+// Outside platform mode this is the run's own catalog, unchanged. In platform
+// mode the local catalog is never consulted: the entries are the union of the
+// APPLIED runs' own catalogs, keeping only the controls a policy actually
+// enables, in /context order. A control no policy declares is absent rather
+// than listed as skipped, because "skipped" is a statement about this run's
+// configuration and there is no such configuration here.
+func outputControlEntries(p providerPkg.Provider, conf *configuration.Configuration, runs []policyRun) ([]control.ControlEntry, map[string][]string) {
+	if len(runs) == 0 {
+		return providerControlEntries(p, conf), nil
+	}
+	var entries []control.ControlEntry
+	seen := map[string]bool{}
+	policies := map[string][]string{}
+	for _, run := range runs {
+		if !run.Applied || run.Config == nil {
+			continue
+		}
+		names := policyNames(run)
+		for _, e := range p.Controls(run.Config) {
+			if e.Skipped {
+				continue
+			}
+			if !seen[e.ControlName] {
+				seen[e.ControlName] = true
+				entries = append(entries, e)
+			}
+			policies[e.ControlName] = appendMissing(policies[e.ControlName], names)
+		}
+	}
+	return entries, policies
+}
+
+// imageComplianceControls are the controls whose findings drive the PBOM's
+// per-image booleans (forbiddenTag / authorized). They are derived from the
+// codes BuildImageComplianceData consumes, through the codes registry, so a
+// code moving to another control cannot leave this list stale.
+func imageComplianceControls() map[string]bool {
+	out := map[string]bool{}
+	for _, code := range []control.ErrorCode{
+		control.CodeImageForbiddenTag,
+		control.CodeImageNotPinnedByDigest,
+		control.CodeImageUnauthorizedSource,
+	} {
+		if info := control.LookupCode(code); info != nil && info.ControlName != "" {
+			out[info.ControlName] = true
+		}
+	}
+	return out
+}
+
+// platformImageControlsEvaluated reports whether any applied policy actually
+// enables the image controls.
+//
+// The PBOM's per-image booleans are a POSITIVE claim: an image absent from
+// every finding is published as authorized with no forbidden tag. That is only
+// true of an image a control judged, so in platform mode it may be said only
+// when a policy asked for those controls; otherwise the writers omit the
+// booleans and the image is reported as inventory alone.
+func platformImageControlsEvaluated(p providerPkg.Provider, runs []policyRun) bool {
+	wanted := imageComplianceControls()
+	for _, run := range runs {
+		if !run.Applied || run.Config == nil {
+			continue
+		}
+		for _, e := range p.Controls(run.Config) {
+			if !e.Skipped && wanted[e.ControlName] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // platformUnionResult returns the result the security-report writers (SARIF,
 // the GitLab SAST report) render in platform mode: the same run, with its
 // findings replaced by the union of every APPLIED policy run's findings,
@@ -142,12 +221,25 @@ func platformUnionResult(result *control.AnalysisResult, runs []policyRun) *cont
 	}
 	union := *result
 	union.Findings = nil
+	// The collected result's not-evaluable marks are the LOCAL evaluation's,
+	// and the CSV and OCSF feeds turn them into a per-control status. Replace
+	// them with the runs' own marks (any run's mark wins, so a control one
+	// policy could not evaluate is never reported as a clean pass).
+	union.NotEvaluable = nil
 	index := map[string]int{}
 	for _, run := range runs {
 		if !run.Applied || run.Result == nil {
 			continue
 		}
 		names := policyNames(run)
+		for controlName, reason := range run.Result.NotEvaluable {
+			if union.NotEvaluable == nil {
+				union.NotEvaluable = map[string]string{}
+			}
+			if _, seen := union.NotEvaluable[controlName]; !seen {
+				union.NotEvaluable[controlName] = reason
+			}
+		}
 		for _, f := range run.Result.Findings {
 			key := unionFindingKey(f)
 			if at, seen := index[key]; seen {
@@ -165,12 +257,20 @@ func platformUnionResult(result *control.AnalysisResult, runs []policyRun) *cont
 
 // unionFindingKey is the identity two policy runs are deduplicated on: the
 // stamped fingerprint, which is exactly what every consumer of these reports
-// tracks a finding by. Findings that were never stamped (codeless ones, or an
-// unstamped caller) fall back to their canonical fields rather than collapsing
-// into one entry under the empty string.
+// tracks a finding by, PLUS the line.
+//
+// The line is what makes this a report identity rather than the fingerprint's:
+// the fingerprint is deliberately line-independent (that is what makes a
+// dismissal survive an edit above the finding), so two occurrences of the same
+// subject on two different lines share it. They are two alerts, and collapsing
+// them would silently drop one from the security report.
+//
+// Findings that were never stamped (codeless ones, or an unstamped caller)
+// fall back to their canonical fields rather than collapsing into one entry
+// under the empty string.
 func unionFindingKey(f opaengine.Finding) string {
 	if f.Fingerprint != "" {
-		return "fp:" + f.Fingerprint
+		return "fp:" + f.Fingerprint + "|" + strconv.Itoa(f.Line)
 	}
 	return "raw:" + f.Code + "|" + f.File + "|" + strconv.Itoa(f.Line) + "|" + f.Job + "|" + f.Message
 }

--- a/cmd/platform_outputs.go
+++ b/cmd/platform_outputs.go
@@ -159,17 +159,12 @@ func outputControlEntries(p providerPkg.Provider, conf *configuration.Configurat
 	return entries, policies
 }
 
-// imageComplianceControls are the controls whose findings drive the PBOM's
-// per-image booleans (forbiddenTag / authorized). They are derived from the
-// codes BuildImageComplianceData consumes, through the codes registry, so a
-// code moving to another control cannot leave this list stale.
-func imageComplianceControls() map[string]bool {
+// controlsBehindCodes are the controls the given codes belong to, read from
+// the codes registry so a code moving to another control cannot leave a list
+// here stale.
+func controlsBehindCodes(codes ...control.ErrorCode) map[string]bool {
 	out := map[string]bool{}
-	for _, code := range []control.ErrorCode{
-		control.CodeImageForbiddenTag,
-		control.CodeImageNotPinnedByDigest,
-		control.CodeImageUnauthorizedSource,
-	} {
+	for _, code := range codes {
 		if info := control.LookupCode(code); info != nil && info.ControlName != "" {
 			out[info.ControlName] = true
 		}
@@ -177,27 +172,50 @@ func imageComplianceControls() map[string]bool {
 	return out
 }
 
-// platformImageControlsEvaluated reports whether any applied policy actually
-// enables the image controls.
+// forbiddenTagControls and authorizedSourceControls are the controls behind
+// each of the PBOM's two per-image booleans, split by the codes
+// BuildImageComplianceData feeds into each one. Two sets, because the two
+// booleans are two separate claims.
+func forbiddenTagControls() map[string]bool {
+	return controlsBehindCodes(control.CodeImageForbiddenTag, control.CodeImageNotPinnedByDigest)
+}
+
+func authorizedSourceControls() map[string]bool {
+	return controlsBehindCodes(control.CodeImageUnauthorizedSource)
+}
+
+// platformImageControlsEvaluated reports, for EACH of the PBOM's per-image
+// booleans, whether any applied policy actually enables the control behind it.
 //
-// The PBOM's per-image booleans are a POSITIVE claim: an image absent from
-// every finding is published as authorized with no forbidden tag. That is only
-// true of an image a control judged, so in platform mode it may be said only
-// when a policy asked for those controls; otherwise the writers omit the
-// booleans and the image is reported as inventory alone.
-func platformImageControlsEvaluated(p providerPkg.Provider, runs []policyRun) bool {
-	wanted := imageComplianceControls()
+// The booleans are a POSITIVE claim: an image absent from every finding is
+// published as authorized with no forbidden tag. That is only true of an image
+// a control judged, so in platform mode each may be said only when a policy
+// asked for THAT control; otherwise the writers omit that boolean and the
+// image is reported as inventory alone on that axis.
+//
+// One answer per control, never one for the pair: enforcing tag pinning
+// without a registry allowlist is a routine policy, and a single flag
+// published the other control's verdict for every image on the strength of
+// the first having run.
+func platformImageControlsEvaluated(p providerPkg.Provider, runs []policyRun) (forbiddenTag, authorizedSource bool) {
+	tagControls, sourceControls := forbiddenTagControls(), authorizedSourceControls()
 	for _, run := range runs {
 		if !run.Applied || run.Config == nil {
 			continue
 		}
 		for _, e := range p.Controls(run.Config) {
-			if !e.Skipped && wanted[e.ControlName] {
-				return true
+			if e.Skipped {
+				continue
+			}
+			if tagControls[e.ControlName] {
+				forbiddenTag = true
+			}
+			if sourceControls[e.ControlName] {
+				authorizedSource = true
 			}
 		}
 	}
-	return false
+	return forbiddenTag, authorizedSource
 }
 
 // platformUnionResult returns the result the security-report writers (SARIF,

--- a/cmd/platform_outputs.go
+++ b/cmd/platform_outputs.go
@@ -1,0 +1,193 @@
+package cmd
+
+import (
+	"math"
+	"strconv"
+
+	"github.com/getplumber/plumber/control"
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
+	"github.com/getplumber/plumber/pbom"
+)
+
+// This file turns the evaluated policy runs and the platform's verdict into
+// what each artifact writer needs (spec s5). Every one of them reads the SAME
+// runs the sections printed and the push reported, so the terminal, the
+// files, the badge and the comment cannot disagree about what a policy found.
+//
+// None of them ever falls back to a locally computed score: where the
+// platform returned nothing, the artifact says so and carries nothing.
+
+// policyNames lists a run's policy names in /context order.
+func policyNames(run policyRun) []string {
+	names := make([]string, 0, len(run.Policies))
+	for _, p := range run.Policies {
+		names = append(names, p.Name)
+	}
+	return names
+}
+
+// finalPointsOf rounds a run's final points the same way the push does
+// (platformScoreFrom), so the badge, the comment and the record agree to the
+// point. ok is false for a run that evaluated nothing.
+func finalPointsOf(run policyRun) (points int, ok bool) {
+	if !run.Applied || run.Score == nil {
+		return 0, false
+	}
+	return int(math.Round(run.Score.FinalPoints)), true
+}
+
+// platformPostSummary builds the badge and merge-request comment's view of
+// the run: the platform's global score and one line per resolved policy, with
+// the platform's own per-policy blocking answer.
+func platformPostSummary(runs []policyRun, v *platformVerdict) *control.PlatformPostSummary {
+	out := &control.PlatformPostSummary{}
+	if v != nil && v.GlobalScore != nil {
+		out.HasGlobal = true
+		out.GlobalLetter = v.GlobalScore.Letter
+		out.GlobalPoints = v.GlobalScore.Points
+	}
+	blocking := blockingPolicyKeys(v)
+	for _, run := range runs {
+		letter := ""
+		points, scored := finalPointsOf(run)
+		if scored {
+			letter = run.Score.Score
+		}
+		for _, pol := range run.Policies {
+			out.Policies = append(out.Policies, control.PlatformPolicyLine{
+				Name:        pol.Name,
+				Enforcement: string(pol.Enforcement),
+				Letter:      letter,
+				FinalPoints: points,
+				Blocking:    blocking["id:"+pol.ID] || blocking["name:"+pol.Name],
+			})
+		}
+	}
+	return out
+}
+
+// blockingPolicyKeys indexes the gate's blocking policies by id AND by name.
+// The platform keys its gate on ids, but the derived "[Plumber default]"
+// placeholder has none that may be used (realPolicyID), so the name is the
+// only handle for it; the two prefixes keep an id from ever matching a name.
+func blockingPolicyKeys(v *platformVerdict) map[string]bool {
+	keys := map[string]bool{}
+	if v == nil || v.Gate == nil {
+		return keys
+	}
+	for _, gp := range v.Gate.Policies {
+		if !gp.Blocking {
+			continue
+		}
+		if gp.ID != "" {
+			keys["id:"+gp.ID] = true
+		}
+		if gp.Name != "" {
+			keys["name:"+gp.Name] = true
+		}
+	}
+	return keys
+}
+
+// platformPBOMSummary builds the PBOM and CycloneDX platform block: one entry
+// per resolved policy plus the platform's global score when the push returned
+// one. Returns nil outside platform mode, which is what keeps a standalone
+// document byte-identical.
+func platformPBOMSummary(runs []policyRun, v *platformVerdict) *pbom.PlatformSummary {
+	if len(runs) == 0 {
+		return nil
+	}
+	out := &pbom.PlatformSummary{}
+	if v != nil && v.GlobalScore != nil {
+		out.GlobalScore = &pbom.PlatformGlobalScore{Letter: v.GlobalScore.Letter, Points: v.GlobalScore.Points}
+	}
+	for _, run := range runs {
+		letter := ""
+		var final *int
+		if points, scored := finalPointsOf(run); scored {
+			letter, final = run.Score.Score, &points
+		}
+		for _, pol := range run.Policies {
+			out.Policies = append(out.Policies, pbom.PolicyScore{
+				Name:        pol.Name,
+				Enforcement: string(pol.Enforcement),
+				Score:       letter,
+				FinalPoints: final,
+				Applied:     run.Applied,
+				Reason:      run.Reason,
+			})
+		}
+	}
+	return out
+}
+
+// platformUnionResult returns the result the security-report writers (SARIF,
+// the GitLab SAST report) render in platform mode: the same run, with its
+// findings replaced by the union of every APPLIED policy run's findings,
+// deduplicated by fingerprint and each tagged with the policies that reported
+// it.
+//
+// The union, not one report per policy: both formats feed a single dashboard
+// that dedups on its own identity key, so emitting the same finding once per
+// covering policy would either double-count it or have the consumer silently
+// merge the entries and lose the policy dimension anyway. Tagging one entry
+// with every policy keeps both facts.
+//
+// The collected result is copied, never mutated: it is still what the JSON
+// report and the PBOM are written from, and its findings are the frozen
+// objects the platform hashes (#467).
+func platformUnionResult(result *control.AnalysisResult, runs []policyRun) *control.AnalysisResult {
+	if result == nil {
+		return nil
+	}
+	union := *result
+	union.Findings = nil
+	index := map[string]int{}
+	for _, run := range runs {
+		if !run.Applied || run.Result == nil {
+			continue
+		}
+		names := policyNames(run)
+		for _, f := range run.Result.Findings {
+			key := unionFindingKey(f)
+			if at, seen := index[key]; seen {
+				union.Findings[at].Policies = appendMissing(union.Findings[at].Policies, names)
+				continue
+			}
+			entry := f
+			entry.Policies = appendMissing(nil, names)
+			index[key] = len(union.Findings)
+			union.Findings = append(union.Findings, entry)
+		}
+	}
+	return &union
+}
+
+// unionFindingKey is the identity two policy runs are deduplicated on: the
+// stamped fingerprint, which is exactly what every consumer of these reports
+// tracks a finding by. Findings that were never stamped (codeless ones, or an
+// unstamped caller) fall back to their canonical fields rather than collapsing
+// into one entry under the empty string.
+func unionFindingKey(f opaengine.Finding) string {
+	if f.Fingerprint != "" {
+		return "fp:" + f.Fingerprint
+	}
+	return "raw:" + f.Code + "|" + f.File + "|" + strconv.Itoa(f.Line) + "|" + f.Job + "|" + f.Message
+}
+
+// appendMissing appends the names not already present, preserving order.
+func appendMissing(existing []string, names []string) []string {
+	for _, n := range names {
+		found := false
+		for _, e := range existing {
+			if e == n {
+				found = true
+				break
+			}
+		}
+		if !found {
+			existing = append(existing, n)
+		}
+	}
+	return existing
+}

--- a/cmd/platform_outputs_test.go
+++ b/cmd/platform_outputs_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/getplumber/plumber/control"
 	opaengine "github.com/getplumber/plumber/internal/engine/opa"
 )
 
@@ -187,5 +188,38 @@ func TestAppendMissing(t *testing.T) {
 	}
 	if got := appendMissing(nil, nil); len(got) != 0 {
 		t.Fatalf("appendMissing(nil, nil) must stay empty, got %#v", got)
+	}
+}
+
+// The union's NotEvaluable field directly: the collected result's local marks
+// are replaced by the applied runs' own, one entry per marked control, and the
+// first run to mark a control owns the reason (any run's mark is enough for
+// the control never to read as a clean pass).
+func TestPlatformUnionResult_NotEvaluableIsTheRunsOwnMarks(t *testing.T) {
+	first := handMadePolicyRun(t, "A", debugTracePolicyYAML, nil)
+	first.Result.MarkNotEvaluable("pipelineMustNotEnableDebugTrace", "policy_lane_unavailable")
+	second := handMadePolicyRun(t, "B", dockerInDockerPolicyYAML, nil)
+	second.Result.MarkNotEvaluable("pipelineMustNotEnableDebugTrace", "a_second_reason")
+	skipped := handMadePolicyRun(t, "C", debugTracePolicyYAML, nil)
+	skipped.Result.MarkNotEvaluable("neverAppliedControl", "an_un_applied_run_marks_nothing")
+	skipped.Applied = false
+	base := &control.AnalysisResult{CiValid: true}
+	base.MarkNotEvaluable("pipelineMustNotUseDockerInDocker", "local_mark_must_not_appear")
+
+	union := platformUnionResult(base, []policyRun{first, second, skipped})
+
+	if _, leaked := union.NotEvaluable["pipelineMustNotUseDockerInDocker"]; leaked {
+		t.Errorf("the collected result's LOCAL mark must not survive into the union: %#v", union.NotEvaluable)
+	}
+	if got := union.NotEvaluable["pipelineMustNotEnableDebugTrace"]; got != "policy_lane_unavailable" {
+		t.Errorf("the first applied run to mark a control owns the reason, got %q", got)
+	}
+	if _, present := union.NotEvaluable["neverAppliedControl"]; present {
+		t.Errorf("an un-applied run evaluated nothing and marks nothing: %#v", union.NotEvaluable)
+	}
+	// The collected result is copied, never mutated: it is still what the JSON
+	// report and the PBOM are written from.
+	if base.NotEvaluable["pipelineMustNotUseDockerInDocker"] != "local_mark_must_not_appear" {
+		t.Errorf("the collected result was mutated: %#v", base.NotEvaluable)
 	}
 }

--- a/cmd/platform_outputs_test.go
+++ b/cmd/platform_outputs_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"reflect"
 	"testing"
 
 	opaengine "github.com/getplumber/plumber/internal/engine/opa"
@@ -135,5 +136,56 @@ func TestBuildGLSAST_StandaloneCarriesNoPolicyIdentifier(t *testing.T) {
 		if id.Type == "plumber_policy" {
 			t.Errorf("policy identifier present outside platform mode: %#v", id)
 		}
+	}
+}
+
+// Review comment 3985437498: outputControlEntries keys its per-control
+// policy map on e.ControlName and APPENDS every applied run's names to it, so
+// a control two DIFFERENT runs both enable must end up naming both, in
+// /context order, while a control only one of them enables names only that
+// one. Every other test reaching this function used a single run; this pins
+// the accumulation directly rather than through the OCSF/CSV writers.
+func TestOutputControlEntries_TwoRunsShareOneControl(t *testing.T) {
+	const debugTraceOnlyYAML = `version: "2.0"
+gitlab:
+  controls:
+    pipelineMustNotEnableDebugTrace:
+      enabled: true
+      forbiddenVariables: ["CI_DEBUG_TRACE"]
+`
+	const debugTraceAndDinDYAML = `version: "2.0"
+gitlab:
+  controls:
+    pipelineMustNotEnableDebugTrace:
+      enabled: true
+      forbiddenVariables: ["CI_DEBUG_TRACE"]
+    pipelineMustNotUseDockerInDocker:
+      enabled: true
+`
+	runA := handMadePolicyRun(t, "A", debugTraceOnlyYAML, nil)
+	runB := handMadePolicyRun(t, "B", debugTraceAndDinDYAML, nil)
+
+	_, policies := outputControlEntries(testProvider(t), nil, []policyRun{runA, runB})
+
+	if got := policies["pipelineMustNotEnableDebugTrace"]; len(got) != 2 || got[0] != "A" || got[1] != "B" {
+		t.Fatalf("a control both runs enable must name both policies in /context order, got %#v", got)
+	}
+	if got := policies["pipelineMustNotUseDockerInDocker"]; len(got) != 1 || got[0] != "B" {
+		t.Fatalf("a control only one run enables must name only that one, got %#v", got)
+	}
+}
+
+// appendMissing is the primitive outputControlEntries and platformUnionResult
+// both build their per-control/per-finding policy lists on: append the names
+// not already present, dedup, and keep order.
+func TestAppendMissing(t *testing.T) {
+	if got := appendMissing([]string{"A"}, []string{"B", "A", "C"}); !reflect.DeepEqual(got, []string{"A", "B", "C"}) {
+		t.Fatalf("appendMissing = %#v, want [A B C]", got)
+	}
+	if got := appendMissing(nil, []string{"X", "X"}); !reflect.DeepEqual(got, []string{"X"}) {
+		t.Fatalf("appendMissing must dedup within the incoming names too, got %#v", got)
+	}
+	if got := appendMissing(nil, nil); len(got) != 0 {
+		t.Fatalf("appendMissing(nil, nil) must stay empty, got %#v", got)
 	}
 }

--- a/cmd/platform_outputs_test.go
+++ b/cmd/platform_outputs_test.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"testing"
+
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
+)
+
+// twoPolicyRuns evaluates the same collected pipeline under two DIFFERENT
+// control configurations that both catch the CI_DEBUG_TRACE job: two runs
+// (distinct fingerprints, so no grouping) reporting one and the same finding.
+// That overlap is what the union has to collapse.
+func twoPolicyRuns(t *testing.T) []policyRun {
+	t.Helper()
+	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", `{"enabled":true,"forbiddenVariables":["CI_DEBUG_TRACE"]}`)
+	b := policyWithTree("B", "pipelineMustNotEnableDebugTrace", `{"enabled":true,"forbiddenVariables":["CI_DEBUG_TRACE","OTHER"]}`)
+	conf := confWithPolicies(t, a, b)
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+	if len(runs) != 2 {
+		t.Fatalf("want two runs (two distinct control configurations), got %d", len(runs))
+	}
+	return runs
+}
+
+// Spec s5: the security reports of a platform-mode run carry the UNION of
+// every applied run's findings, deduplicated by fingerprint. One alert per
+// finding whatever number of policies cover it: a dashboard must not show the
+// same finding twice because two policies enable the same control.
+func TestPlatformUnionResult_DedupsByFingerprintAndNamesThePolicies(t *testing.T) {
+	runs := twoPolicyRuns(t)
+	base := debugTraceResult()
+	base.Warnings = []string{"could not verify"}
+
+	union := platformUnionResult(base, runs)
+
+	if len(union.Findings) != 1 {
+		t.Fatalf("the same finding under two policies is ONE union entry, got %d", len(union.Findings))
+	}
+	got := union.Findings[0].Policies
+	if len(got) != 2 || got[0] != "A" || got[1] != "B" {
+		t.Fatalf("policies on the union finding = %#v, want [A B] in /context order", got)
+	}
+	if union.Findings[0].Fingerprint == "" {
+		t.Error("the union is keyed on the fingerprint, so the entry must carry it")
+	}
+	// The run-level facts the writers report beside the findings (warnings,
+	// degradation, the analyzed commit) are the run's, not a policy's.
+	if len(union.Warnings) != 1 {
+		t.Errorf("the union keeps the run's warnings, got %#v", union.Warnings)
+	}
+	// The collected result must not be mutated: it is what the JSON report
+	// and the PBOM are still written from.
+	if len(base.Findings) != 0 {
+		t.Errorf("the collected result was mutated: %#v", base.Findings)
+	}
+}
+
+// A finding no policy reported is not in the union: platform mode publishes
+// what the platform's policies found, never a local-configuration finding.
+func TestPlatformUnionResult_OnlyThePoliciesFindings(t *testing.T) {
+	runs := twoPolicyRuns(t)
+	base := debugTraceResult()
+	base.Findings = []opaengine.Finding{{Code: "ISSUE-999", Message: "local only", Fingerprint: "local"}}
+
+	union := platformUnionResult(base, runs)
+
+	for _, f := range union.Findings {
+		if f.Code == "ISSUE-999" {
+			t.Fatalf("a local-configuration finding reached the platform-mode report: %#v", f)
+		}
+	}
+}
+
+// Spec s5 for SARIF: each result names the policies that reported it.
+func TestBuildSARIF_PlatformMode_ResultCarriesPolicyNames(t *testing.T) {
+	union := platformUnionResult(debugTraceResult(), twoPolicyRuns(t))
+
+	doc := buildSARIF(union.Findings, ".plumber.yaml", "gitlab")
+
+	if len(doc.Runs[0].Results) != 1 {
+		t.Fatalf("results = %d, want 1", len(doc.Runs[0].Results))
+	}
+	got, _ := doc.Runs[0].Results[0].Properties["policies"].([]string)
+	if len(got) != 2 || got[0] != "A" || got[1] != "B" {
+		t.Fatalf("properties.policies = %#v, want [A B]", doc.Runs[0].Results[0].Properties["policies"])
+	}
+}
+
+// A standalone run's results carry no policies property: there are no
+// policies, and an empty array would read as "no policy covers this".
+func TestBuildSARIF_StandaloneCarriesNoPoliciesProperty(t *testing.T) {
+	doc := buildSARIF([]opaengine.Finding{
+		{Code: "ISSUE-701", Severity: "high", Message: "unpinned", File: "ci.yml", Line: 3},
+	}, ".plumber.yaml", "github")
+
+	if _, present := doc.Runs[0].Results[0].Properties["policies"]; present {
+		t.Errorf("policies property present outside platform mode: %#v", doc.Runs[0].Results[0].Properties)
+	}
+}
+
+// Spec s5 for the GitLab SAST report: the schema has no free-form per-finding
+// bag, but `identifiers` is an open list, so each policy rides there as its
+// own identifier. The primary identifier (the issue code, which GitLab dedups
+// on) stays first and untouched.
+func TestBuildGLSAST_PlatformMode_PolicyIdentifiers(t *testing.T) {
+	union := platformUnionResult(debugTraceResult(), twoPolicyRuns(t))
+
+	rep := buildGLSAST(union.Findings, "gitlab")
+
+	if len(rep.Vulnerabilities) != 1 {
+		t.Fatalf("vulnerabilities = %d, want 1", len(rep.Vulnerabilities))
+	}
+	v := rep.Vulnerabilities[0]
+	if v.Identifiers[0].Type != "plumber" {
+		t.Fatalf("the primary identifier must stay the issue code: %#v", v.Identifiers[0])
+	}
+	var policies []string
+	for _, id := range v.Identifiers {
+		if id.Type == "plumber_policy" {
+			policies = append(policies, id.Value)
+		}
+	}
+	if len(policies) != 2 || policies[0] != "A" || policies[1] != "B" {
+		t.Fatalf("plumber_policy identifiers = %#v, want [A B]", policies)
+	}
+}
+
+// A standalone report gains no policy identifier.
+func TestBuildGLSAST_StandaloneCarriesNoPolicyIdentifier(t *testing.T) {
+	rep := buildGLSAST([]opaengine.Finding{
+		{Code: "ISSUE-701", Severity: "high", Message: "x", File: "ci.yml", Line: 5},
+	}, "github")
+
+	for _, id := range rep.Vulnerabilities[0].Identifiers {
+		if id.Type == "plumber_policy" {
+			t.Errorf("policy identifier present outside platform mode: %#v", id)
+		}
+	}
+}

--- a/cmd/platform_policy_tree_test.go
+++ b/cmd/platform_policy_tree_test.go
@@ -19,24 +19,12 @@ func treePolicy(name string, controls ...platform.PolicyControl) platform.Policy
 	}
 }
 
-func localConf(t *testing.T) *configuration.Configuration {
-	t.Helper()
-	enabled := true
-	return &configuration.Configuration{PlumberConfig: &configuration.PlumberConfig{
-		Version: "2.0",
-		GitLab: &configuration.ProviderConfig{Controls: configuration.ControlsConfig{
-			BranchMustBeProtected: &configuration.BranchProtectionControlConfig{Enabled: &enabled},
-		}},
-	}}
-}
-
 // The #368 shape: two policies declaring the SAME control_type with
 // DIFFERENT parameters must each evaluate under their own. Reading one
 // policy's config and reporting it under the other's name is the bug the
 // control tree exists to end, so this asserts the two configs differ AND
-// that each carries its own value rather than merely "not the local one".
+// that each carries its own value.
 func TestConfigForPolicyUsesEachPolicysOwnConfig(t *testing.T) {
-	conf := localConf(t)
 	strict := treePolicy("Strict", platform.PolicyControl{
 		ControlType: "branchMustBeProtected",
 		Config:      []byte(`{"enabled":true,"minMergeAccessLevel":40}`),
@@ -46,10 +34,10 @@ func TestConfigForPolicyUsesEachPolicysOwnConfig(t *testing.T) {
 		Config:      []byte(`{"enabled":true,"minMergeAccessLevel":30}`),
 	})
 
-	sc := configForPolicy("gitlab", conf, strict)
-	lc := configForPolicy("gitlab", conf, lenient)
+	sc, _, sr := configForPlatformPolicy("gitlab", strict)
+	lc, _, lr := configForPlatformPolicy("gitlab", lenient)
 	if sc == nil || lc == nil {
-		t.Fatal("both policies must resolve a config")
+		t.Fatalf("both policies must resolve a config, got reasons %q / %q", sr, lr)
 	}
 
 	got := func(c *configuration.PlumberConfig) int {
@@ -72,41 +60,49 @@ func TestConfigForPolicyUsesEachPolicysOwnConfig(t *testing.T) {
 	}
 }
 
-// A policy with no stored tree (the derived [Plumber default], or a real
-// policy an admin has not configured) must fall back to the local config.
-// Evaluating it against an empty ruleset would report a clean pass for a
-// policy that simply has not been filled in yet.
-func TestConfigForPolicyFallsBackWhenTreeIsEmpty(t *testing.T) {
-	conf := localConf(t)
+// R2: a REAL policy with no stored tree declares an empty set, and that is
+// what it is evaluated under. Falling back to the local configuration would
+// report a verdict the policy never asked for, under this policy's name -
+// the same confusion the control tree exists to end - so the honest answer
+// is an empty configuration plus the reason.
+func TestConfigForPlatformPolicy_NoTreeIsEmptySet(t *testing.T) {
 	for _, pol := range []platform.Policy{
-		{ID: platform.NilUUID, Name: "[Plumber default]", Enforcement: platform.EnforcementReport},
 		{ID: "abc", Name: "Unconfigured", Requirements: []platform.PolicyRequirement{}},
 		{ID: "def", Name: "EmptyRequirement", Requirements: []platform.PolicyRequirement{{Name: "R"}}},
 	} {
 		t.Run(pol.Name, func(t *testing.T) {
-			if got := configForPolicy("gitlab", conf, pol); got != conf.PlumberConfig {
-				t.Fatal("a policy declaring no controls must fall back to the local configuration")
+			cfg, derived, reason := configForPlatformPolicy("gitlab", pol)
+			if cfg == nil || derived {
+				t.Fatalf("a real policy declaring no controls must resolve an empty config, got cfg=%v derived=%v", cfg, derived)
+			}
+			if reason != reasonNoControls {
+				t.Fatalf("reason = %q, want %q", reason, reasonNoControls)
+			}
+			controls := cfg.ControlsFor("gitlab")
+			if controls == nil {
+				t.Fatal("an empty configuration must still answer with a controls block")
+			}
+			if controls.BranchMustBeProtected != nil || controls.CicdVariablesMustBeMasked != nil {
+				t.Fatalf("the empty set must enable no control at all: %+v", controls)
 			}
 		})
 	}
 }
 
-// Only the controls the policy declares are configured. A control it does
-// not mention must not leak in from the local config, or the policy's
-// verdict would include checks it never asked for.
+// Only the controls the policy declares are configured. Nothing else may
+// appear, or the policy's verdict would include checks it never asked for.
 func TestConfigForPolicyOmitsUndeclaredControls(t *testing.T) {
-	conf := localConf(t)
 	pol := treePolicy("OnlyVariables", platform.PolicyControl{
 		ControlType: "cicdVariablesMustBeMasked",
 		Config:      []byte(`{"enabled":true}`),
 	})
-	cfg := configForPolicy("gitlab", conf, pol)
+	cfg, _, _ := configForPlatformPolicy("gitlab", pol)
 	controls := cfg.ControlsFor("gitlab")
 	if controls.CicdVariablesMustBeMasked == nil || !controls.CicdVariablesMustBeMasked.IsEnabled() {
 		t.Fatal("the declared control must be configured")
 	}
 	if controls.BranchMustBeProtected != nil {
-		t.Fatal("a control the policy never declared must not be inherited from the local config")
+		t.Fatal("a control the policy never declared must not appear in its configuration")
 	}
 }
 
@@ -114,12 +110,11 @@ func TestConfigForPolicyOmitsUndeclaredControls(t *testing.T) {
 // rounded. The CLI splices those bytes into YAML rather than decoding and
 // re-encoding them, so the value has to survive to the typed config.
 func TestConfigForPolicyPreservesLargeIntegers(t *testing.T) {
-	conf := localConf(t)
 	pol := treePolicy("Big", platform.PolicyControl{
 		ControlType: "projectMustHaveSecurityPolicySource",
 		Config:      []byte(`{"enabled":true,"expectedProjectId":9007199254740993}`),
 	})
-	cfg := configForPolicy("gitlab", conf, pol)
+	cfg, _, _ := configForPlatformPolicy("gitlab", pol)
 	sp := cfg.ControlsFor("gitlab").ProjectMustHaveSecurityPolicySource
 	if sp == nil || sp.ExpectedProjectId == nil {
 		t.Fatal("the control must be configured with its expectedProjectId")
@@ -129,33 +124,45 @@ func TestConfigForPolicyPreservesLargeIntegers(t *testing.T) {
 	}
 }
 
-// Malformed config must not silently evaluate the policy under someone
-// else's parameters without saying so. The run continues on the local
-// config; the point here is that it does not panic and does not produce a
-// half-applied tree.
-func TestConfigForPolicyToleratesMalformedConfig(t *testing.T) {
-	conf := localConf(t)
-	pol := treePolicy("Broken", platform.PolicyControl{
-		ControlType: "branchMustBeProtected",
-		Config:      []byte(`{"enabled":`), // truncated
-	})
-	got := configForPolicy("gitlab", conf, pol)
-	if got != conf.PlumberConfig {
-		t.Fatal("a policy whose tree cannot be applied must fall back to the local configuration")
+// One malformed control costs the policy that control and nothing else: the
+// rest of the tree still applies. Dropping the whole policy over a single
+// unreadable entry would leave it unevaluated and absent from the push, and
+// falling back to the local configuration would evaluate it under parameters
+// it never asked for.
+func TestConfigForPlatformPolicy_MalformedControlIsDropped_OthersApply(t *testing.T) {
+	pol := treePolicy("Broken",
+		platform.PolicyControl{ControlType: "cicdVariablesMustBeMasked", Config: []byte(`{"enabled":`)}, // truncated
+		platform.PolicyControl{ControlType: "branchMustBeProtected", Config: []byte(`{"enabled":true,"minMergeAccessLevel":40}`)},
+	)
+
+	cfg, _, reason := configForPlatformPolicy("gitlab", pol)
+
+	if cfg == nil {
+		t.Fatalf("one bad control must not cost the policy its tree, got reason %q", reason)
+	}
+	if reason != "" {
+		t.Fatalf("reason = %q, want none: the tree WAS applied", reason)
+	}
+	controls := cfg.ControlsFor("gitlab")
+	if controls.BranchMustBeProtected == nil || controls.BranchMustBeProtected.MinMergeAccessLevel == nil ||
+		*controls.BranchMustBeProtected.MinMergeAccessLevel != 40 {
+		t.Fatal("the readable control must still take effect alongside the unreadable one")
+	}
+	if controls.CicdVariablesMustBeMasked != nil {
+		t.Fatal("the unreadable control must not be applied from guessed bytes")
 	}
 }
 
 // A control_type the CLI does not know must not break the whole tree: the
 // controls it DOES know still apply. Forward tolerance is the contract.
 func TestConfigForPolicyIgnoresUnknownControlType(t *testing.T) {
-	conf := localConf(t)
 	pol := treePolicy("Mixed",
 		platform.PolicyControl{ControlType: "someFutureControl", Config: []byte(`{"enabled":true}`)},
 		platform.PolicyControl{ControlType: "branchMustBeProtected", Config: []byte(`{"enabled":true,"minMergeAccessLevel":40}`)},
 	)
-	cfg := configForPolicy("gitlab", conf, pol)
-	if cfg == conf.PlumberConfig {
-		t.Fatal("a tree with one unknown control must still be applied, not abandoned")
+	cfg, _, reason := configForPlatformPolicy("gitlab", pol)
+	if cfg == nil {
+		t.Fatalf("a tree with one unknown control must still be applied, not abandoned: %q", reason)
 	}
 	b := cfg.ControlsFor("gitlab").BranchMustBeProtected
 	if b == nil || b.MinMergeAccessLevel == nil || *b.MinMergeAccessLevel != 40 {
@@ -164,14 +171,11 @@ func TestConfigForPolicyIgnoresUnknownControlType(t *testing.T) {
 }
 
 // One control the CLI cannot read must cost the policy that control, not
-// its whole tree. Falling back to the local configuration over a single bad
-// entry evaluates the policy under someone else's parameters and reports it
-// under this policy's name, which is the confusion the tree exists to end.
+// its whole tree. Dropping the whole tree over a single bad entry leaves the
+// policy unevaluated and absent from the push entirely.
 func TestPolicyConfigFromTreeSkipsUnusableControls(t *testing.T) {
-	conf := localConf(t)
-
 	// A blank name alongside a real control: the real one still applies.
-	cfg, err := policyConfigFromTree("gitlab", conf, treePolicy("Mixed",
+	cfg, err := policyConfigFromTree("gitlab", treePolicy("Mixed",
 		platform.PolicyControl{ControlType: "  ", Config: []byte(`{"enabled":true}`)},
 		platform.PolicyControl{ControlType: "branchMustBeProtected", Config: []byte(`{"enabled":true,"minMergeAccessLevel":40}`)},
 	))
@@ -186,7 +190,7 @@ func TestPolicyConfigFromTreeSkipsUnusableControls(t *testing.T) {
 	// A truncated config alongside a real control: same rule. Failing the
 	// whole tree over one control would send the policy back to the local
 	// configuration and report it under someone else's parameters.
-	cfg, err = policyConfigFromTree("gitlab", conf, treePolicy("Truncated",
+	cfg, err = policyConfigFromTree("gitlab", treePolicy("Truncated",
 		platform.PolicyControl{ControlType: "cicdVariablesMustBeMasked", Config: []byte(`{"enabled":`)},
 		platform.PolicyControl{ControlType: "branchMustBeProtected", Config: []byte(`{"enabled":true}`)},
 	))
@@ -207,8 +211,7 @@ func TestPolicyConfigFromTreeSkipsUnusableControls(t *testing.T) {
 // policy would fall back to the local configuration over a control the
 // platform served perfectly well.
 func TestPolicyConfigFromTreeTreatsAnAbsentConfigAsDefaults(t *testing.T) {
-	conf := localConf(t)
-	cfg, err := policyConfigFromTree("gitlab", conf, treePolicy("Bare",
+	cfg, err := policyConfigFromTree("gitlab", treePolicy("Bare",
 		platform.PolicyControl{ControlType: "branchMustBeProtected"},
 	))
 	if err != nil {
@@ -219,16 +222,23 @@ func TestPolicyConfigFromTreeTreatsAnAbsentConfigAsDefaults(t *testing.T) {
 	}
 }
 
-// A tree in which nothing at all could be read is a tree that did not
+// R3: a tree in which nothing at all could be read is a tree that did not
 // arrive. Assembling an empty ruleset from it would push a verdict in which
-// the policy checked nothing; the error routes the caller to the same
-// local-config fallback a policy with no tree takes.
+// the policy checked nothing, so the policy is NOT APPLIED: no configuration,
+// a reason, and (buildPolicyResults) no entry in the push at all.
 func TestPolicyConfigFromTreeRefusesAnEntirelyUnreadableTree(t *testing.T) {
-	conf := localConf(t)
-	if _, err := policyConfigFromTree("gitlab", conf, treePolicy("Empty",
-		platform.PolicyControl{ControlType: "  ", Config: []byte(`{"enabled":true}`)},
-	)); err == nil {
+	pol := treePolicy("Empty", platform.PolicyControl{ControlType: "  ", Config: []byte(`{"enabled":true}`)})
+
+	if _, err := policyConfigFromTree("gitlab", pol); err == nil {
 		t.Fatal("a tree with nothing usable in it must not assemble to an empty ruleset")
+	}
+
+	cfg, derived, reason := configForPlatformPolicy("gitlab", pol)
+	if cfg != nil || derived {
+		t.Fatalf("an unreadable tree must resolve no configuration, got cfg=%v derived=%v", cfg, derived)
+	}
+	if !strings.HasPrefix(reason, reasonTreeNotApplied) {
+		t.Fatalf("reason = %q, want the not-applied reason", reason)
 	}
 }
 
@@ -236,8 +246,7 @@ func TestPolicyConfigFromTreeRefusesAnEntirelyUnreadableTree(t *testing.T) {
 // GitHub policy under `gitlab:` marks every GitHub control skipped, and the
 // push then reports a run in which nothing was checked.
 func TestPolicyConfigFromTreeUsesTheAnalysedProviderSection(t *testing.T) {
-	conf := localConf(t)
-	cfg, err := policyConfigFromTree("github", conf, treePolicy("GH",
+	cfg, err := policyConfigFromTree("github", treePolicy("GH",
 		platform.PolicyControl{ControlType: "actionsMustBePinnedByCommitSha", Config: []byte(`{"enabled":true}`)},
 	))
 	if err != nil {
@@ -251,17 +260,19 @@ func TestPolicyConfigFromTreeUsesTheAnalysedProviderSection(t *testing.T) {
 	}
 }
 
+// R4: the assembled version is the schema constant, never read off the run's
+// local file. In platform mode the policy's tree IS the configuration, and a
+// file the policy has nothing to do with must not decide how its controls
+// parse - not even by supplying a version number.
 func TestPolicyConfigFromTreeKeepsConfigVersion(t *testing.T) {
-	conf := localConf(t)
-	conf.PlumberConfig.Version = "2.0"
-	cfg, err := policyConfigFromTree("gitlab", conf, treePolicy("V", platform.PolicyControl{
+	cfg, err := policyConfigFromTree("gitlab", treePolicy("V", platform.PolicyControl{
 		ControlType: "branchMustBeProtected", Config: []byte(`{"enabled":true}`),
 	}))
 	if err != nil {
 		t.Fatalf("assemble: %v", err)
 	}
-	if !strings.HasPrefix(cfg.Version, "2") {
-		t.Fatalf("assembled config version = %q, want the run's own 2.x", cfg.Version)
+	if cfg.Version != policyConfigVersion {
+		t.Fatalf("assembled config version = %q, want the schema constant %q", cfg.Version, policyConfigVersion)
 	}
 }
 

--- a/cmd/platform_post_summary_test.go
+++ b/cmd/platform_post_summary_test.go
@@ -1,0 +1,276 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/control"
+	"github.com/getplumber/plumber/internal/platform"
+	providerPkg "github.com/getplumber/plumber/provider"
+	"github.com/spf13/cobra"
+)
+
+// This file covers the step between the platform's answer and what the badge
+// and the merge-request comment say: platformPostSummary and its
+// blockingPolicyKeys helper. The control-layer tests build a
+// PlatformPostSummary by hand and assert the RENDERING; the translation from
+// the real runs plus the real gate response is what is asserted here, and a
+// wrong Blocking flag here is published in a comment posted with Plumber's
+// identity (spec s5).
+
+// scoredRun is an applied run of one policy with the given letter and final
+// points, the shape the mapping reads.
+func scoredRun(name, id, enforcement, letter string, finalPoints float64) policyRun {
+	return policyRun{
+		Policies: []platform.Policy{{ID: id, Name: name, Enforcement: platform.Enforcement(enforcement)}},
+		Score:    &control.PlumberScoreResult{Score: letter, FinalPoints: finalPoints},
+		Applied:  true,
+	}
+}
+
+// unappliedRun is a policy the CLI evaluated nothing for: no score at all, a
+// reason instead. Its line must carry no letter and no points rather than a
+// zero that reads as a verdict.
+func unappliedRun(name, id, reason string) policyRun {
+	return policyRun{
+		Policies: []platform.Policy{{ID: id, Name: name, Enforcement: platform.EnforcementReport}},
+		Applied:  false,
+		Reason:   reason,
+	}
+}
+
+func TestPlatformPostSummary_MapsTheRunsAndTheGate(t *testing.T) {
+	runs := []policyRun{
+		// 66.6 ROUNDS to 67, the same rounding the push applies, so the badge,
+		// the comment and the pushed record cannot disagree by a point.
+		scoredRun("Prod", "id-prod", "block", "C", 66.6),
+		unappliedRun("Later", "id-later", "no control enabled"),
+	}
+	verdict := &platformVerdict{
+		Gate: &platformGate{Evaluated: true, Blocking: true, Policies: []platformGatePolicy{
+			{ID: "id-prod", Name: "Prod", Enforcement: "block", Blocking: true, LiveFailCount: 2},
+			{ID: "id-later", Name: "Later", Enforcement: "report", Blocking: false},
+		}},
+		GlobalScore: &platformScore{Letter: "B", Points: 83},
+	}
+
+	got := platformPostSummary(runs, verdict)
+
+	if !got.HasGlobal || got.GlobalLetter != "B" || got.GlobalPoints != 83 {
+		t.Errorf("the global score is the platform's own: HasGlobal=%v letter=%q points=%d",
+			got.HasGlobal, got.GlobalLetter, got.GlobalPoints)
+	}
+	want := []control.PlatformPolicyLine{
+		{Name: "Prod", Enforcement: "block", Letter: "C", FinalPoints: 67, Blocking: true},
+		{Name: "Later", Enforcement: "report", Letter: "", FinalPoints: 0, Blocking: false},
+	}
+	if len(got.Policies) != len(want) {
+		t.Fatalf("one line per resolved policy, got %#v", got.Policies)
+	}
+	for i, w := range want {
+		if got.Policies[i] != w {
+			t.Errorf("policy line %d = %#v, want %#v", i, got.Policies[i], w)
+		}
+	}
+}
+
+// The derived "[Plumber default]" placeholder carries the nil uuid and the
+// gate has no id for it, so the name is the only handle. Dropping the
+// name-keyed fallback would render a policy the platform blocks as
+// "Blocking: no".
+func TestPlatformPostSummary_DerivedPlaceholderIsMatchedByName(t *testing.T) {
+	runs := []policyRun{{
+		Policies: []platform.Policy{{ID: platform.NilUUID, Name: "[Plumber default]", Enforcement: platform.EnforcementReport}},
+		Score:    &control.PlumberScoreResult{Score: "A", FinalPoints: 95},
+		Applied:  true,
+	}}
+	verdict := &platformVerdict{Gate: &platformGate{Evaluated: true, Blocking: true, Policies: []platformGatePolicy{
+		{Name: "[Plumber default]", Enforcement: "report", Blocking: true, LiveFailCount: 1},
+	}}}
+
+	got := platformPostSummary(runs, verdict)
+
+	if len(got.Policies) != 1 || !got.Policies[0].Blocking {
+		t.Fatalf("the placeholder is blocked by name, the only handle the gate gives it: %#v", got.Policies)
+	}
+}
+
+// A run whose policy shares a name with a DIFFERENT gate id, and vice versa,
+// must not borrow the other's answer: the two prefixes keep an id from ever
+// matching a name.
+func TestPlatformPostSummary_IdAndNameNamespacesDoNotCross(t *testing.T) {
+	runs := []policyRun{scoredRun("Prod", "id-prod", "block", "C", 66)}
+	verdict := &platformVerdict{Gate: &platformGate{Evaluated: true, Blocking: true, Policies: []platformGatePolicy{
+		// A blocking gate entry whose ID happens to be the run policy's NAME.
+		{ID: "Prod", Name: "id-prod", Enforcement: "block", Blocking: true},
+	}}}
+
+	got := platformPostSummary(runs, verdict)
+
+	if got.Policies[0].Blocking {
+		t.Errorf("an id must never match a name: %#v", got.Policies[0])
+	}
+}
+
+func TestPlatformPostSummary_NoVerdictAndNoGate(t *testing.T) {
+	runs := []policyRun{scoredRun("Prod", "id-prod", "block", "C", 66)}
+
+	t.Run("a nil verdict has no global score and blocks nothing", func(t *testing.T) {
+		got := platformPostSummary(runs, nil)
+		if got.HasGlobal || got.GlobalLetter != "" || got.GlobalPoints != 0 {
+			t.Errorf("no push answer is no score, never a locally computed one: %#v", got)
+		}
+		if len(got.Policies) != 1 || got.Policies[0].Blocking {
+			t.Errorf("nothing may be reported as blocking without a gate: %#v", got.Policies)
+		}
+	})
+
+	t.Run("a fail-open verdict still publishes the global score it carried", func(t *testing.T) {
+		got := platformPostSummary(runs, &platformVerdict{
+			GlobalScore: &platformScore{Letter: "B", Points: 83},
+			Unavailable: platformGateNoVerdictLine,
+		})
+		if !got.HasGlobal || got.GlobalLetter != "B" {
+			t.Errorf("the gate is missing, the score the platform sent is not: %#v", got)
+		}
+		if got.Policies[0].Blocking {
+			t.Errorf("no gate means nothing blocks: %#v", got.Policies[0])
+		}
+	})
+
+	// The letter is passed through verbatim, NOT sanitized here: whether it
+	// may be published is answered once for the badge and the comment by
+	// control.hasPublishableGlobal (the closed A-E set), which is where
+	// control/platform_post_test.go asserts it. This is the record that the
+	// mapping does not silently drop or rewrite what the platform sent.
+	t.Run("an out-of-set letter reaches the summary unchanged", func(t *testing.T) {
+		got := platformPostSummary(runs, &platformVerdict{
+			GlobalScore: &platformScore{Letter: "A)](https://elsewhere", Points: 83},
+		})
+		if !got.HasGlobal || got.GlobalLetter != "A)](https://elsewhere" {
+			t.Errorf("the mapping reports what the platform sent: %#v", got)
+		}
+	})
+}
+
+func TestBlockingPolicyKeys(t *testing.T) {
+	t.Run("only the blocking entries, indexed by id AND by name", func(t *testing.T) {
+		keys := blockingPolicyKeys(&platformVerdict{Gate: &platformGate{Policies: []platformGatePolicy{
+			{ID: "id-prod", Name: "Prod", Blocking: true},
+			{ID: "id-a", Name: "A", Blocking: false},
+			{Name: "[Plumber default]", Blocking: true},
+			{ID: "id-empty-name", Blocking: true},
+		}}})
+		want := map[string]bool{
+			"id:id-prod":             true,
+			"name:Prod":              true,
+			"name:[Plumber default]": true,
+			"id:id-empty-name":       true,
+		}
+		if len(keys) != len(want) {
+			t.Fatalf("keys = %#v, want %#v", keys, want)
+		}
+		for k := range want {
+			if !keys[k] {
+				t.Errorf("missing key %q: %#v", k, keys)
+			}
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		v    *platformVerdict
+	}{
+		{"a nil verdict", nil},
+		{"a verdict with no gate", &platformVerdict{Unavailable: platformGateNoVerdictLine}},
+	} {
+		t.Run(tc.name+" indexes nothing", func(t *testing.T) {
+			if keys := blockingPolicyKeys(tc.v); len(keys) != 0 {
+				t.Errorf("keys = %#v, want empty", keys)
+			}
+		})
+	}
+}
+
+// postActionsRecorder is the real provider with PostAnalysisActions replaced
+// by a capture, so a flow test can assert what runPostActions actually handed
+// the badge and the merge-request comment. Every other method is the real
+// provider's, so the evaluation, the push and the verdict are production's.
+type postActionsRecorder struct {
+	providerPkg.Provider
+	got    *providerPkg.PostActionSummary
+	called *bool
+}
+
+func (r postActionsRecorder) PostAnalysisActions(_ *cobra.Command, _ *control.AnalysisResult, _ *configuration.Configuration, s providerPkg.PostActionSummary) error {
+	*r.got = s
+	*r.called = true
+	return nil
+}
+
+// The whole pas.Platform wiring end to end. Every other platform-mode flow
+// test drives the pipeline with cmd == nil, which returns from runPostActions
+// before its platform branch, so this is the only test where the badge and
+// the comment's actual input is produced by the production path.
+func TestPlatformFlow_PostActionsReceiveThePlatformVerdict(t *testing.T) {
+	cmd := newGateFlagsCmd(t)
+	origPrint := printOutput
+	printOutput = false
+	defer func() { printOutput = origPrint }()
+
+	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	prod := policyWithTree("Prod", "pipelineMustNotUseDockerInDocker", `{"enabled":true}`)
+	prod.Enforcement = platform.EnforcementBlock
+	conf := confWithPolicies(t, a, prod)
+
+	var pushed []byte
+	srv := pushServer(t, 200, `{"gate":{"evaluated":true,"blocking":true,"policies":[`+
+		`{"id":"`+a.ID+`","name":"A","enforcement":"report","blocking":false,"live_fail_count":1},`+
+		`{"id":"`+prod.ID+`","name":"Prod","enforcement":"block","blocking":true,"live_fail_count":0}]},`+
+		`"global_score":{"letter":"B","points":83}}`, &pushed)
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok")
+	defer restore()
+
+	var got providerPkg.PostActionSummary
+	called := false
+	rec := postActionsRecorder{Provider: testProvider(t), got: &got, called: &called}
+
+	var err error
+	_ = captureStderr(t, func() {
+		err = presentResultWithProvider(rec, cmd, debugTraceResult(), conf)
+	})
+	var gateErr *PlatformGateError
+	if !errors.As(err, &gateErr) {
+		t.Fatalf("exit must be the platform's blocking verdict, got %v", err)
+	}
+	if !called {
+		t.Fatal("the post actions must run: with cmd nil the platform branch is never reached")
+	}
+	if got.Platform == nil {
+		t.Fatal("a platform-mode run hands the post actions the platform's summary")
+	}
+	if got.Passed {
+		t.Error("Passed is the platform's gate answer, and this gate blocks")
+	}
+	if got.Score != nil {
+		t.Errorf("there is no run-level score in platform mode, got %#v", got.Score)
+	}
+	if !got.Platform.HasGlobal || got.Platform.GlobalLetter != "B" || got.Platform.GlobalPoints != 83 {
+		t.Errorf("the headline is the platform's global score: %#v", got.Platform)
+	}
+	if len(got.Platform.Policies) != 2 {
+		t.Fatalf("one line per resolved policy: %#v", got.Platform.Policies)
+	}
+	byName := map[string]control.PlatformPolicyLine{}
+	for _, line := range got.Platform.Policies {
+		byName[line.Name] = line
+	}
+	if line := byName["Prod"]; !line.Blocking || line.Enforcement != "block" {
+		t.Errorf("Prod is the policy the platform blocks: %#v", line)
+	}
+	if line := byName["A"]; line.Blocking || line.Enforcement != "report" {
+		t.Errorf("A is reported, not blocking: %#v", line)
+	}
+}

--- a/cmd/platform_push.go
+++ b/cmd/platform_push.go
@@ -195,19 +195,22 @@ type platformScore struct {
 }
 
 // UnmarshalJSON decodes a score the PLATFORM sent (the push response's
-// global_score) tolerantly. Outgoing, this type is what the CLI writes and
-// the fields are exact; incoming, the numbers are the platform's own and it
-// types points as a NUMBER, so 60.5 is a legal value and letter can be null.
-// Decoded strictly, either one produced an UnmarshalTypeError on a field the
-// gate does not even read, and evaluatePlatformGate threw the whole response
-// away with it: the platform's blocking verdict silently became a fail-open,
-// on the one path that is now the only source of a non-zero exit in platform
-// mode (spec s4).
+// global_score). Outgoing, this type is what the CLI writes and the fields
+// are exact; incoming, the numbers are the platform's own and its contract
+// types points as a NUMBER, so 60.5 is a legal value and letter may be null.
+// Decoded into the int and string this struct declares, either one produced
+// an UnmarshalTypeError, and the caller threw the whole response away with
+// it, gate included: a blocking verdict became a fail-open over a field the
+// gate never reads (the review finding).
 //
-// Points is rounded with math.Round, the same rounding platformScoreFrom
-// applies on the way out, so a figure that makes the round trip is unchanged.
-// A field of an unexpected type is dropped rather than failing the decode:
-// the platform's verdict beside it is what matters.
+// So the tolerance is exactly this: any JSON number for the points (rounded
+// with math.Round, the same rounding platformScoreFrom applies on the way
+// out, so a figure that makes the round trip is unchanged), and a null or
+// absent letter. It is NOT "accept anything": a points value that is not a
+// number, or a letter that is not a string, fails the decode, and the caller
+// drops the score entirely rather than publishing a zero the platform never
+// sent. The gate beside it is decoded separately and strictly, so nothing
+// here can ever soften a verdict.
 func (s *platformScore) UnmarshalJSON(data []byte) error {
 	var raw struct {
 		Letter      any `json:"letter"`
@@ -217,33 +220,47 @@ func (s *platformScore) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-	if letter, ok := raw.Letter.(string); ok {
+	switch letter := raw.Letter.(type) {
+	case nil:
+	case string:
 		s.Letter = letter
+	default:
+		return fmt.Errorf("letter: want a string, got %T", raw.Letter)
 	}
-	s.Points = roundJSONScorePoints(raw.Points)
+	points, err := roundJSONScorePoints(raw.Points)
+	if err != nil {
+		return fmt.Errorf("points: %w", err)
+	}
+	s.Points = points
 	if raw.FinalPoints != nil {
-		final := roundJSONScorePoints(raw.FinalPoints)
+		final, err := roundJSONScorePoints(raw.FinalPoints)
+		if err != nil {
+			return fmt.Errorf("final_points: %w", err)
+		}
 		s.FinalPoints = &final
 	}
 	return nil
 }
 
 // roundJSONScorePoints reads a points figure out of a decoded JSON value in
-// whichever numeric shape it arrived in, and rounds it to the nearest
-// integer. Anything that is not a number is not a points figure and reads as
-// zero, which is what an absent field already meant.
-func roundJSONScorePoints(v any) int {
+// whichever numeric shape it arrived in and rounds it to the nearest integer.
+// An absent or null figure is zero, which is what the field's zero value
+// already meant; anything else is not a points figure at all and is an error,
+// because reporting it as zero would publish a score the platform never sent.
+func roundJSONScorePoints(v any) (int, error) {
 	switch n := v.(type) {
+	case nil:
+		return 0, nil
 	case float64:
-		return int(math.Round(n))
+		return int(math.Round(n)), nil
 	case json.Number:
 		f, err := n.Float64()
 		if err != nil {
-			return 0
+			return 0, err
 		}
-		return int(math.Round(f))
+		return int(math.Round(f)), nil
 	}
-	return 0
+	return 0, fmt.Errorf("want a number, got %T", v)
 }
 
 // platformScoreFrom converts the already-computed Plumber Score to the wire

--- a/cmd/platform_push.go
+++ b/cmd/platform_push.go
@@ -255,11 +255,25 @@ func platformPolicyNameFor(configPath string) string {
 //
 // configPath is the resolved config path the caller computed
 // (conf.ConfigFilePath, falling back to the --config flag); it names the
-// single policy of a STANDALONE push. In platform mode the results array
-// instead carries one entry per policy the platform resolved - see
-// buildPolicyResults, which owns that decision.
-func buildPlatformPush(p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult, score *control.PlumberScoreResult, configPath string) ([]byte, error) {
+// single policy of a STANDALONE push.
+//
+// runs are the evaluated platform policy runs (evaluatePlatformPolicies).
+// When there are any, the results array carries one entry per policy they
+// cover and nothing else - see buildPolicyResults, which owns that decision.
+// With none, this is a run that resolved no platform policy, and the push
+// keeps the single locally-named entry the CLI has always sent.
+func buildPlatformPush(p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult, score *control.PlumberScoreResult, configPath string, runs []policyRun) ([]byte, error) {
 	forgeHost, projectPath, _ := resolveScoreTarget(p, conf)
+
+	// The two branches are exclusive on purpose: a push built from the policy
+	// runs never touches the local configuration, and a standalone push never
+	// builds a per-policy entry.
+	var results []platformPolicyResult
+	if len(runs) > 0 {
+		results = buildPolicyResults(runs, p, conf)
+	} else {
+		results = []platformPolicyResult{standalonePolicyResult(p, conf, result, score, configPath)}
+	}
 
 	push := platformPush{
 		SchemaVersion: 1,
@@ -270,7 +284,7 @@ func buildPlatformPush(p providerPkg.Provider, conf *configuration.Configuration
 		Pipeline:      platformPipelineFor(p),
 		CLI:           platformCLI{Version: strings.TrimPrefix(Version, "v")},
 		Collection:    platformCollectionFor(conf, result),
-		Results:       buildPolicyResults(p, conf, result, score, configPath),
+		Results:       results,
 	}
 
 	body, err := json.Marshal(push)
@@ -539,10 +553,13 @@ func platformTokenFailure(reason string) error {
 // (falling back to the --config flag when conf is nil or has no resolved
 // path, e.g. in tests that call this directly); result and score are
 // threaded straight through so the platform, the terminal banner and the
-// JSON report can never disagree about a run's findings or score. Project
-// identity for the platform record is a separate matter and still comes from
-// the verified OIDC claims server-side, never from operator-supplied config.
-func maybePushPlatform(p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult, score *control.PlumberScoreResult) (*platformVerdict, error) {
+// JSON report can never disagree about a run's findings or score. runs are
+// the evaluated platform policy runs the push reports one entry per policy
+// for; none means a run with no resolved policy set, which pushes the single
+// locally-named entry. Project identity for the platform record is a separate
+// matter and still comes from the verified OIDC claims server-side, never
+// from operator-supplied config.
+func maybePushPlatform(p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult, score *control.PlumberScoreResult, runs []policyRun) (*platformVerdict, error) {
 	push, endpoint := effectivePlatformPush()
 	if !push {
 		return nil, nil
@@ -576,7 +593,7 @@ func maybePushPlatform(p providerPkg.Provider, conf *configuration.Configuration
 			configPath = resolved
 		}
 	}
-	body, err := buildPlatformPush(p, conf, result, score, configPath)
+	body, err := buildPlatformPush(p, conf, result, score, configPath, runs)
 	if err != nil {
 		scoreWarn(fmt.Sprintf("platform push skipped: %v", err))
 		return nil, nil

--- a/cmd/platform_push.go
+++ b/cmd/platform_push.go
@@ -530,20 +530,22 @@ func platformTokenFailure(reason string) error {
 	return &PlatformTokenError{Reason: reason}
 }
 
-// maybePushPlatform pushes the analysis result to the configured platform.
-// It returns non-nil ONLY for a token failure; see PlatformTokenError. conf
-// supplies the resolved config path/PlumberConfig/ProjectID/control filters
-// buildPlatformPush needs (falling back to the --config flag when conf is
-// nil or has no resolved path, e.g. in tests that call this directly);
-// result and score are threaded straight through so the platform, the
-// terminal banner and the JSON report can never disagree about a run's
-// findings or score. Project identity for the platform record is a separate
-// matter and still comes from the verified OIDC claims server-side, never
-// from operator-supplied config.
-func maybePushPlatform(p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult, score *control.PlumberScoreResult) error {
+// maybePushPlatform pushes the analysis result to the configured platform. It
+// returns a *platformVerdict for every reached push (fail-open branches carry
+// Unavailable and a nil error; a blocking gate carries the decoded verdict
+// together with a *PlatformGateError) and (nil, error) ONLY for a token
+// failure; see PlatformTokenError. conf supplies the resolved config
+// path/PlumberConfig/ProjectID/control filters buildPlatformPush needs
+// (falling back to the --config flag when conf is nil or has no resolved
+// path, e.g. in tests that call this directly); result and score are
+// threaded straight through so the platform, the terminal banner and the
+// JSON report can never disagree about a run's findings or score. Project
+// identity for the platform record is a separate matter and still comes from
+// the verified OIDC claims server-side, never from operator-supplied config.
+func maybePushPlatform(p providerPkg.Provider, conf *configuration.Configuration, result *control.AnalysisResult, score *control.PlumberScoreResult) (*platformVerdict, error) {
 	push, endpoint := effectivePlatformPush()
 	if !push {
-		return nil
+		return nil, nil
 	}
 
 	// Every failure to obtain the token fails the run, INCLUDING a transport
@@ -557,14 +559,14 @@ func maybePushPlatform(p providerPkg.Provider, conf *configuration.Configuration
 	// the pipeline should not be coupled to; the CI's token endpoint is not.
 	token, err := scoreOIDCToken(p, endpoint)
 	if err != nil {
-		return platformTokenFailure(fmt.Sprintf("could not mint the CI OIDC id-token for %s: %v", endpoint, err))
+		return nil, platformTokenFailure(fmt.Sprintf("could not mint the CI OIDC id-token for %s: %v", endpoint, err))
 	}
 	if token == "" {
 		switch {
 		case p.Name() == "github":
-			return platformTokenFailure("the workflow must grant `permissions: id-token: write` to push to the platform")
+			return nil, platformTokenFailure("the workflow must grant `permissions: id-token: write` to push to the platform")
 		default:
-			return platformTokenFailure("no CI OIDC id-token available for the platform push; the pipeline must declare the component's `id_tokens:` block (" + gitlabPlatformTokenEnv + ")")
+			return nil, platformTokenFailure("no CI OIDC id-token available for the platform push; the pipeline must declare the component's `id_tokens:` block (" + gitlabPlatformTokenEnv + ")")
 		}
 	}
 
@@ -577,7 +579,7 @@ func maybePushPlatform(p providerPkg.Provider, conf *configuration.Configuration
 	body, err := buildPlatformPush(p, conf, result, score, configPath)
 	if err != nil {
 		scoreWarn(fmt.Sprintf("platform push skipped: %v", err))
-		return nil
+		return nil, nil
 	}
 
 	// Every remote condition lands here, including 413 for an oversized body:
@@ -589,8 +591,9 @@ func maybePushPlatform(p providerPkg.Provider, conf *configuration.Configuration
 	// gate timeout knob exists.
 	respBody, statusCode, err := postScoreReportForBody(endpoint+"/api/v1/pushes", token, body)
 	if err != nil {
-		scoreWarn(fmt.Sprintf("%s: %v", platformGateFailOpenLine(statusCode), err))
-		return nil
+		line := platformGateFailOpenLine(statusCode)
+		scoreWarn(fmt.Sprintf("%s: %v", line, err))
+		return &platformVerdict{Unavailable: line}, nil
 	}
 	fmt.Fprintf(os.Stderr, "✓ Results pushed to the platform: %s\n", endpoint)
 	return evaluatePlatformGate(respBody)

--- a/cmd/platform_push.go
+++ b/cmd/platform_push.go
@@ -194,6 +194,58 @@ type platformScore struct {
 	FinalPoints *int   `json:"final_points,omitempty"`
 }
 
+// UnmarshalJSON decodes a score the PLATFORM sent (the push response's
+// global_score) tolerantly. Outgoing, this type is what the CLI writes and
+// the fields are exact; incoming, the numbers are the platform's own and it
+// types points as a NUMBER, so 60.5 is a legal value and letter can be null.
+// Decoded strictly, either one produced an UnmarshalTypeError on a field the
+// gate does not even read, and evaluatePlatformGate threw the whole response
+// away with it: the platform's blocking verdict silently became a fail-open,
+// on the one path that is now the only source of a non-zero exit in platform
+// mode (spec s4).
+//
+// Points is rounded with math.Round, the same rounding platformScoreFrom
+// applies on the way out, so a figure that makes the round trip is unchanged.
+// A field of an unexpected type is dropped rather than failing the decode:
+// the platform's verdict beside it is what matters.
+func (s *platformScore) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Letter      any `json:"letter"`
+		Points      any `json:"points"`
+		FinalPoints any `json:"final_points"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if letter, ok := raw.Letter.(string); ok {
+		s.Letter = letter
+	}
+	s.Points = roundJSONScorePoints(raw.Points)
+	if raw.FinalPoints != nil {
+		final := roundJSONScorePoints(raw.FinalPoints)
+		s.FinalPoints = &final
+	}
+	return nil
+}
+
+// roundJSONScorePoints reads a points figure out of a decoded JSON value in
+// whichever numeric shape it arrived in, and rounds it to the nearest
+// integer. Anything that is not a number is not a points figure and reads as
+// zero, which is what an absent field already meant.
+func roundJSONScorePoints(v any) int {
+	switch n := v.(type) {
+	case float64:
+		return int(math.Round(n))
+	case json.Number:
+		f, err := n.Float64()
+		if err != nil {
+			return 0
+		}
+		return int(math.Round(f))
+	}
+	return 0
+}
+
 // platformScoreFrom converts the already-computed Plumber Score to the wire
 // shape. Points is RawPointsUnclamped — the SIGNED deficit with no floor at
 // zero (the contract stores it unclamped; the gate/badge's floored-at-zero

--- a/cmd/platform_push_test.go
+++ b/cmd/platform_push_test.go
@@ -177,7 +177,7 @@ func TestBuildPublishPayload_GateAndBytes(t *testing.T) {
 // only way these failure modes, being silent or type-safe-in-isolation, are
 // actually caught.
 func TestBuildPlatformPush_KeysAreSnakeCaseAndPolicyIsAString(t *testing.T) {
-	body, err := buildPlatformPush(testProvider(t), nil, nil, nil, ".plumber.yaml")
+	body, err := buildPlatformPush(testProvider(t), nil, nil, nil, ".plumber.yaml", nil)
 	if err != nil {
 		t.Fatalf("buildPlatformPush: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestBuildPlatformPush_ScorePointsRoundToSignedInt(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			score := &control.PlumberScoreResult{Score: "E", RawPointsUnclamped: tc.raw}
-			body, err := buildPlatformPush(testProvider(t), nil, &control.AnalysisResult{}, score, ".plumber.yaml")
+			body, err := buildPlatformPush(testProvider(t), nil, &control.AnalysisResult{}, score, ".plumber.yaml", nil)
 			if err != nil {
 				t.Fatalf("buildPlatformPush: %v", err)
 			}
@@ -264,7 +264,7 @@ func TestBuildPlatformPush_ScoreFinalPointsOnWire(t *testing.T) {
 		{"zero final_points (malus floor)", &control.PlumberScoreResult{Score: "E", RawPointsUnclamped: -5, FinalPoints: 0}, 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			body, err := buildPlatformPush(testProvider(t), nil, &control.AnalysisResult{}, tc.score, ".plumber.yaml")
+			body, err := buildPlatformPush(testProvider(t), nil, &control.AnalysisResult{}, tc.score, ".plumber.yaml", nil)
 			if err != nil {
 				t.Fatalf("buildPlatformPush: %v", err)
 			}
@@ -395,7 +395,7 @@ func TestMaybePushPlatform_PolicyNameUsesResolvedConfigPathFromConf(t *testing.T
 	defer func() { configFile = origConfigFile }()
 
 	conf := &configuration.Configuration{ConfigFilePath: builtinDefaultConfigSource}
-	if _, err := maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, nil); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, nil, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 	var push platformPush
@@ -424,7 +424,7 @@ func TestMaybePushPlatform_PolicyNameFallsBackToConfigFlagWhenConfHasNoPath(t *t
 	configFile = "config/.plumber.strict.yaml"
 	defer func() { configFile = origConfigFile }()
 
-	if _, err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 	var push platformPush
@@ -460,7 +460,7 @@ func TestMaybePushPlatform_PostsThePush(t *testing.T) {
 		Findings: []opaengine.Finding{{Code: "ISSUE-101", Severity: "high", Message: "untrusted registry"}},
 	}
 	score := &control.PlumberScoreResult{Score: "B", RawPointsUnclamped: 82.5}
-	_, err := maybePushPlatform(testProvider(t), conf, result, score)
+	_, err := maybePushPlatform(testProvider(t), conf, result, score, nil)
 	if err != nil {
 		t.Fatalf("maybePushPlatform returned %v, want nil on a 202", err)
 	}
@@ -525,7 +525,7 @@ func TestMaybePushPlatform_FindingsCoverPassFailAndNotEvaluable(t *testing.T) {
 		// truly evaluated on this fixture (control/status.go StatusFor),
 		// giving a real not_evaluable case alongside the pass/fail ones.
 	}
-	if _, err := maybePushPlatform(testProvider(t), conf, result, &control.PlumberScoreResult{Score: "C"}); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), conf, result, &control.PlumberScoreResult{Score: "C"}, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 
@@ -647,7 +647,7 @@ func TestMaybePushPlatform_DismissedFindingWireShape(t *testing.T) {
 			{Code: "ISSUE-101", Severity: "high", Message: "untrusted registry", Job: "build", File: ".gitlab-ci.yml", Line: 4, Dismissed: true},
 		},
 	}
-	if _, err := maybePushPlatform(testProvider(t), conf, result, &control.PlumberScoreResult{Score: "C"}); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), conf, result, &control.PlumberScoreResult{Score: "C"}, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 
@@ -888,7 +888,7 @@ func TestMaybePushPlatform_SkippedControlIsOmittedFromFindings(t *testing.T) {
 		SkipControlsFilter: []string{"pipelineMustNotEnableDebugTrace"},
 	}
 	result := &control.AnalysisResult{CiValid: true}
-	if _, err := maybePushPlatform(testProvider(t), conf, result, nil); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), conf, result, nil, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 	var push platformPush
@@ -926,7 +926,7 @@ func TestMaybePushPlatform_NegativeScorePointsReachTheWire(t *testing.T) {
 	// 199.5, so the true value was -99.5 where the clamped RawPoints read 0.
 	// math.Round rounds half away from zero, so -99.5 -> -100.
 	score := &control.PlumberScoreResult{Score: "E", RawPointsUnclamped: -99.5}
-	if _, err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, score); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, score, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 	var push platformPush
@@ -950,7 +950,7 @@ func TestMaybePushPlatform_NilScoreDoesNotPanic(t *testing.T) {
 	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
 	defer restore()
 
-	if _, err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 }
@@ -974,7 +974,7 @@ func TestMaybePushPlatform_EffectiveConfigReflectsTheLoadedConfig(t *testing.T) 
 		ConfigFilePath: ".plumber.yaml",
 		PlumberConfig:  &configuration.PlumberConfig{Source: ".plumber.yaml", Raw: loaded},
 	}
-	if _, err := maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, nil); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, nil, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 	var push platformPush
@@ -1021,7 +1021,7 @@ func TestMaybePushPlatform_RemoteFailuresOnlyWarn(t *testing.T) {
 
 			var err error
 			out := captureStderr(t, func() {
-				_, err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
+				_, err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil, nil)
 			})
 			if err != nil {
 				t.Errorf("status %d returned %v, want nil: a remote condition must not fail the run", status, err)
@@ -1046,7 +1046,7 @@ func TestMaybePushPlatform_UnreachableOnlyWarns(t *testing.T) {
 
 	var err error
 	out := captureStderr(t, func() {
-		_, err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil, nil)
 	})
 	if err != nil {
 		t.Errorf("unreachable platform returned %v, want nil", err)
@@ -1062,7 +1062,7 @@ func TestMaybePushPlatform_MissingTokenFailsWithActionableMessage(t *testing.T) 
 	restore := withPlatformTestEnv(t, "https://app.example.com", "")
 	defer restore()
 
-	_, err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
+	_, err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil, nil)
 	if err == nil {
 		t.Fatal("missing id-token returned nil, want an error: a silently skipped push is the failure mode this prevents")
 	}
@@ -1094,7 +1094,7 @@ func TestMaybePushPlatform_GitHubMissingGrantFailsWithActionableMessage(t *testi
 	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "")
 	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "")
 
-	_, err := maybePushPlatform(p, nil, &control.AnalysisResult{}, nil)
+	_, err := maybePushPlatform(p, nil, &control.AnalysisResult{}, nil, nil)
 	if err == nil {
 		t.Fatal("missing GitHub id-token grant returned nil, want an error: a silently skipped push is the failure mode this prevents")
 	}
@@ -1131,7 +1131,7 @@ func TestMaybePushPlatform_GitHubTokenMintFailureReturnsPlatformTokenError(t *te
 	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", mint.URL)
 	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "req-token")
 
-	_, err := maybePushPlatform(p, nil, &control.AnalysisResult{}, nil)
+	_, err := maybePushPlatform(p, nil, &control.AnalysisResult{}, nil, nil)
 	if err == nil {
 		t.Fatal("a failed token mint returned nil, want a *PlatformTokenError: the run must not proceed as if the push were merely skipped")
 	}
@@ -1160,7 +1160,7 @@ func TestMaybePushPlatform_SendsCollectionDegradedMarker(t *testing.T) {
 		DataCollectionDegraded: true,
 		DegradedReasons:        []string{"pipeline configuration could not be fetched (network or timeout)"},
 	}
-	if _, err := maybePushPlatform(testProvider(t), nil, result, nil); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), nil, result, nil, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 	var push platformPush
@@ -1231,7 +1231,7 @@ func TestMaybePushPlatform_TokenFailureIsAnnouncedNotOnlyReturned(t *testing.T) 
 
 	var err error
 	out := captureStderr(t, func() {
-		_, err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil, nil)
 	})
 
 	if err == nil {
@@ -1314,7 +1314,7 @@ func TestBuildPlatformPush_GitLabCIIdentityValuesReachTheWire(t *testing.T) {
 	t.Setenv("CI_JOB_ID", "job-gl-444")
 	t.Setenv("CI_PROJECT_ID", "proj-gl-555")
 
-	body, err := buildPlatformPush(p, nil, &control.AnalysisResult{}, nil, ".plumber.yaml")
+	body, err := buildPlatformPush(p, nil, &control.AnalysisResult{}, nil, ".plumber.yaml", nil)
 	if err != nil {
 		t.Fatalf("buildPlatformPush: %v", err)
 	}
@@ -1358,7 +1358,7 @@ func TestBuildPlatformPush_GitHubCIIdentityValuesReachTheWire(t *testing.T) {
 	t.Setenv("GITHUB_RUN_ID", "run-gh-333")
 	t.Setenv("GITHUB_JOB", "job-gh-444")
 
-	body, err := buildPlatformPush(p, nil, &control.AnalysisResult{}, nil, ".plumber.yaml")
+	body, err := buildPlatformPush(p, nil, &control.AnalysisResult{}, nil, ".plumber.yaml", nil)
 	if err != nil {
 		t.Fatalf("buildPlatformPush: %v", err)
 	}

--- a/cmd/platform_push_test.go
+++ b/cmd/platform_push_test.go
@@ -395,7 +395,7 @@ func TestMaybePushPlatform_PolicyNameUsesResolvedConfigPathFromConf(t *testing.T
 	defer func() { configFile = origConfigFile }()
 
 	conf := &configuration.Configuration{ConfigFilePath: builtinDefaultConfigSource}
-	if err := maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, nil); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 	var push platformPush
@@ -424,7 +424,7 @@ func TestMaybePushPlatform_PolicyNameFallsBackToConfigFlagWhenConfHasNoPath(t *t
 	configFile = "config/.plumber.strict.yaml"
 	defer func() { configFile = origConfigFile }()
 
-	if err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 	var push platformPush
@@ -460,7 +460,7 @@ func TestMaybePushPlatform_PostsThePush(t *testing.T) {
 		Findings: []opaengine.Finding{{Code: "ISSUE-101", Severity: "high", Message: "untrusted registry"}},
 	}
 	score := &control.PlumberScoreResult{Score: "B", RawPointsUnclamped: 82.5}
-	err := maybePushPlatform(testProvider(t), conf, result, score)
+	_, err := maybePushPlatform(testProvider(t), conf, result, score)
 	if err != nil {
 		t.Fatalf("maybePushPlatform returned %v, want nil on a 202", err)
 	}
@@ -525,7 +525,7 @@ func TestMaybePushPlatform_FindingsCoverPassFailAndNotEvaluable(t *testing.T) {
 		// truly evaluated on this fixture (control/status.go StatusFor),
 		// giving a real not_evaluable case alongside the pass/fail ones.
 	}
-	if err := maybePushPlatform(testProvider(t), conf, result, &control.PlumberScoreResult{Score: "C"}); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), conf, result, &control.PlumberScoreResult{Score: "C"}); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 
@@ -647,7 +647,7 @@ func TestMaybePushPlatform_DismissedFindingWireShape(t *testing.T) {
 			{Code: "ISSUE-101", Severity: "high", Message: "untrusted registry", Job: "build", File: ".gitlab-ci.yml", Line: 4, Dismissed: true},
 		},
 	}
-	if err := maybePushPlatform(testProvider(t), conf, result, &control.PlumberScoreResult{Score: "C"}); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), conf, result, &control.PlumberScoreResult{Score: "C"}); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 
@@ -888,7 +888,7 @@ func TestMaybePushPlatform_SkippedControlIsOmittedFromFindings(t *testing.T) {
 		SkipControlsFilter: []string{"pipelineMustNotEnableDebugTrace"},
 	}
 	result := &control.AnalysisResult{CiValid: true}
-	if err := maybePushPlatform(testProvider(t), conf, result, nil); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), conf, result, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 	var push platformPush
@@ -926,7 +926,7 @@ func TestMaybePushPlatform_NegativeScorePointsReachTheWire(t *testing.T) {
 	// 199.5, so the true value was -99.5 where the clamped RawPoints read 0.
 	// math.Round rounds half away from zero, so -99.5 -> -100.
 	score := &control.PlumberScoreResult{Score: "E", RawPointsUnclamped: -99.5}
-	if err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, score); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, score); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 	var push platformPush
@@ -950,7 +950,7 @@ func TestMaybePushPlatform_NilScoreDoesNotPanic(t *testing.T) {
 	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
 	defer restore()
 
-	if err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 }
@@ -974,7 +974,7 @@ func TestMaybePushPlatform_EffectiveConfigReflectsTheLoadedConfig(t *testing.T) 
 		ConfigFilePath: ".plumber.yaml",
 		PlumberConfig:  &configuration.PlumberConfig{Source: ".plumber.yaml", Raw: loaded},
 	}
-	if err := maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, nil); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), conf, &control.AnalysisResult{}, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 	var push platformPush
@@ -1021,7 +1021,7 @@ func TestMaybePushPlatform_RemoteFailuresOnlyWarn(t *testing.T) {
 
 			var err error
 			out := captureStderr(t, func() {
-				err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
+				_, err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
 			})
 			if err != nil {
 				t.Errorf("status %d returned %v, want nil: a remote condition must not fail the run", status, err)
@@ -1046,7 +1046,7 @@ func TestMaybePushPlatform_UnreachableOnlyWarns(t *testing.T) {
 
 	var err error
 	out := captureStderr(t, func() {
-		err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
 	})
 	if err != nil {
 		t.Errorf("unreachable platform returned %v, want nil", err)
@@ -1062,7 +1062,7 @@ func TestMaybePushPlatform_MissingTokenFailsWithActionableMessage(t *testing.T) 
 	restore := withPlatformTestEnv(t, "https://app.example.com", "")
 	defer restore()
 
-	err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
+	_, err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
 	if err == nil {
 		t.Fatal("missing id-token returned nil, want an error: a silently skipped push is the failure mode this prevents")
 	}
@@ -1094,7 +1094,7 @@ func TestMaybePushPlatform_GitHubMissingGrantFailsWithActionableMessage(t *testi
 	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "")
 	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "")
 
-	err := maybePushPlatform(p, nil, &control.AnalysisResult{}, nil)
+	_, err := maybePushPlatform(p, nil, &control.AnalysisResult{}, nil)
 	if err == nil {
 		t.Fatal("missing GitHub id-token grant returned nil, want an error: a silently skipped push is the failure mode this prevents")
 	}
@@ -1131,7 +1131,7 @@ func TestMaybePushPlatform_GitHubTokenMintFailureReturnsPlatformTokenError(t *te
 	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", mint.URL)
 	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "req-token")
 
-	err := maybePushPlatform(p, nil, &control.AnalysisResult{}, nil)
+	_, err := maybePushPlatform(p, nil, &control.AnalysisResult{}, nil)
 	if err == nil {
 		t.Fatal("a failed token mint returned nil, want a *PlatformTokenError: the run must not proceed as if the push were merely skipped")
 	}
@@ -1160,7 +1160,7 @@ func TestMaybePushPlatform_SendsCollectionDegradedMarker(t *testing.T) {
 		DataCollectionDegraded: true,
 		DegradedReasons:        []string{"pipeline configuration could not be fetched (network or timeout)"},
 	}
-	if err := maybePushPlatform(testProvider(t), nil, result, nil); err != nil {
+	if _, err := maybePushPlatform(testProvider(t), nil, result, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
 	}
 	var push platformPush
@@ -1231,7 +1231,7 @@ func TestMaybePushPlatform_TokenFailureIsAnnouncedNotOnlyReturned(t *testing.T) 
 
 	var err error
 	out := captureStderr(t, func() {
-		err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
+		_, err = maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil)
 	})
 
 	if err == nil {

--- a/cmd/platform_push_test.go
+++ b/cmd/platform_push_test.go
@@ -137,7 +137,7 @@ func TestBuildPublishPayload_GateAndBytes(t *testing.T) {
 		}
 		want, err := buildAnalysisJSONReport(result, conf.PlumberConfig, summary, jsonOutputParams{
 			provider: prov.Name(), includeOnly: conf.ControlsFilter, skip: conf.SkipControlsFilter,
-		})
+		}, nil, nil)
 		if err != nil {
 			t.Fatalf("buildAnalysisJSONReport: %v", err)
 		}

--- a/cmd/platform_push_test.go
+++ b/cmd/platform_push_test.go
@@ -19,6 +19,7 @@ import (
 	defaultconfig "github.com/getplumber/plumber/defaultConfig"
 	"github.com/getplumber/plumber/finding/identity"
 	opaengine "github.com/getplumber/plumber/internal/engine/opa"
+	"github.com/getplumber/plumber/internal/ir"
 	"github.com/getplumber/plumber/internal/platform"
 	providerPkg "github.com/getplumber/plumber/provider"
 )
@@ -702,46 +703,85 @@ func (s stubRunProvider) Run(*configuration.Configuration) (*control.AnalysisRes
 	return s.result, nil
 }
 
+// dismissalPolicy is the resolved policy this test's runs are evaluated under: one real policy
+// declaring containerImageMustComeFromAuthorizedSources with a trusted list the fixture image
+// does not match, so the control produces exactly one live ISSUE-101.
+//
+// A resolved policy is required, not decoration: in platform mode a run that resolves NONE
+// evaluates nothing and never reaches the push (runPlatformMode), so a context carrying only a
+// dismissed list would assert against a push that was never sent.
+func dismissalPolicy() platform.Policy {
+	return policyWithTree("Images", "containerImageMustComeFromAuthorizedSources",
+		`{"enabled":true,"trustedUrls":["registry.example.com/*"],"includePlumberDefaults":false}`)
+}
+
+// imageResult is a collected GitLab run whose RETAINED IR carries one job pulling from the given
+// registry. Re-evaluated under dismissalPolicy it produces one ISSUE-101 for an untrusted
+// registry and none for the trusted one, which is what makes the dismissal's effect on the score
+// observable.
+func imageResult(registry string) *control.AnalysisResult {
+	return &control.AnalysisResult{
+		CiValid:     true,
+		ProjectPath: "grp/app",
+		Pipeline: &ir.NormalizedPipeline{
+			Provider:      ir.ProviderGitLab,
+			ProjectPath:   "grp/app",
+			DefaultBranch: "main",
+			Jobs: []ir.Job{{
+				Name:       "build",
+				OriginFile: ".gitlab-ci.yml",
+				Image:      &ir.Image{Registry: registry, Name: "app", Tag: "1"},
+			}},
+		},
+	}
+}
+
 // TestSharedPipeline_ServedDismissalMarksThePushAndLeavesTheScore pins the run-level half of #447,
-// which the wire-shape test above does not reach: nothing on the shared pipeline marks a finding
-// except the single markPlatformDismissedFindings call inside finalizeFindings, between
-// StampFingerprints and buildComplianceSummary. Drop it and a run pushes a served dismissal as a
-// live finding and scores it, with every unit test still green.
+// which the wire-shape test above does not reach: on the shared pipeline a served dismissal must
+// reach the pushed entry as "dismissed":true and cost the score nothing. Drop the marking on
+// either path and a run pushes a served dismissal as a live finding and scores it, with every
+// unit test still green.
 //
 // Both production entry points are driven, because platform mode is not symmetric between them:
 // presentResultWithProvider serves the GitHub paths, while runWithProvider is GitLab's and is the
-// one path where platform mode actually operates. They share finalizeFindings, and this test is
-// what says so - a copy of the sequence in either of them, minus a step, fails here.
+// one path where platform mode actually operates. They share finalizeFindings and the
+// platform-mode tail it hands to (continueRun), and this test is what says so - a copy of the
+// sequence in either of them, minus a step, fails here.
 //
 // The served entry is built the way the platform builds it: the identity hash of the finding as it
 // exists AFTER fingerprint stamping, under the current recipe version, keyed by the finding's
-// control. Both halves of the claim are asserted on the SAME run: the captured push body carries
-// "dismissed":true on that entry, and the score the run computed is the score of a run with no
-// such finding at all.
+// control. It is derived by a probe evaluation through the very helpers production uses
+// (policyConfigFromTree + control.ReEvaluateForConfig) rather than hand-written, so the fixture
+// cannot drift away from the identity the run actually computes. Both halves of the claim are
+// asserted on the SAME run: the captured push body carries "dismissed":true on that entry, and the
+// score the run computed is the score of a run with no such finding at all.
 func TestSharedPipeline_ServedDismissalMarksThePushAndLeavesTheScore(t *testing.T) {
 	origPrint := printOutput
 	printOutput = false // the terminal report is not under test
 	defer func() { printOutput = origPrint }()
 	newGateFlagsCmd(t) // reset gate globals: default points gate (min-points 100)
 
-	// The same fixture the wire-shape test uses: ISSUE-101 belongs to
-	// containerImageMustComeFromAuthorizedSources, which the shipped default config enables, so
-	// this is a fail finding a real run of that config produces, and it costs the score real
-	// points.
-	failFinding := func() opaengine.Finding {
-		return opaengine.Finding{Code: "ISSUE-101", Severity: "high", Message: "untrusted registry", Job: "build", File: ".gitlab-ci.yml", Line: 4}
+	// The probe: evaluate the fixture under the policy exactly as the run will, and read the
+	// identity of the finding it produces. That is the identity the platform would have hashed.
+	probeCfg, err := policyConfigFromTree("gitlab", dismissalPolicy())
+	if err != nil {
+		t.Fatalf("assembling the policy config: %v", err)
 	}
-
-	stamped := []opaengine.Finding{failFinding()}
-	opaengine.StampFingerprints(stamped, "")
-	hash, _, ok := identity.PlatformHash(stamped[0].IdentityInput())
+	probe, _, ok := control.ReEvaluateForConfig(imageResult("evil.registry.io"), confWithPolicies(t, dismissalPolicy()), "gitlab", probeCfg)
+	if !ok {
+		t.Fatal("the fixture has no retained IR: nothing could be re-evaluated per policy")
+	}
+	if len(probe.Findings) != 1 || probe.Findings[0].Code != "ISSUE-101" {
+		t.Fatalf("want exactly one ISSUE-101 from the untrusted image, got %+v", probe.Findings)
+	}
+	hash, _, ok := identity.PlatformHash(probe.Findings[0].IdentityInput())
 	if !ok {
 		t.Fatal("the fixture finding has no platform identity, so no served dismissal could ever match it")
 	}
 	served := platform.DismissedIssue{
 		IdentityHash:  hash,
 		RecipeVersion: identity.RecipeVersion,
-		ControlType:   control.ControlKeyFor(stamped[0].Code),
+		ControlType:   control.ControlKeyFor(probe.Findings[0].Code),
 	}
 
 	// dismissedKeyFor reads the marker off the raw wire bytes rather than through platformFinding,
@@ -801,7 +841,7 @@ func TestSharedPipeline_ServedDismissalMarksThePushAndLeavesTheScore(t *testing.
 			// score that same run computed. A context with no policies pushes the single
 			// locally-named entry, so the assertions read one result rather than one per policy;
 			// the served dismissed list is the only variable.
-			run := func(t *testing.T, findings []opaengine.Finding, dismissed []platform.DismissedIssue) ([]byte, int) {
+			run := func(t *testing.T, registry string, dismissed []platform.DismissedIssue) ([]byte, int) {
 				t.Helper()
 				var gotBody []byte
 				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -815,17 +855,20 @@ func TestSharedPipeline_ServedDismissalMarksThePushAndLeavesTheScore(t *testing.
 				conf := configuration.NewDefaultConfiguration()
 				conf.ConfigFilePath = ".plumber.yaml"
 				conf.PlumberConfig = testDefaultPlumberConfig(t)
-				conf.PlatformRun = &platform.RunContext{
-					Endpoint: srv.URL,
-					Context:  &platform.ProjectContext{DismissedIssues: dismissed},
-				}
+				// runContextWith supplies the resolved-and-valid config resolution the
+				// probe used. It is load bearing: with no resolution the lane-gap rule
+				// marks every pipeline control not_evaluable and drops its findings, so
+				// the fixture violation would vanish and the test would compare two
+				// perfect scores (it did, before this line).
+				conf.PlatformRun = runContextWith(dismissalPolicy())
+				conf.PlatformRun.Endpoint = srv.URL
+				conf.PlatformRun.Context.DismissedIssues = dismissed
 
-				// The returned error is the gate verdict, which is not what this test reads: a
-				// live high finding fails the default points gate and the same finding dismissed
-				// does not. That difference is asserted on the pushed score below, which is the
-				// score itself rather than a proxy for it.
+				// The returned error is the gate verdict, which is not what this test reads: the
+				// difference the dismissal makes is asserted on the pushed score below, which is
+				// the score itself rather than a proxy for it.
 				_ = captureStderr(t, func() {
-					entry.drive(t, testProvider(t), conf, &control.AnalysisResult{CiValid: true, Findings: findings})
+					entry.drive(t, testProvider(t), conf, imageResult(registry))
 				})
 
 				if len(gotBody) == 0 {
@@ -841,16 +884,19 @@ func TestSharedPipeline_ServedDismissalMarksThePushAndLeavesTheScore(t *testing.
 				return gotBody, push.Results[0].Score.Points
 			}
 
-			servedBody, servedPoints := run(t, []opaengine.Finding{failFinding()}, []platform.DismissedIssue{served})
-			liveBody, livePoints := run(t, []opaengine.Finding{failFinding()}, nil)
-			_, cleanPoints := run(t, nil, nil)
+			// The clean run swaps the registry for the one the policy trusts, so the control
+			// produces no finding at all: the same policy, the same pipeline shape, and the
+			// only difference is whether the finding exists.
+			servedBody, servedPoints := run(t, "evil.registry.io", []platform.DismissedIssue{served})
+			liveBody, livePoints := run(t, "evil.registry.io", nil)
+			_, cleanPoints := run(t, "registry.example.com", nil)
 
 			val, present, found := dismissedKeyFor(t, servedBody, dismissedControl)
 			if !found {
 				t.Fatalf("control %q is absent from the pushed findings: the served dismissal must be pushed, not withheld", dismissedControl)
 			}
 			if b, ok := val.(bool); !present || !ok || !b {
-				t.Errorf("dismissed = %v (present=%v), want \"dismissed\":true: markPlatformDismissedFindings must run on this entry point's pipeline", val, present)
+				t.Errorf("dismissed = %v (present=%v), want \"dismissed\":true: the served dismissal must be marked on this entry point's pipeline", val, present)
 			}
 
 			if _, present, found := dismissedKeyFor(t, liveBody, dismissedControl); !found || present {
@@ -1257,9 +1303,13 @@ func TestPresentResultWithProvider_ThreadsPlatformErrIntoTheExitCode(t *testing.
 	defer func() { printOutput = origPrint }()
 	newGateFlagsCmd(t) // reset gate globals: default points gate (min-points 100)
 
-	// A clean result with one enabled control scores 100 and passes the gate,
-	// so the ONLY thing deciding the returned error is the platform push.
-	conf := confWithDebugTrace()
+	// Platform mode makes every local gate inert, so the ONLY thing deciding
+	// the returned error is the platform push. The context carries one
+	// resolved policy against a result with retained IR, because a run that
+	// resolves NO policy evaluates nothing and never reaches the push
+	// (runPlatformMode) - the token guarantee is about a run that had
+	// something to send.
+	conf := confWithPolicies(t, policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig))
 
 	t.Run("missing id-token fails the run", func(t *testing.T) {
 		restore := withPlatformTestEnv(t, "https://app.example.com", "")
@@ -1267,7 +1317,7 @@ func TestPresentResultWithProvider_ThreadsPlatformErrIntoTheExitCode(t *testing.
 
 		var err error
 		_ = captureStderr(t, func() {
-			err = presentResultWithProvider(testProvider(t), nil, &control.AnalysisResult{CiValid: true}, conf)
+			err = presentResultWithProvider(testProvider(t), nil, debugTraceResult(), conf)
 		})
 
 		var tokenErr *PlatformTokenError
@@ -1285,7 +1335,7 @@ func TestPresentResultWithProvider_ThreadsPlatformErrIntoTheExitCode(t *testing.
 
 		var err error
 		_ = captureStderr(t, func() {
-			err = presentResultWithProvider(testProvider(t), nil, &control.AnalysisResult{CiValid: true}, conf)
+			err = presentResultWithProvider(testProvider(t), nil, debugTraceResult(), conf)
 		})
 
 		if err != nil {

--- a/cmd/platform_render.go
+++ b/cmd/platform_render.go
@@ -112,6 +112,16 @@ func renderPolicySections(p providerPkg.Provider, conf *configuration.Configurat
 func renderPlatformVerdict(runs []policyRun, v *platformVerdict, exitErr error) {
 	fmt.Println()
 	if v == nil || v.Gate == nil {
+		// A verdict that is missing BECAUSE something failed is not a
+		// fail-open: maybePushPlatform returns a *PlatformTokenError when the
+		// CI OIDC grant is broken, classifyExecError exits 2 on it, and a
+		// line promising "fail-open, exit 0" would contradict the process's
+		// own exit code in the log the operator reads to diagnose it. State
+		// that no verdict was obtained, and let the error say why.
+		if exitErr != nil {
+			fmt.Printf("Platform verdict: not obtained (%v)\n", exitErr)
+			return
+		}
 		// Invariant 5: no usable gate lets the run through, and says so
 		// in plain words rather than passing silently.
 		reason := "no push"

--- a/cmd/platform_render.go
+++ b/cmd/platform_render.go
@@ -136,6 +136,16 @@ func renderPlatformVerdict(runs []policyRun, v *platformVerdict, exitErr error) 
 		fmt.Printf("  Global score (platform): %s  %d / 100 pts\n", v.GlobalScore.Letter, v.GlobalScore.Points)
 	}
 	if exitErr != nil {
+		// The top-level Blocking flag is the platform's decision and does
+		// not structurally guarantee a non-empty per-policy subset (a
+		// run-level reason, or a shape this CLI predates). With no name to
+		// print, the line falls back to the gate's own reason through the
+		// same chain the job-log line uses, rather than rendering a bare
+		// "Exit 1:  blocks" that says nothing at all.
+		if len(blocking) == 0 {
+			fmt.Printf("  Exit 1: %s\n", platformGateDetail(nil, v.Gate.Reason))
+			return
+		}
 		fmt.Printf("  Exit 1: %s blocks\n", strings.Join(blocking, ", "))
 		return
 	}

--- a/cmd/platform_render.go
+++ b/cmd/platform_render.go
@@ -59,6 +59,11 @@ func equalMinPoints(a, b *int) bool {
 // that outranks the policies, --no-controls, which is a request for no
 // verdict at all and must not be turned into a scored, published section
 // (see providerControlEntries).
+//
+// That guard is defence in depth rather than the live path: continueRun sends
+// a --no-controls run down the non-platform branch, which never renders a
+// policy section at all. It stays because "no verdict was requested" must not
+// depend on which caller happens to be in front of this function.
 func renderPolicySections(p providerPkg.Provider, conf *configuration.Configuration, runs []policyRun, controlsFilterList, skipControlsList []string) {
 	noControls := conf != nil && conf.NoControls
 	for _, r := range runs {

--- a/cmd/platform_render.go
+++ b/cmd/platform_render.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/internal/platform"
+	providerPkg "github.com/getplumber/plumber/provider"
+)
+
+// policyHeader renders "== Policy: A, B  [report]" or "[block, min_points
+// 80]". When the group's policies differ in enforcement or min_points, each
+// policy gets its own bracket after its name: one bracket for the whole
+// group would state the wrong enforcement for half of it.
+func policyHeader(r policyRun) string {
+	if len(r.Policies) == 0 {
+		return "== Policy:"
+	}
+	same := true
+	for _, p := range r.Policies[1:] {
+		if p.Enforcement != r.Policies[0].Enforcement || !equalMinPoints(p.MinPoints, r.Policies[0].MinPoints) {
+			same = false
+		}
+	}
+	if same {
+		return fmt.Sprintf("== Policy: %s  %s", r.Names(), enforcementBracket(r.Policies[0]))
+	}
+	parts := make([]string, 0, len(r.Policies))
+	for _, p := range r.Policies {
+		parts = append(parts, p.Name+" "+enforcementBracket(p))
+	}
+	return "== Policy: " + strings.Join(parts, ", ")
+}
+
+func enforcementBracket(p platform.Policy) string {
+	if p.MinPoints != nil {
+		return fmt.Sprintf("[%s, min_points %d]", p.Enforcement, *p.MinPoints)
+	}
+	return fmt.Sprintf("[%s]", p.Enforcement)
+}
+
+func equalMinPoints(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+// renderPolicySections prints one section per evaluated run (spec s3): the
+// header, the control blocks today's report prints (passed, skipped, not
+// evaluated, failed), the issues table, and the run's own score banner. A run
+// that was not applied prints its reason and no banner: an empty verdict
+// would read as a policy that found nothing wrong.
+//
+// Everything a section prints comes from the RUN (r.Result, r.Config,
+// r.Score), never from conf's local configuration: that separation is the
+// whole point of the mode (spec s2). conf is read for the one run-level fact
+// that outranks the policies, --no-controls, which is a request for no
+// verdict at all and must not be turned into a scored, published section
+// (see providerControlEntries).
+func renderPolicySections(p providerPkg.Provider, conf *configuration.Configuration, runs []policyRun, controlsFilterList, skipControlsList []string) {
+	noControls := conf != nil && conf.NoControls
+	for _, r := range runs {
+		fmt.Println()
+		fmt.Println(policyHeader(r))
+		if r.Derived {
+			fmt.Println("  (the platform has no policy for this project: the embedded default configuration is evaluated under this name)")
+		}
+		if !r.Applied {
+			fmt.Printf("  %s, nothing evaluated\n", r.Reason)
+			continue
+		}
+		if r.Reason == reasonNoControls {
+			fmt.Println("  declares no controls, nothing evaluated")
+		}
+		var controls []controlSummary
+		var groups []findingGroup
+		// Under --no-controls nothing was selected, so listing every
+		// control as "skipped" is noise that reads like a
+		// misconfiguration, and the banner is withheld rather than
+		// stamping a perfect score on a run that evaluated nothing.
+		if !noControls {
+			controls, groups = buildProviderControlSummariesAndGroups(p, r.Result, r.Config, controlsFilterList, skipControlsList)
+		}
+		renderFindingGroups(filterGroupsForDegraded(groups, r.Result.DataCollectionDegraded))
+		if n := countNotEvaluated(groups); n > 0 {
+			fmt.Printf("  %s⚠️  %d control(s) could not be evaluated, the score below is computed over the rest%s\n\n", colorYellow, n, colorReset)
+		}
+		// On a degraded run an empty issues table would imply a clean
+		// pipeline we never evaluated (#220), and under --no-controls it
+		// would read as a clean scan.
+		if (!r.Result.DataCollectionDegraded || len(r.Result.Findings) > 0) && !noControls {
+			printIssuesTable(controls)
+			fmt.Println()
+		}
+		printSummaryScoreBanner(r.Score, !noControls, r.Result.DataCollectionDegraded)
+	}
+}
+
+// renderPlatformVerdict prints the block built from the push response (spec
+// s3): one line per policy the platform gated, with the reason rendered from
+// the policy's enforcement, its min_points and this run's own final points,
+// then the platform's global score, then the exit line. The exit code is the
+// platform's verdict, never a local recomputation, so exitErr (what
+// evaluatePlatformGate returned) is what decides the last line.
+func renderPlatformVerdict(runs []policyRun, v *platformVerdict, exitErr error) {
+	fmt.Println()
+	if v == nil || v.Gate == nil {
+		// Invariant 5: no usable gate lets the run through, and says so
+		// in plain words rather than passing silently.
+		reason := "no push"
+		if v != nil && v.Unavailable != "" {
+			reason = v.Unavailable
+		}
+		fmt.Printf("Platform verdict: unavailable (%s), fail-open, exit 0\n", reason)
+		return
+	}
+	fmt.Println("== Platform verdict")
+	width := 0
+	for _, gp := range v.Gate.Policies {
+		if len(gp.Name) > width {
+			width = len(gp.Name)
+		}
+	}
+	blocking := make([]string, 0, len(v.Gate.Policies))
+	for _, gp := range v.Gate.Policies {
+		status := "not blocking"
+		if gp.Blocking {
+			status = "BLOCKING" + blockingReason(runs, gp)
+			blocking = append(blocking, gp.Name)
+		}
+		fmt.Printf("  %-*s   %-6s   %s\n", width, gp.Name, gp.Enforcement, status)
+	}
+	if v.GlobalScore != nil {
+		fmt.Printf("  Global score (platform): %s  %d / 100 pts\n", v.GlobalScore.Letter, v.GlobalScore.Points)
+	}
+	if exitErr != nil {
+		fmt.Printf("  Exit 1: %s blocks\n", strings.Join(blocking, ", "))
+		return
+	}
+	fmt.Println("  Exit 0")
+}
+
+// blockingReason renders " (66 < min_points 80)" for a policy the platform
+// gates on a threshold, and " (N live failures)" otherwise. The points are
+// this run's own recomputed final points for that policy, which is what the
+// sections above printed: the line explains the platform's verdict in the
+// numbers the reader just saw.
+func blockingReason(runs []policyRun, gp platformGatePolicy) string {
+	for _, r := range runs {
+		for _, p := range r.Policies {
+			if p.ID != gp.ID {
+				continue
+			}
+			if p.MinPoints != nil && r.Score != nil {
+				return fmt.Sprintf(" (%.0f < min_points %d)", r.Score.FinalPoints, *p.MinPoints)
+			}
+		}
+	}
+	return fmt.Sprintf(" (%d live failures)", gp.LiveFailCount)
+}
+
+// renderNothingEvaluated is the whole report of a platform-mode run that
+// resolved no policy (unreachable platform, or none assigned): one line
+// (spec s3). It never prints a score or a status, because nothing was
+// evaluated and a verdict here would be invented.
+func renderNothingEvaluated(rc *platform.RunContext) {
+	reason := "no policy assigned"
+	if rc != nil && rc.ContextErr != nil {
+		reason = rc.ContextErr.Error()
+	}
+	endpoint, project := "", ""
+	if rc != nil {
+		endpoint, project = rc.Endpoint, rc.ProjectPath
+	}
+	fmt.Printf("  linked to %s: no policy resolved for %s (%s), nothing evaluated, exit 0\n", endpoint, project, reason)
+}

--- a/cmd/platform_render_test.go
+++ b/cmd/platform_render_test.go
@@ -206,6 +206,27 @@ func TestRenderPlatformVerdict_NoBlockExitZero(t *testing.T) {
 	assertContains(t, out, "  Exit 0\n")
 }
 
+// A gate that blocks the run without marking any single policy blocking (a
+// run-level reason, or a shape this CLI predates) must still say WHY: the
+// exit line falls back to the gate's own reason rather than printing
+// "Exit 1:  blocks" with an empty name list. Same fallback chain the job-log
+// line uses (platformGateDetail).
+func TestRenderPlatformVerdict_BlockingWithNoBlockingPolicyFallsBackToTheReason(t *testing.T) {
+	v := &platformVerdict{Gate: &platformGate{
+		Evaluated: true,
+		Blocking:  true,
+		Reason:    "the project exceeded its live-failure budget",
+		Policies:  []platformGatePolicy{{ID: "p1", Name: "Only", Enforcement: "report"}},
+	}}
+
+	out := captureStdoutAll(t, func() { renderPlatformVerdict(nil, v, &PlatformGateError{Reason: v.Gate.Reason}) })
+
+	assertContains(t, out, "  Exit 1: the project exceeded its live-failure budget\n")
+	if strings.Contains(out, "Exit 1:  blocks") {
+		t.Fatal("an empty blocking-policy list must never render as a bare \"Exit 1:  blocks\"")
+	}
+}
+
 // Invariant 5: no usable gate is fail-open, said in plain words, never a
 // silent pass and never a fake verdict.
 func TestRenderPlatformVerdict_Unavailable(t *testing.T) {

--- a/cmd/platform_render_test.go
+++ b/cmd/platform_render_test.go
@@ -266,3 +266,32 @@ func TestRenderNothingEvaluated_NoAssignment(t *testing.T) {
 
 	assertContains(t, out, "no policy resolved for g/p (no policy assigned), nothing evaluated, exit 0")
 }
+
+// A verdict that never arrived because the token failed is NOT a fail-open.
+// maybePushPlatform returns a *PlatformTokenError there, classifyExecError
+// exits 2 on it, and a line claiming "fail-open, exit 0" would contradict the
+// process's own exit code in the very log the operator reads to diagnose it.
+func TestRenderPlatformVerdict_TokenFailureIsNotFailOpen(t *testing.T) {
+	out := captureStdoutAll(t, func() {
+		renderPlatformVerdict(nil, nil, &PlatformTokenError{Reason: "no CI OIDC id-token available"})
+	})
+
+	assertContains(t, out, "Platform verdict: not obtained (platform push: no CI OIDC id-token available)")
+	if strings.Contains(out, "fail-open") || strings.Contains(out, "exit 0") {
+		t.Fatalf("a run that exits 2 on a token failure must not claim a fail-open exit 0:\n%s", out)
+	}
+}
+
+// The fail-open line stays exactly as it was whenever nothing failed: an
+// unreachable platform, or a 2xx that carried no gate, is the let-through
+// invariant 5 requires, in the words the README tells operators to alert on.
+func TestRenderPlatformVerdict_UnavailableWithoutAnErrorIsStillFailOpen(t *testing.T) {
+	out := captureStdoutAll(t, func() {
+		renderPlatformVerdict(nil, &platformVerdict{Unavailable: "gate unavailable, letting through"}, nil)
+	})
+
+	assertContains(t, out, "Platform verdict: unavailable (gate unavailable, letting through), fail-open, exit 0")
+	if strings.Contains(out, "not obtained") {
+		t.Fatalf("nothing failed here, the line must stay the fail-open one:\n%s", out)
+	}
+}

--- a/cmd/platform_render_test.go
+++ b/cmd/platform_render_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
 	"github.com/getplumber/plumber/internal/platform"
 )
 
@@ -147,6 +148,50 @@ func TestRenderPolicySections_DifferingEnforcementBracketsPerPolicy(t *testing.T
 	out := captureStdoutAll(t, func() { renderPolicySections(testProvider(t), conf, runs, nil, nil) })
 
 	assertContains(t, out, "== Policy: Soft [report], Hard [block, min_points 70]")
+}
+
+// A DEGRADED policy run with no findings: the section says controls could not
+// be evaluated and prints NO issues table. An empty table there would read as
+// a clean pipeline nobody actually evaluated (#220, the reason the guard on
+// the table exists), and the not-evaluated warning is the only disclosure that
+// the score below was computed over a subset of the controls.
+func TestRenderPolicySections_DegradedRunWarnsAndPrintsNoEmptyIssuesTable(t *testing.T) {
+	run := handMadePolicyRun(t, "A", debugTracePolicyYAML, nil)
+	run.Result.DataCollectionDegraded = true
+	run.Result.MarkNotEvaluable("pipelineMustNotEnableDebugTrace", "policy_lane_unavailable")
+
+	out := captureStdoutAll(t, func() { renderPolicySections(testProvider(t), nil, []policyRun{run}, nil, nil) })
+
+	assertContains(t, out, "control(s) could not be evaluated, the score below is computed over the rest")
+	if strings.Contains(out, "none with open issues") {
+		t.Fatalf("a degraded run with no findings must print no issues table at all:\n%s", out)
+	}
+	// The degraded filter drops every group with no findings, so the
+	// per-control sections a degraded run cannot vouch for are not rendered as
+	// verdicts: the warning above is what the reader gets instead.
+	if strings.Contains(out, "Not Evaluated (") {
+		t.Fatalf("a degraded run must not render per-control sections built on data it never collected:\n%s", out)
+	}
+	// #220: no letter grade over incomplete data.
+	assertContains(t, out, "Score withheld")
+}
+
+// A degraded run WITH findings keeps its issues table: the findings are real,
+// and suppressing them would hide what the run did see. Only the empty-table
+// case above is suppressed.
+func TestRenderPolicySections_DegradedRunWithFindingsKeepsTheIssuesTable(t *testing.T) {
+	run := handMadePolicyRun(t, "A", debugTracePolicyYAML, []opaengine.Finding{debugTraceFinding()})
+	run.Result.DataCollectionDegraded = true
+
+	out := captureStdoutAll(t, func() { renderPolicySections(testProvider(t), nil, []policyRun{run}, nil, nil) })
+
+	assertContains(t, out, "Failed Controls (1)")
+	// The issues table's own header row, printed only when the table is.
+	assertContains(t, out, "Codes")
+	if strings.Contains(out, "none with open issues") {
+		t.Fatalf("this run has findings, the table must list them:\n%s", out)
+	}
+	assertContains(t, out, "Score withheld")
 }
 
 // Spec s3: the verdict block is the platform's, one line per gated policy,

--- a/cmd/platform_render_test.go
+++ b/cmd/platform_render_test.go
@@ -1,0 +1,247 @@
+package cmd
+
+import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/internal/platform"
+)
+
+// debugTraceControlConfigWide is a SECOND debug-trace configuration that
+// still fires on the fixture's CI_DEBUG_TRACE job but fingerprints
+// differently from debugTraceControlConfig, so two policies can each own a
+// failing section instead of collapsing into one.
+const debugTraceControlConfigWide = `{"enabled":true,"forbiddenVariables":["CI_DEBUG_TRACE","CI_DEBUG_SERVICES"]}`
+
+// captureStdoutAll redirects os.Stdout for the duration of fn and returns
+// everything written. The shared captureStdout reads once into a 16 KiB
+// buffer, which a full policy section (control blocks plus the score banner)
+// overflows and, worse, deadlocks on: the pipe fills while fn is still
+// printing. Draining through a goroutine (like captureStderr) is the only
+// safe capture for these renderers.
+func captureStdoutAll(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+	return <-done
+}
+
+// Spec s3: one section per fingerprint group, in /context order, the header
+// listing every policy name in the group, and one score banner per run.
+func TestRenderPolicySections_OneSectionPerRun_SharedNamesCollapsed(t *testing.T) {
+	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	b := policyWithTree("B", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	c := policyWithTree("C", "pipelineMustNotUseDockerInDocker", `{"enabled":true}`)
+	c.Enforcement = platform.EnforcementBlock
+	eighty := 80
+	c.MinPoints = &eighty
+	conf := confWithPolicies(t, a, b, c)
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+
+	out := captureStdoutAll(t, func() { renderPolicySections(testProvider(t), conf, runs, nil, nil) })
+
+	assertContains(t, out, "== Policy: A, B  [report]")
+	assertContains(t, out, "== Policy: C  [block, min_points 80]")
+	if strings.Index(out, "== Policy: A, B") > strings.Index(out, "== Policy: C") {
+		t.Fatal("sections must follow /context order")
+	}
+	assertContains(t, out, "Failed Controls (1)") // the debug-trace finding under A, B
+	assertContains(t, out, "Plumber Score")       // the per-policy banner
+	if strings.Count(out, "Plumber Score") != 2 {
+		t.Fatalf("want one banner per run, got %d", strings.Count(out, "Plumber Score"))
+	}
+}
+
+// R3: a run that was not applied says why and prints no banner - an empty
+// verdict would read as a policy that found nothing wrong.
+func TestRenderPolicySections_NotAppliedRunSaysWhy(t *testing.T) {
+	bad := policyWithTree("Bad", "pipelineMustNotEnableDebugTrace", `{"enabled": not-json`)
+	conf := confWithPolicies(t, bad)
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+
+	out := captureStdoutAll(t, func() { renderPolicySections(testProvider(t), conf, runs, nil, nil) })
+
+	assertContains(t, out, "== Policy: Bad  [report]")
+	assertContains(t, out, "control tree could not be applied")
+	assertContains(t, out, "nothing evaluated")
+	if strings.Contains(out, "Plumber Score") {
+		t.Fatal("an un-applied run must not print a score banner")
+	}
+}
+
+// R1: the derived placeholder says the platform has no policy for the
+// project, so nobody reads "[Plumber default]" as a configured policy.
+func TestRenderPolicySections_DerivedSaysWhereTheConfigCameFrom(t *testing.T) {
+	conf := confWithPolicies(t, derivedDefaultPolicy())
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+
+	out := captureStdoutAll(t, func() { renderPolicySections(testProvider(t), conf, runs, nil, nil) })
+
+	assertContains(t, out, "== Policy: [Plumber default]  [report]")
+	assertContains(t, out, "the platform has no policy for this project")
+}
+
+// R2: a policy declaring no control is applied and honest about the empty
+// set it evaluated.
+func TestRenderPolicySections_NoControlsDeclared(t *testing.T) {
+	conf := confWithPolicies(t, platform.Policy{
+		ID:          "11111111-1111-1111-1111-111111111111",
+		Name:        "Empty",
+		Enforcement: platform.EnforcementReport,
+	})
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+
+	out := captureStdoutAll(t, func() { renderPolicySections(testProvider(t), conf, runs, nil, nil) })
+
+	assertContains(t, out, "== Policy: Empty  [report]")
+	assertContains(t, out, "declares no controls, nothing evaluated")
+}
+
+// --no-controls is a request for NO verdict, and platform mode does not
+// override it: the section prints no control blocks and no score banner, so
+// no run that evaluated nothing is stamped with a grade (the safety chain
+// documented on providerControlEntries).
+func TestRenderPolicySections_NoControlsFlagWithholdsTheVerdict(t *testing.T) {
+	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	conf := confWithPolicies(t, a)
+	conf.NoControls = true
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+
+	out := captureStdoutAll(t, func() { renderPolicySections(testProvider(t), conf, runs, nil, nil) })
+
+	assertContains(t, out, "== Policy: A  [report]")
+	for _, forbidden := range []string{"Plumber Score", "Failed Controls", "Skipped Controls"} {
+		if strings.Contains(out, forbidden) {
+			t.Fatalf("--no-controls must not render %q, got:\n%s", forbidden, out)
+		}
+	}
+}
+
+// Policies sharing a configuration but differing in enforcement or
+// min_points get their bracket per name: one bracket for the group would
+// tell the reader the wrong enforcement for half of it.
+func TestRenderPolicySections_DifferingEnforcementBracketsPerPolicy(t *testing.T) {
+	a := policyWithTree("Soft", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	b := policyWithTree("Hard", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	b.Enforcement = platform.EnforcementBlock
+	seventy := 70
+	b.MinPoints = &seventy
+	conf := confWithPolicies(t, a, b)
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+
+	out := captureStdoutAll(t, func() { renderPolicySections(testProvider(t), conf, runs, nil, nil) })
+
+	assertContains(t, out, "== Policy: Soft [report], Hard [block, min_points 70]")
+}
+
+// Spec s3: the verdict block is the platform's, one line per gated policy,
+// then the platform's global score, then the exit line.
+func TestRenderPlatformVerdict_BlockingAndGlobal(t *testing.T) {
+	a := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	c := policyWithTree("Prod", "pipelineMustNotEnableDebugTrace", debugTraceControlConfigWide)
+	c.Enforcement = platform.EnforcementBlock
+	eighty := 80
+	c.MinPoints = &eighty
+	runs := evaluatePlatformPolicies(testProvider(t), confWithPolicies(t, a, c), debugTraceResult())
+	v := &platformVerdict{
+		Gate: &platformGate{Evaluated: true, Blocking: true, Policies: []platformGatePolicy{
+			{ID: a.ID, Name: "A", Enforcement: "report", Blocking: false, LiveFailCount: 1},
+			{ID: c.ID, Name: "Prod", Enforcement: "block", Blocking: true, LiveFailCount: 0},
+		}},
+		GlobalScore: &platformScore{Letter: "B", Points: 83},
+	}
+	gateErr := &PlatformGateError{Reason: "blocked", Policies: v.Gate.Policies[1:]}
+
+	out := captureStdoutAll(t, func() { renderPlatformVerdict(runs, v, gateErr) })
+
+	assertContains(t, out, "== Platform verdict")
+	// The exact columns of "  %-*s   %-6s   %s" at width 4 ("Prod"). Prod's
+	// own re-evaluated run scores 30 (one Critical, malus applied), which is
+	// the figure its section printed: the reason line explains the
+	// platform's verdict in the numbers the reader just saw.
+	assertContains(t, out, "  A      report   not blocking\n")
+	assertContains(t, out, "  Prod   block    BLOCKING (30 < min_points 80)\n")
+	assertContains(t, out, "  Global score (platform): B  83 / 100 pts\n")
+	assertContains(t, out, "  Exit 1: Prod blocks\n")
+}
+
+// A gate that blocks a policy with no min_points reports the platform's
+// live-failure count instead of a threshold comparison.
+func TestRenderPlatformVerdict_LiveFailuresReasonWithoutMinPoints(t *testing.T) {
+	v := &platformVerdict{Gate: &platformGate{Evaluated: true, Blocking: true, Policies: []platformGatePolicy{
+		{ID: "p1", Name: "Live", Enforcement: "block", Blocking: true, LiveFailCount: 3},
+	}}}
+
+	out := captureStdoutAll(t, func() { renderPlatformVerdict(nil, v, &PlatformGateError{Reason: "blocked"}) })
+
+	assertContains(t, out, "  Live   block    BLOCKING (3 live failures)\n")
+	assertContains(t, out, "  Exit 1: Live blocks\n")
+}
+
+// Nothing blocking: the block still prints, and it says exit 0 rather than
+// leaving the reader to infer it.
+func TestRenderPlatformVerdict_NoBlockExitZero(t *testing.T) {
+	v := &platformVerdict{Gate: &platformGate{Evaluated: true, Policies: []platformGatePolicy{
+		{ID: "p1", Name: "Only", Enforcement: "report"},
+	}}}
+
+	out := captureStdoutAll(t, func() { renderPlatformVerdict(nil, v, nil) })
+
+	assertContains(t, out, "  Only   report   not blocking\n")
+	assertContains(t, out, "  Exit 0\n")
+}
+
+// Invariant 5: no usable gate is fail-open, said in plain words, never a
+// silent pass and never a fake verdict.
+func TestRenderPlatformVerdict_Unavailable(t *testing.T) {
+	out := captureStdoutAll(t, func() {
+		renderPlatformVerdict(nil, &platformVerdict{Unavailable: "gate unavailable, letting through"}, nil)
+	})
+
+	assertContains(t, out, "Platform verdict: unavailable (gate unavailable, letting through), fail-open, exit 0")
+}
+
+// A nil verdict (no push at all) still prints the fail-open line.
+func TestRenderPlatformVerdict_NilVerdictIsUnavailable(t *testing.T) {
+	out := captureStdoutAll(t, func() { renderPlatformVerdict(nil, nil, nil) })
+
+	assertContains(t, out, "Platform verdict: unavailable (no push), fail-open, exit 0")
+}
+
+// Spec s3: zero policies resolved is one honest line, not an empty report.
+func TestRenderNothingEvaluated(t *testing.T) {
+	rc := &platform.RunContext{
+		Endpoint:    "https://platform.example.com",
+		ProjectPath: "g/p",
+		ContextErr:  errors.New("dial tcp: refused"),
+	}
+
+	out := captureStdoutAll(t, func() { renderNothingEvaluated(rc) })
+
+	assertContains(t, out, "  linked to https://platform.example.com: no policy resolved for g/p (dial tcp: refused), nothing evaluated, exit 0")
+}
+
+// A reachable platform that assigned nothing is a different fact from an
+// unreachable one, and the line must not claim an error that did not happen.
+func TestRenderNothingEvaluated_NoAssignment(t *testing.T) {
+	rc := &platform.RunContext{Endpoint: "https://platform.example.com", ProjectPath: "g/p"}
+
+	out := captureStdoutAll(t, func() { renderNothingEvaluated(rc) })
+
+	assertContains(t, out, "no policy resolved for g/p (no policy assigned), nothing evaluated, exit 0")
+}

--- a/cmd/platform_report_shape_test.go
+++ b/cmd/platform_report_shape_test.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+)
+
+// A --no-controls run takes the STANDALONE branch in continueRun under every
+// mode, so its JSON report is the standalone inventory report.
+//
+// buildComplianceSummary set platformMode from the platform link alone, while
+// buildAnalysisJSONReport keys its platform branches on that flag and nothing
+// else. A linked inventory run therefore wrote platformMode:true and an empty
+// policies array and dropped plumberConfig and every per-control block. The
+// flag has to be the routing condition itself (platformPolicyMode).
+func TestBuildComplianceSummary_NoControlsUnderPlatformStaysStandalone(t *testing.T) {
+	newGateFlagsCmd(t)
+	restore := withPlatformTestEnv(t, "https://platform.example.com", "tok")
+	defer restore()
+	p := testProvider(t)
+
+	conf := &configuration.Configuration{
+		PlumberConfig: testDefaultPlumberConfig(t),
+		PlatformRun:   runContextWith(policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)),
+	}
+	// The control: the very same link, without --no-controls, IS platform
+	// mode. Without it, a summary that never claims the mode would pass.
+	if s := buildComplianceSummary(p, debugTraceResult(), conf); !s.platformMode {
+		t.Fatal("a linked run that evaluates controls is platform mode")
+	}
+
+	conf.NoControls = true
+	if s := buildComplianceSummary(p, debugTraceResult(), conf); s.platformMode {
+		t.Error("--no-controls runs the standalone branch, so its summary must not claim platform mode")
+	}
+}
+
+// The same fact where it is observable: the report a linked --no-controls run
+// writes is the standalone inventory report, key for key. Adding --platform to
+// an inventory run must not change the artifact, because the platform's
+// policies were deliberately never consulted on that path.
+func TestBuildAnalysisJSONReport_NoControlsUnderPlatformIsTheStandaloneReport(t *testing.T) {
+	newGateFlagsCmd(t)
+	p := testProvider(t)
+	pol := policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+
+	inventoryReport := func(t *testing.T, linked bool) map[string]any {
+		t.Helper()
+		conf := &configuration.Configuration{PlumberConfig: testDefaultPlumberConfig(t), NoControls: true}
+		if linked {
+			conf.PlatformRun = runContextWith(pol)
+			restore := withPlatformTestEnv(t, "https://platform.example.com", "tok")
+			defer restore()
+		}
+		// The summary is built the way production builds it, not hand-set:
+		// the bug lived in buildComplianceSummary, so a literal
+		// complianceSummary here would test nothing.
+		s := buildComplianceSummary(p, debugTraceResult(), conf)
+		payload, err := buildAnalysisJSONReport(debugTraceResult(), conf.PlumberConfig, s,
+			jsonOutputParams{provider: "gitlab", noControls: true}, nil, nil)
+		if err != nil {
+			t.Fatalf("buildAnalysisJSONReport: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(payload, &m); err != nil {
+			t.Fatalf("the report is not valid JSON: %v", err)
+		}
+		return m
+	}
+
+	linked := inventoryReport(t, true)
+	standalone := inventoryReport(t, false)
+
+	if _, present := linked["platformMode"]; present {
+		t.Error("an inventory run took the standalone branch; platformMode would claim the policies produced it")
+	}
+	if _, present := linked["policies"]; present {
+		t.Error("no policy was evaluated on this path, so an empty policies array must not be written")
+	}
+	if _, present := linked["plumberConfig"]; !present {
+		t.Error("the inventory report names the local configuration it was collected under")
+	}
+	blocks := 0
+	for k := range linked {
+		if strings.HasSuffix(k, "Result") {
+			blocks++
+		}
+	}
+	if blocks == 0 {
+		t.Error("the per-control inventory blocks are the point of a --no-controls report")
+	}
+	for k := range linked {
+		if _, present := standalone[k]; !present {
+			t.Errorf("the linked report gains key %q the standalone one does not have", k)
+		}
+	}
+	for k := range standalone {
+		if _, present := linked[k]; !present {
+			t.Errorf("the linked report loses key %q the standalone one has", k)
+		}
+	}
+}

--- a/cmd/platform_results.go
+++ b/cmd/platform_results.go
@@ -16,66 +16,44 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// policyEvaluation is one distinct control configuration and the verdict it
-// produced. Several policies pointing at the same configuration share one
-// of these: the configuration is what decides the verdict, so evaluating it
-// twice could only ever produce the same answer at twice the cost.
-type policyEvaluation struct {
-	effectiveConfig []byte
-	findings        []platformFinding
-	score           platformScore
-}
-
-// buildPolicyResults produces one result entry per policy the platform
-// resolved for this project, which is what the push contract's results
-// array is: never a merged policy, always one entry each.
+// buildPolicyResults maps the evaluated policy runs onto the push contract's
+// results array: one entry per REAL policy of every applied run (policies
+// sharing a run share its findings and score), the derived placeholder under
+// its own name (R1), and nothing at all for a run that was not applied (R3,
+// R6): a policy the CLI could not evaluate is absent from the push, never a
+// clean entry.
 //
-// Policies are grouped by the FINGERPRINT of the control configuration they
-// evaluate under, and each distinct configuration is evaluated exactly once
-// (evaluationFor). Two policies configuring the same control differently
-// therefore get two independent verdicts, and two policies agreeing on it
-// share one evaluation. Today every policy resolves to this run's single
-// local configuration, so the grouping collapses to one evaluation feeding
-// every entry - which is the correct answer for identical configurations,
-// and leaves the structure right for when per-policy configuration starts
-// arriving.
-//
-// In standalone mode - and whenever the context fetch failed - there is no
-// policy set to key on, so this falls back to the single locally-named
-// entry the CLI has always pushed.
-func buildPolicyResults(
-	p providerPkg.Provider,
-	conf *configuration.Configuration,
-	result *control.AnalysisResult,
-	score *control.PlumberScoreResult,
-	configPath string,
-) []platformPolicyResult {
-	policies := platformRunOf(conf).Policies()
-	if len(policies) == 0 {
-		return []platformPolicyResult{localPolicyResult(p, conf, result, score, configPath, "")}
+// The runs are the product of evaluatePlatformPolicies, which is also what
+// the terminal render and the artifacts read - so an entry here can never
+// disagree with what the run reported.
+func buildPolicyResults(runs []policyRun, p providerPkg.Provider, conf *configuration.Configuration) []platformPolicyResult {
+	var includeOnly, skip []string
+	if conf != nil {
+		includeOnly, skip = conf.ControlsFilter, conf.SkipControlsFilter
 	}
 
-	cache := map[string]*policyEvaluation{}
-	out := make([]platformPolicyResult, 0, len(policies))
-	for _, pol := range policies {
-		cfg := configForPolicy(p.Name(), conf, pol)
-		key := configFingerprint(cfg)
-		eval, ok := cache[key]
-		if !ok {
-			eval = evaluationFor(p, conf, result, score, cfg)
-			cache[key] = eval
+	out := []platformPolicyResult{}
+	for _, run := range runs {
+		if !run.Applied {
+			continue
 		}
-		out = append(out, platformPolicyResult{
-			Policy: pol.Name,
-			// Only a real platform policy id is stamped. The derived
-			// fallback carries the nil uuid, which is not a policies row:
-			// keying a result on it would attach the run to a policy that
-			// does not exist, so it is pushed name-only instead.
-			PolicyID:        realPolicyID(pol),
-			EffectiveConfig: eval.effectiveConfig,
-			Findings:        eval.findings,
-			Score:           eval.score,
-		})
+		findings := platformFindingsFor(p, run.Result, run.Config, includeOnly, skip)
+		effective := platformEffectiveConfigRaw(run.Config, p.Name())
+		score := platformScoreFrom(run.Score)
+		for _, pol := range run.Policies {
+			out = append(out, platformPolicyResult{
+				Policy: pol.Name,
+				// Only a real platform policy id is stamped. The derived
+				// fallback carries the nil uuid, which is not a policies
+				// row: keying a result on it would attach the run to a
+				// policy that does not exist, so it is pushed name-only
+				// instead.
+				PolicyID:        realPolicyID(pol),
+				EffectiveConfig: effective,
+				Findings:        findings,
+				Score:           score,
+			})
+		}
 	}
 	return out
 }
@@ -102,42 +80,12 @@ func realPolicyID(pol platform.Policy) string {
 	return pol.ID
 }
 
-// configForPolicy resolves the control configuration a policy is evaluated
-// under. It is THE extension point for per-policy configuration, and a
-// variable so that is visible: everything downstream already keys on
-// whatever it returns, so when the platform starts serving each policy's
-// controls this is the only function that changes.
-//
-// A policy that declares its own control tree is evaluated under THAT tree
-// and nothing else. Two policies may declare the same control_type with
-// different parameters, which is the shape #368 needed: reading one
-// policy's config and reporting it under another's name is precisely the
-// bug this replaces.
-//
-// A policy that declares NO controls falls back to the local configuration.
-// That covers the derived "[Plumber default]" fallback, which is not a real
-// policies row and has no tree by definition, and any real policy an admin
-// has not configured yet. Evaluating those against an empty ruleset would
-// report a clean pass for a policy that simply has not been filled in.
-var configForPolicy = func(provider string, conf *configuration.Configuration, pol platform.Policy) *configuration.PlumberConfig {
-	if conf == nil {
-		return nil
-	}
-	if !pol.DeclaresAnyControl() {
-		return conf.PlumberConfig
-	}
-	cfg, err := policyConfigFromTree(provider, conf, pol)
-	if err != nil {
-		// Falling back to local config here would silently evaluate this
-		// policy under someone else's parameters and report it under this
-		// policy's name - the exact confusion the tree exists to end. The
-		// run continues; this policy's verdict is the local one and the
-		// operator is told the tree could not be applied.
-		fmt.Fprintf(os.Stderr, "  platform: policy %q control tree could not be applied (%v); evaluating it under the local configuration\n", pol.Name, err)
-		return conf.PlumberConfig
-	}
-	return cfg
-}
+// policyConfigVersion is the schema version every assembled policy
+// configuration declares. It is a constant on purpose (R4): the platform's
+// control tree is the whole configuration in platform mode, and reading the
+// version off the run's LOCAL file would let a file the policy has nothing to
+// do with decide how that policy's controls are parsed.
+const policyConfigVersion = "2.0"
 
 // policyConfigFromTree builds the effective PlumberConfig for one policy out
 // of the control tree the platform served for it.
@@ -148,11 +96,8 @@ var configForPolicy = func(provider string, conf *configuration.Configuration, p
 // a decode/re-encode round trip destroys: integer literals above 2^53, which
 // a generic map turns into a lossy float64. The platform went to the same
 // trouble to serve these bytes verbatim; discarding that here would waste it.
-func policyConfigFromTree(provider string, conf *configuration.Configuration, pol platform.Policy) (*configuration.PlumberConfig, error) {
-	version := "2.0"
-	if conf.PlumberConfig != nil && strings.TrimSpace(conf.PlumberConfig.Version) != "" {
-		version = conf.PlumberConfig.Version
-	}
+func policyConfigFromTree(provider string, pol platform.Policy) (*configuration.PlumberConfig, error) {
+	version := policyConfigVersion
 
 	// The provider section has to be the one being analysed. A v2 config
 	// keys controls under `gitlab:` or `github:`, and ControlsFor answers
@@ -178,11 +123,9 @@ func policyConfigFromTree(provider string, conf *configuration.Configuration, po
 			value, err := policyControlValue(c.Config)
 			if err != nil {
 				// One unreadable control must not cost the policy its other
-				// nine. Failing the whole tree over it would send the policy
-				// back to the LOCAL configuration, which is the "evaluate one
-				// policy under someone else's parameters" outcome this
-				// function exists to prevent - a far larger error than
-				// dropping the single control that could not be read.
+				// nine. Failing the whole tree over it would leave the policy
+				// unevaluated and absent from the push, a far larger error
+				// than dropping the single control that could not be read.
 				fmt.Fprintf(os.Stderr, "  platform: policy %q control %q could not be read (%v); it is not applied\n", pol.Name, name, err)
 				continue
 			}
@@ -194,9 +137,9 @@ func policyConfigFromTree(provider string, conf *configuration.Configuration, po
 	// A tree in which NOTHING could be read is not a policy that configures
 	// nothing: it is a tree that did not arrive. Evaluating against the
 	// empty ruleset it assembles to would report every control skipped and
-	// push a verdict in which the policy checked nothing at all, so this
-	// takes the same route a policy with no tree takes - the caller's
-	// fallback to the local configuration, with the reason on stderr.
+	// push a verdict in which the policy checked nothing at all, so the
+	// caller reports the policy as not applied instead and it is left out of
+	// the push entirely.
 	if applied == 0 {
 		return nil, fmt.Errorf("none of the policy's %d declared control(s) could be read", len(seen))
 	}
@@ -286,70 +229,33 @@ func configFingerprint(pc *configuration.PlumberConfig) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// evaluationFor produces the verdict for one distinct control
-// configuration.
+// standalonePolicyResult is the standalone entry: one policy named after the
+// config file this run loaded, evaluated under that same local
+// configuration. Unchanged from what the CLI has always pushed (it is the
+// former localPolicyResult body), so a run without --platform context
+// behaves exactly as before.
 //
 // The findings come from control.StatusFor over the already-collected
-// result, exactly as the single-policy path has always built them, so a
-// policy's entry and the terminal output can never disagree about what this
+// result, exactly as the single-policy path has always built them, so the
+// pushed entry and the terminal output can never disagree about what this
 // run found.
-func evaluationFor(
+func standalonePolicyResult(
 	p providerPkg.Provider,
 	conf *configuration.Configuration,
 	result *control.AnalysisResult,
 	score *control.PlumberScoreResult,
-	pc *configuration.PlumberConfig,
-) *policyEvaluation {
-	var includeOnly, skip []string
-	if conf != nil {
-		includeOnly, skip = conf.ControlsFilter, conf.SkipControlsFilter
-	}
-
-	// When this policy carries its OWN config, the verdict must come from
-	// that config. Reusing the run's findings would report a finding computed
-	// under different parameters while claiming this policy's effective
-	// config - a false positive under a policy that never asked for the
-	// check. Re-evaluation reuses the collected IR, so it costs no git-host
-	// traffic.
-	scopedResult, scopedScore := result, score
-	if conf != nil && pc != nil && pc != conf.PlumberConfig {
-		if scoped, s, ok := control.ReEvaluateForConfig(result, conf, p.Name(), pc); ok {
-			// The whole scoped result, not a copy with only the findings
-			// swapped in: it carries this policy's own not_evaluable marks,
-			// and StatusFor reads them to report a control whose lane died
-			// as an error rather than a pass.
-			scopedResult = scoped
-			scopedScore = &s
-		}
-	}
-
-	return &policyEvaluation{
-		effectiveConfig: platformEffectiveConfigRaw(pc, p.Name()),
-		findings:        platformFindingsFor(p, scopedResult, pc, includeOnly, skip),
-		score:           platformScoreFrom(scopedScore),
-	}
-}
-
-// localPolicyResult is the standalone entry: one policy named after the
-// config file this run loaded. Unchanged from what the CLI has always
-// pushed, so a run without --platform context behaves exactly as before.
-func localPolicyResult(
-	p providerPkg.Provider,
-	conf *configuration.Configuration,
-	result *control.AnalysisResult,
-	score *control.PlumberScoreResult,
-	configPath, policyID string,
+	configPath string,
 ) platformPolicyResult {
 	var pc *configuration.PlumberConfig
+	var includeOnly, skip []string
 	if conf != nil {
 		pc = conf.PlumberConfig
+		includeOnly, skip = conf.ControlsFilter, conf.SkipControlsFilter
 	}
-	eval := evaluationFor(p, conf, result, score, pc)
 	return platformPolicyResult{
 		Policy:          platformPolicyNameFor(configPath),
-		PolicyID:        policyID,
-		EffectiveConfig: eval.effectiveConfig,
-		Findings:        eval.findings,
-		Score:           eval.score,
+		EffectiveConfig: platformEffectiveConfigRaw(pc, p.Name()),
+		Findings:        platformFindingsFor(p, result, pc, includeOnly, skip),
+		Score:           platformScoreFrom(score),
 	}
 }

--- a/cmd/platform_results_test.go
+++ b/cmd/platform_results_test.go
@@ -10,18 +10,6 @@ import (
 	"github.com/getplumber/plumber/internal/platform"
 )
 
-// strictConfigYAML enables one GitLab control, so a config using it
-// produces a different verdict from one that enables nothing.
-const strictConfigYAML = `version: "2.0"
-gitlab:
-  controls:
-    branchMustBeProtected:
-      enabled: true
-      defaultMustBeProtected: true
-      namePatterns:
-        - main
-`
-
 // runContextWith builds a platform run context carrying a resolved policy
 // set, as /context would have returned it.
 func runContextWith(policies ...platform.Policy) *platform.RunContext {
@@ -46,12 +34,15 @@ func confWithPolicies(t *testing.T, policies ...platform.Policy) *configuration.
 // TestBuildPolicyResults_OneEntryPerPolicy is the contract: the results
 // array carries one entry per resolved policy, never a merged one.
 func TestBuildPolicyResults_OneEntryPerPolicy(t *testing.T) {
-	conf := confWithPolicies(t,
-		platform.Policy{ID: "33333333-3333-3333-3333-333333330001", Name: "Baseline", Enforcement: platform.EnforcementReport},
-		platform.Policy{ID: "44444444-4444-4444-4444-444444440002", Name: "Blocking", Enforcement: platform.EnforcementBlock},
-	)
+	baseline := policyWithTree("Baseline", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig)
+	baseline.ID = "33333333-3333-3333-3333-333333330001"
+	blocking := policyWithTree("Blocking", "pipelineMustNotUseDockerInDocker", `{"enabled":true}`)
+	blocking.ID = "44444444-4444-4444-4444-444444440002"
+	blocking.Enforcement = platform.EnforcementBlock
+	conf := confWithPolicies(t, baseline, blocking)
 
-	got := buildPolicyResults(testProvider(t), conf, &control.AnalysisResult{}, nil, ".plumber.yaml")
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+	got := buildPolicyResults(runs, testProvider(t), conf)
 
 	if len(got) != 2 {
 		t.Fatalf("want one entry per policy (2), got %d", len(got))
@@ -59,7 +50,7 @@ func TestBuildPolicyResults_OneEntryPerPolicy(t *testing.T) {
 	if got[0].Policy != "Baseline" || got[1].Policy != "Blocking" {
 		t.Fatalf("entries must be named after their policies: %q, %q", got[0].Policy, got[1].Policy)
 	}
-	if got[0].PolicyID != "33333333-3333-3333-3333-333333330001" || got[1].PolicyID != "44444444-4444-4444-4444-444444440002" {
+	if got[0].PolicyID != baseline.ID || got[1].PolicyID != blocking.ID {
 		t.Fatalf("each entry must carry its own policy id: %q, %q", got[0].PolicyID, got[1].PolicyID)
 	}
 }
@@ -68,22 +59,18 @@ func TestBuildPolicyResults_OneEntryPerPolicy(t *testing.T) {
 // control shared by several policies under the SAME configuration is
 // evaluated once, and the verdict feeds every policy requiring it.
 func TestBuildPolicyResults_SharedConfigIsEvaluatedOnce(t *testing.T) {
-	var evaluations int
-	restore := configForPolicy
-	t.Cleanup(func() { configForPolicy = restore })
-	configForPolicy = func(_ string, conf *configuration.Configuration, _ platform.Policy) *configuration.PlumberConfig {
-		evaluations++ // counts RESOLUTIONS; the cache below is what bounds EVALUATIONS
-		return conf.PlumberConfig
-	}
-
 	conf := confWithPolicies(t,
-		platform.Policy{ID: "1111", Name: "A", Enforcement: platform.EnforcementReport},
-		platform.Policy{ID: "2222", Name: "B", Enforcement: platform.EnforcementReport},
-		platform.Policy{ID: "3333", Name: "C", Enforcement: platform.EnforcementBlock},
+		policyWithTree("A", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig),
+		policyWithTree("B", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig),
+		policyWithTree("C", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig),
 	)
 
-	got := buildPolicyResults(testProvider(t), conf, &control.AnalysisResult{}, nil, ".plumber.yaml")
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+	if len(runs) != 1 {
+		t.Fatalf("three policies on one configuration must share ONE evaluation, got %d runs", len(runs))
+	}
 
+	got := buildPolicyResults(runs, testProvider(t), conf)
 	if len(got) != 3 {
 		t.Fatalf("want 3 entries, got %d", len(got))
 	}
@@ -99,36 +86,19 @@ func TestBuildPolicyResults_SharedConfigIsEvaluatedOnce(t *testing.T) {
 
 // TestBuildPolicyResults_DifferentConfigsProduceIndependentVerdicts is the
 // stated acceptance criterion: two policies configuring a control
-// differently produce two artifacts whose verdicts are independent. It
-// drives the seam per-policy configuration will arrive through, which is
-// what makes the multi-policy machinery real rather than a shape.
+// differently produce two artifacts whose verdicts are independent. In
+// platform mode each policy's own control tree IS its configuration, so this
+// is the ordinary case rather than a seam.
 func TestBuildPolicyResults_DifferentConfigsProduceIndependentVerdicts(t *testing.T) {
-	// One config disables every control; the other enables branch
-	// protection. The verdicts must differ.
-	lax, _, _, err := configuration.LoadPlumberConfigFromBytes([]byte("version: \"2.0\"\n"), "lax")
-	if err != nil {
-		t.Fatalf("load lax: %v", err)
-	}
-	strict, _, _, err := configuration.LoadPlumberConfigFromBytes([]byte(strictConfigYAML), "strict")
-	if err != nil {
-		t.Fatalf("load strict: %v", err)
-	}
-
-	restore := configForPolicy
-	t.Cleanup(func() { configForPolicy = restore })
-	configForPolicy = func(_ string, _ *configuration.Configuration, pol platform.Policy) *configuration.PlumberConfig {
-		if pol.Name == "Strict" {
-			return strict
-		}
-		return lax
-	}
-
+	// One policy enables only docker-in-docker, which the fixture does not
+	// violate; the other enables the debug-trace control, which it does.
 	conf := confWithPolicies(t,
-		platform.Policy{ID: "1111", Name: "Lax", Enforcement: platform.EnforcementReport},
-		platform.Policy{ID: "2222", Name: "Strict", Enforcement: platform.EnforcementBlock},
+		policyWithTree("Lax", "pipelineMustNotUseDockerInDocker", `{"enabled":true}`),
+		policyWithTree("Strict", "pipelineMustNotEnableDebugTrace", debugTraceControlConfig),
 	)
 
-	got := buildPolicyResults(testProvider(t), conf, &control.AnalysisResult{}, nil, ".plumber.yaml")
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+	got := buildPolicyResults(runs, testProvider(t), conf)
 
 	if len(got) != 2 {
 		t.Fatalf("want 2 entries, got %d", len(got))
@@ -148,11 +118,10 @@ func TestBuildPolicyResults_DifferentConfigsProduceIndependentVerdicts(t *testin
 // fallback policy carries the nil uuid, which names no policies row.
 // Sending it would key the run to a policy that does not exist.
 func TestBuildPolicyResults_DerivedDefaultIsPushedNameOnly(t *testing.T) {
-	conf := confWithPolicies(t, platform.Policy{
-		ID: platform.NilUUID, Name: "[Plumber default]", Enforcement: platform.EnforcementReport,
-	})
+	conf := confWithPolicies(t, derivedDefaultPolicy())
 
-	got := buildPolicyResults(testProvider(t), conf, &control.AnalysisResult{}, nil, ".plumber.yaml")
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+	got := buildPolicyResults(runs, testProvider(t), conf)
 
 	if len(got) != 1 {
 		t.Fatalf("want 1 entry, got %d", len(got))
@@ -186,7 +155,8 @@ func TestBuildPolicyResults_DerivedDefaultIsPushedNameOnly(t *testing.T) {
 // TestBuildPolicyResults_StandaloneFallsBackToTheLocalPolicy: with no
 // platform context there is no policy set to key on, so the CLI pushes the
 // single locally-named entry it always has. This is the default path and
-// must not change.
+// must not change - the push is built with NO policy runs, which is exactly
+// what a standalone run produces.
 func TestBuildPolicyResults_StandaloneFallsBackToTheLocalPolicy(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -199,7 +169,19 @@ func TestBuildPolicyResults_StandaloneFallsBackToTheLocalPolicy(t *testing.T) {
 		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildPolicyResults(testProvider(t), tc.conf, &control.AnalysisResult{}, nil, "team.plumber.yaml")
+			if runs := evaluatePlatformPolicies(testProvider(t), tc.conf, &control.AnalysisResult{}); len(runs) != 0 {
+				t.Fatalf("a standalone run resolves no policy to evaluate, got %d runs", len(runs))
+			}
+
+			body, err := buildPlatformPush(testProvider(t), tc.conf, &control.AnalysisResult{}, nil, "team.plumber.yaml", nil)
+			if err != nil {
+				t.Fatalf("buildPlatformPush: %v", err)
+			}
+			var push platformPush
+			if err := json.Unmarshal(body, &push); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			got := push.Results
 			if len(got) != 1 {
 				t.Fatalf("want the single local entry, got %d", len(got))
 			}

--- a/cmd/report_provenance_test.go
+++ b/cmd/report_provenance_test.go
@@ -22,7 +22,7 @@ func TestReportCarriesCommitAndAnalyzedCIConfig(t *testing.T) {
 			Merged:  true,
 		},
 	}
-	payload, err := buildAnalysisJSONReport(result, testDefaultPlumberConfig(t), complianceSummary{}, jsonOutputParams{provider: "gitlab"})
+	payload, err := buildAnalysisJSONReport(result, testDefaultPlumberConfig(t), complianceSummary{}, jsonOutputParams{provider: "gitlab"}, nil, nil)
 	if err != nil {
 		t.Fatalf("build report: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestReportAnalyzedCIConfigExcludedFromScorePush(t *testing.T) {
 	pc := testDefaultPlumberConfig(t)
 
 	// The local --output report keeps it.
-	local, err := buildAnalysisJSONReport(result, pc, complianceSummary{}, jsonOutputParams{provider: "gitlab"})
+	local, err := buildAnalysisJSONReport(result, pc, complianceSummary{}, jsonOutputParams{provider: "gitlab"}, nil, nil)
 	if err != nil {
 		t.Fatalf("build local report: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestReportAnalyzedCIConfigExcludedFromScorePush(t *testing.T) {
 	}
 
 	// The score-push payload drops it.
-	pushed, err := buildAnalysisJSONReport(result, pc, complianceSummary{}, jsonOutputParams{provider: "gitlab", forScorePush: true})
+	pushed, err := buildAnalysisJSONReport(result, pc, complianceSummary{}, jsonOutputParams{provider: "gitlab", forScorePush: true}, nil, nil)
 	if err != nil {
 		t.Fatalf("build score-push payload: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestReportOmitsUnresolvedCommit(t *testing.T) {
 		ArtifactCommitSHA: "",
 		ArtifactRef:       "",
 	}
-	payload, err := buildAnalysisJSONReport(result, testDefaultPlumberConfig(t), complianceSummary{}, jsonOutputParams{provider: "gitlab"})
+	payload, err := buildAnalysisJSONReport(result, testDefaultPlumberConfig(t), complianceSummary{}, jsonOutputParams{provider: "gitlab"}, nil, nil)
 	if err != nil {
 		t.Fatalf("build report: %v", err)
 	}

--- a/cmd/run_header_test.go
+++ b/cmd/run_header_test.go
@@ -129,3 +129,45 @@ func TestBuildRunHeaderRows(t *testing.T) {
 		})
 	}
 }
+
+// Spec s2: in platform mode the controls, their configuration and the verdict
+// all come from the platform's policies. A "Config  .plumber.yaml" row would
+// assert a local configuration this run did not evaluate, which is the exact
+// wrong-verdict reading the mode exists to remove (QUESTIONS row 44).
+func TestBuildRunHeaderRows_PlatformModeNamesThePlatformsPolicies(t *testing.T) {
+	restore := withPlatformTestEnv(t, "https://platform.example.com", "tok")
+	defer restore()
+
+	for name, path := range map[string]string{
+		"a local file":         ".plumber.yaml",
+		"the built-in default": builtinDefaultConfigSource,
+		"nothing resolved":     "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			rows := buildRunHeaderRows("gitlab",
+				&control.AnalysisResult{ProjectPath: "grp/app"},
+				&configuration.Configuration{ConfigFilePath: path})
+
+			got, ok := findRow(rows, "Config")
+			if !ok || got != "the platform's policies" {
+				t.Fatalf("Config row = %q (present=%v), want %q", got, ok, "the platform's policies")
+			}
+		})
+	}
+}
+
+// --no-controls evaluates nothing under any mode and takes the standalone
+// branch (continueRun), so its header keeps naming the local configuration
+// that was loaded.
+func TestBuildRunHeaderRows_NoControlsUnderPlatformKeepsTheLocalConfigRow(t *testing.T) {
+	restore := withPlatformTestEnv(t, "https://platform.example.com", "tok")
+	defer restore()
+
+	rows := buildRunHeaderRows("gitlab",
+		&control.AnalysisResult{ProjectPath: "grp/app"},
+		&configuration.Configuration{ConfigFilePath: ".plumber.yaml", NoControls: true})
+
+	if got, ok := findRow(rows, "Config"); !ok || got != ".plumber.yaml" {
+		t.Fatalf("Config row = %q (present=%v), want the local path", got, ok)
+	}
+}

--- a/cmd/sarif.go
+++ b/cmd/sarif.go
@@ -382,6 +382,18 @@ func buildSARIF(findings []opaengine.Finding, fallbackURI, provider string) sari
 		if f.URL != "" {
 			res.Properties = map[string]any{"url": f.URL}
 		}
+		// The policies that reported this finding (platform mode, spec s5).
+		// SARIF has no first-class field for it and the results are the
+		// UNION of every policy run, so the property bag is where the policy
+		// dimension lives: one alert, tagged with every policy it belongs
+		// to. Absent on a standalone run, where an empty array would read as
+		// "no policy covers this".
+		if len(f.Policies) > 0 {
+			if res.Properties == nil {
+				res.Properties = map[string]any{}
+			}
+			res.Properties["policies"] = f.Policies
+		}
 		if uri := reportFilePath(f.File); uri != "" {
 			phys := sarifPhysical{ArtifactLocation: sarifArtifact{URI: uri}}
 			if f.Line > 0 {

--- a/control/badge.go
+++ b/control/badge.go
@@ -23,16 +23,17 @@ func ManageProjectBadge(
 }
 
 // ManageProjectBadgePlatform is the platform-mode badge (spec s5): the letter
-// is the platform's own global score. When the push returned none
-// (HasGlobal false: an older platform, a fail-open gate) the badge is NOT
-// updated - it keeps its last good value rather than being overwritten with a
-// blank, or with a locally computed letter the platform never agreed to.
+// is the platform's own global score. When the push returned none, or one
+// that is not a Plumber Score letter (see hasPublishableGlobal), the badge is
+// NOT updated - it keeps its last good value rather than being overwritten
+// with a blank, with something that is not a grade, or with a locally
+// computed letter the platform never agreed to.
 func ManageProjectBadgePlatform(
 	projectID int,
 	conf *configuration.Configuration,
 	s *PlatformPostSummary,
 ) error {
-	if s == nil || !s.HasGlobal || s.GlobalLetter == "" {
+	if !s.hasPublishableGlobal() {
 		return nil
 	}
 	return manageProjectBadgeLetter(projectID, conf, s.GlobalLetter)

--- a/control/badge.go
+++ b/control/badge.go
@@ -19,14 +19,41 @@ func ManageProjectBadge(
 	if ps == nil {
 		return nil
 	}
+	return manageProjectBadgeLetter(projectID, conf, ps.Score)
+}
+
+// ManageProjectBadgePlatform is the platform-mode badge (spec s5): the letter
+// is the platform's own global score. When the push returned none
+// (HasGlobal false: an older platform, a fail-open gate) the badge is NOT
+// updated - it keeps its last good value rather than being overwritten with a
+// blank, or with a locally computed letter the platform never agreed to.
+func ManageProjectBadgePlatform(
+	projectID int,
+	conf *configuration.Configuration,
+	s *PlatformPostSummary,
+) error {
+	if s == nil || !s.HasGlobal || s.GlobalLetter == "" {
+		return nil
+	}
+	return manageProjectBadgeLetter(projectID, conf, s.GlobalLetter)
+}
+
+// manageProjectBadgeLetter is the shared badge write: both entry points
+// resolve to a letter and then run exactly the same create-or-update, so the
+// two modes cannot drift on how the badge is matched or named.
+func manageProjectBadgeLetter(
+	projectID int,
+	conf *configuration.Configuration,
+	letter string,
+) error {
 	l := logrus.WithFields(logrus.Fields{
 		"action":    "ManageProjectBadge",
 		"projectID": projectID,
-		"score":     ps.Score,
+		"score":     letter,
 	})
 
 	// Generate badge image URL
-	badgeImageURL := ScoreBadgeURL(ps.Score)
+	badgeImageURL := ScoreBadgeURL(letter)
 	badgeLinkURL := PlumberScoreDocURL
 
 	// List existing badges to find Plumber badge

--- a/control/mrcomment.go
+++ b/control/mrcomment.go
@@ -236,7 +236,7 @@ func writeMRStatusLine(b *strings.Builder, passed bool, gateLine string) {
 	if passed {
 		fmt.Fprintf(b, ":white_check_mark: **Plumber check passed** (%s)\n\n", gateLine)
 	} else {
-		fmt.Fprintf(b, ":warning: **Plumber check failed** — %s\n\n", gateLine)
+		fmt.Fprintf(b, ":warning: **Plumber check failed** - %s\n\n", gateLine)
 	}
 }
 

--- a/control/mrcomment.go
+++ b/control/mrcomment.go
@@ -261,14 +261,16 @@ func writeMRFooter(b *strings.Builder) {
 func generatePlatformMRComment(platform *PlatformPostSummary, passed bool, gateLine string) string {
 	var b strings.Builder
 
+	hasGlobal := platform.hasPublishableGlobal()
+
 	b.WriteString(MRCommentIdentifier + "\n")
-	if platform.HasGlobal && platform.GlobalLetter != "" {
+	if hasGlobal {
 		fmt.Fprintf(&b, "[![Plumber](%s)](%s)\n\n", ScoreBadgeURL(platform.GlobalLetter), PlumberScoreDocURL)
 	}
 	b.WriteString("*Enforcement comes from the platform's policies; the scores below are this run's.*\n\n")
 
 	b.WriteString("### Plumber Score\n\n")
-	if platform.HasGlobal {
+	if hasGlobal {
 		fmt.Fprintf(&b, "- **Global score (platform):** **%s** - %d / 100 pts\n\n",
 			sanitizeMarkdownInline(platform.GlobalLetter), platform.GlobalPoints)
 	} else {

--- a/control/mrcomment.go
+++ b/control/mrcomment.go
@@ -33,6 +33,7 @@ func ManageMergeRequestComment(
 	score *PlumberScoreResult,
 	scoreMode bool,
 	scorePointMode bool,
+	platform *PlatformPostSummary,
 ) error {
 	l := logrus.WithFields(logrus.Fields{
 		"action":          "ManageMergeRequestComment",
@@ -41,7 +42,7 @@ func ManageMergeRequestComment(
 	})
 
 	// Generate comment body
-	commentBody := generateMRComment(result, pc, passed, gateLine, score, scoreMode, scorePointMode, conf.ControlsFilter, conf.SkipControlsFilter)
+	commentBody := generateMRComment(result, pc, passed, gateLine, score, scoreMode, scorePointMode, conf.ControlsFilter, conf.SkipControlsFilter, platform)
 
 	// List existing notes to find our comment
 	notes, err := gitlab.ListMergeRequestNotes(
@@ -121,7 +122,14 @@ func ScoreBadgeURL(letter string) string {
 
 // generateMRComment builds the Markdown body for the merge request comment
 // based on the analysis result.
-func generateMRComment(result *AnalysisResult, pc *configuration.PlumberConfig, passed bool, gateLine string, score *PlumberScoreResult, scoreMode, scorePointMode bool, controlsFilterList, skipControlsList []string) string {
+//
+// platform is set only in platform mode and then owns the whole body (spec
+// s5): what a reviewer must see there is the platform's verdict per policy,
+// not the local configuration's evaluation of the same pipeline.
+func generateMRComment(result *AnalysisResult, pc *configuration.PlumberConfig, passed bool, gateLine string, score *PlumberScoreResult, scoreMode, scorePointMode bool, controlsFilterList, skipControlsList []string, platform *PlatformPostSummary) string {
+	if platform != nil {
+		return generatePlatformMRComment(platform, passed, gateLine)
+	}
 	var b strings.Builder
 
 	// Hidden identifier so we can find this comment later
@@ -206,11 +214,7 @@ func generateMRComment(result *AnalysisResult, pc *configuration.PlumberConfig, 
 	b.WriteString("\n")
 
 	// Status line after the table
-	if passed {
-		fmt.Fprintf(&b, ":white_check_mark: **Plumber check passed** (%s)\n\n", gateLine)
-	} else {
-		fmt.Fprintf(&b, ":warning: **Plumber check failed** — %s\n\n", gateLine)
-	}
+	writeMRStatusLine(&b, passed, gateLine)
 
 	// Issue details as a normal section
 	if totalIssues > 0 {
@@ -218,9 +222,81 @@ func generateMRComment(result *AnalysisResult, pc *configuration.PlumberConfig, 
 		writeIssueDetails(&b, result)
 	}
 
-	// Footer
+	writeMRFooter(&b)
+
+	return b.String()
+}
+
+// writeMRStatusLine and writeMRFooter are the two blocks every Plumber
+// comment ends with, standalone or platform mode. They are shared rather than
+// repeated so the two bodies cannot drift on the wording a reader uses to
+// recognise a Plumber comment; the strings are the existing ones, moved
+// verbatim, so a standalone comment is byte-for-byte what it was.
+func writeMRStatusLine(b *strings.Builder, passed bool, gateLine string) {
+	if passed {
+		fmt.Fprintf(b, ":white_check_mark: **Plumber check passed** (%s)\n\n", gateLine)
+	} else {
+		fmt.Fprintf(b, ":warning: **Plumber check failed** — %s\n\n", gateLine)
+	}
+}
+
+func writeMRFooter(b *strings.Builder) {
 	b.WriteString("---\n")
 	b.WriteString("*Automatically posted by [Plumber](https://getplumber.io) — do not edit manually.*\n")
+}
+
+// generatePlatformMRComment builds the merge-request comment of a
+// platform-mode run (spec s5): the platform's global score as the headline,
+// then one row per resolved policy.
+//
+// It deliberately does NOT carry the controls table or the issue details the
+// standalone comment ends with. Both are rendered from the run-level result,
+// which in platform mode is the LOCAL configuration's evaluation - the one
+// thing this mode exists to stop publishing (QUESTIONS row 44). The per-policy
+// findings live in the report artifacts and on the platform, where they carry
+// the policy they belong to.
+//
+// A missing global score is stated, never filled in: an unavailable verdict
+// and a bad one must not look the same to a reviewer.
+func generatePlatformMRComment(platform *PlatformPostSummary, passed bool, gateLine string) string {
+	var b strings.Builder
+
+	b.WriteString(MRCommentIdentifier + "\n")
+	if platform.HasGlobal && platform.GlobalLetter != "" {
+		fmt.Fprintf(&b, "[![Plumber](%s)](%s)\n\n", ScoreBadgeURL(platform.GlobalLetter), PlumberScoreDocURL)
+	}
+	b.WriteString("*Enforcement comes from the platform's policies; the scores below are this run's.*\n\n")
+
+	b.WriteString("### Plumber Score\n\n")
+	if platform.HasGlobal {
+		fmt.Fprintf(&b, "- **Global score (platform):** **%s** - %d / 100 pts\n\n",
+			sanitizeMarkdownInline(platform.GlobalLetter), platform.GlobalPoints)
+	} else {
+		b.WriteString("- **Global score (platform):** _score unavailable_ - the platform returned none for this run\n\n")
+	}
+
+	b.WriteString("### Policies\n\n")
+	b.WriteString("| Policy | Enforcement | Score | Blocking |\n")
+	b.WriteString("|--------|-------------|-------|----------|\n")
+	for _, p := range platform.Policies {
+		// A policy the CLI could not evaluate has no letter. Rendering the
+		// zero it carries would read as a policy that scored nothing rather
+		// than one that ran nothing.
+		scoreCell := "_not evaluated_"
+		if p.Letter != "" {
+			scoreCell = fmt.Sprintf("%s - %d / 100", sanitizeMarkdownInline(p.Letter), p.FinalPoints)
+		}
+		blocking := "no"
+		if p.Blocking {
+			blocking = "**yes**"
+		}
+		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n",
+			sanitizeMarkdownInline(p.Name), sanitizeMarkdownInline(p.Enforcement), scoreCell, blocking)
+	}
+	b.WriteString("\n")
+
+	writeMRStatusLine(&b, passed, gateLine)
+	writeMRFooter(&b)
 
 	return b.String()
 }

--- a/control/mrcomment_test.go
+++ b/control/mrcomment_test.go
@@ -173,3 +173,21 @@ func TestGenerateMRComment_NotEvaluableRow(t *testing.T) {
 		t.Fatalf("a not_evaluable control must never render as a green check:\n%s", body)
 	}
 }
+
+// House style (CLAUDE.md): no em dash in anything Plumber writes, and a
+// comment posted on a merge request is the most public of those. The
+// failed-status line is shared by the standalone and the platform-mode
+// comment, so pinning it once covers both.
+func TestWriteMRStatusLine_FailedLineCarriesNoEmDash(t *testing.T) {
+	var b strings.Builder
+
+	writeMRStatusLine(&b, false, "score C - 66/100 pts")
+
+	got := b.String()
+	if !strings.Contains(got, ":warning: **Plumber check failed** - score C - 66/100 pts") {
+		t.Errorf("status line = %q, want the gate line after a spaced hyphen", got)
+	}
+	if strings.Contains(got, "\u2014") {
+		t.Errorf("status line = %q, want no em dash", got)
+	}
+}

--- a/control/mrcomment_test.go
+++ b/control/mrcomment_test.go
@@ -39,7 +39,7 @@ func TestGenerateMRComment_FailedGate(t *testing.T) {
 		},
 	}
 	gateLine := "score D — 45.0/100 pts, required ≥ 100 pts"
-	body := generateMRComment(result, mrCommentPC(), false, gateLine, &PlumberScoreResult{Score: "D", FinalPoints: 45}, true, false, nil, nil)
+	body := generateMRComment(result, mrCommentPC(), false, gateLine, &PlumberScoreResult{Score: "D", FinalPoints: 45}, true, false, nil, nil, nil)
 
 	if !strings.Contains(body, ":warning: **Plumber check failed**") {
 		t.Fatalf("failed gate must render the failure line, got:\n%s", body)
@@ -59,7 +59,7 @@ func TestGenerateMRComment_FailedGate(t *testing.T) {
 func TestGenerateMRComment_PassedGate(t *testing.T) {
 	result := &AnalysisResult{CiValid: true}
 	gateLine := "score A — 100.0/100 pts, required ≥ 100 pts"
-	body := generateMRComment(result, mrCommentPC(), true, gateLine, &PlumberScoreResult{Score: "A", FinalPoints: 100}, true, false, nil, nil)
+	body := generateMRComment(result, mrCommentPC(), true, gateLine, &PlumberScoreResult{Score: "A", FinalPoints: 100}, true, false, nil, nil, nil)
 
 	if !strings.Contains(body, ":white_check_mark: **Plumber check passed** ("+gateLine+")") {
 		t.Fatalf("passed gate must render the pass line with the gate line, got:\n%s", body)
@@ -75,7 +75,7 @@ func TestGenerateMRComment_PassedGate(t *testing.T) {
 func TestGenerateMRComment_IdentifierStability(t *testing.T) {
 	// Update-in-place matches comments posted by older versions against this
 	// exact historical wording; the body must start with it, verbatim.
-	body := generateMRComment(&AnalysisResult{CiValid: true}, mrCommentPC(), true, "gate", nil, false, false, nil, nil)
+	body := generateMRComment(&AnalysisResult{CiValid: true}, mrCommentPC(), true, "gate", nil, false, false, nil, nil, nil)
 	if !strings.HasPrefix(body, MRCommentIdentifier+"\n") {
 		t.Fatalf("body must start with the MR comment identifier, got:\n%s", body[:min(len(body), 120)])
 	}
@@ -91,7 +91,7 @@ func TestGenerateMRComment_ControlsTable(t *testing.T) {
 			{Code: string(CodeBranchUnprotected), Message: "branch main is not protected", Severity: "critical"},
 		},
 	}
-	body := generateMRComment(result, mrCommentPC(), false, "gate", nil, false, false, nil, nil)
+	body := generateMRComment(result, mrCommentPC(), false, "gate", nil, false, false, nil, nil, nil)
 
 	if !strings.Contains(body, "| :x: Branch must be protected | failed | 1 |") {
 		t.Fatalf("control with findings must render a failed row, got:\n%s", body)
@@ -107,14 +107,14 @@ func TestGenerateMRComment_ControlsTable(t *testing.T) {
 func TestGenerateMRComment_BadgeOnlyWithScore(t *testing.T) {
 	result := &AnalysisResult{CiValid: true}
 
-	withScore := generateMRComment(result, mrCommentPC(), true, "gate", &PlumberScoreResult{Score: "B", FinalPoints: 85}, true, false, nil, nil)
+	withScore := generateMRComment(result, mrCommentPC(), true, "gate", &PlumberScoreResult{Score: "B", FinalPoints: 85}, true, false, nil, nil, nil)
 	if !strings.Contains(withScore, ScoreBadgeURL("B")) {
 		t.Fatalf("score mode with a score must render the letter badge, got:\n%s", withScore)
 	}
 
 	// No score (e.g. score withheld): no badge at all — the old always-badge
 	// else branch was removed on purpose.
-	withoutScore := generateMRComment(result, mrCommentPC(), true, "gate", nil, true, false, nil, nil)
+	withoutScore := generateMRComment(result, mrCommentPC(), true, "gate", nil, true, false, nil, nil, nil)
 	if strings.Contains(withoutScore, "img.shields.io") {
 		t.Fatalf("no score must render no badge, got:\n%s", withoutScore)
 	}
@@ -165,7 +165,7 @@ func TestGenerateMRComment_NotEvaluableRow(t *testing.T) {
 	result := &AnalysisResult{CiValid: true}
 	result.MarkNotEvaluable("branchMustBeProtected", ReasonCollectionFailed)
 
-	body := generateMRComment(result, pc, true, "", nil, false, false, nil, nil)
+	body := generateMRComment(result, pc, true, "", nil, false, false, nil, nil, nil)
 	if !strings.Contains(body, ":grey_question:") || !strings.Contains(body, "_not evaluated_") {
 		t.Fatalf("a not_evaluable control must render its own row, got:\n%s", body)
 	}

--- a/control/platform_post.go
+++ b/control/platform_post.go
@@ -1,0 +1,34 @@
+package control
+
+// PlatformPostSummary is what a platform-mode run tells the post-analysis
+// actions (the GitLab badge and the merge-request comment) about the
+// platform's verdict, in place of the run-level Plumber Score they read for a
+// standalone run. There is no run-level score in platform mode: every verdict
+// belongs to one of the platform's policies, and the single headline figure
+// is the platform's own global score from the push response (spec
+// 2026-09-10-cli-platform-mode-policies-only s5).
+//
+// HasGlobal is the honest flag rather than an empty GlobalLetter: a push that
+// returned no global score is a routine state (an older platform, a fail-open
+// gate), and the comment must say "score unavailable" while the badge stays
+// on its last good value. Neither may fall back to a locally computed figure
+// the platform never agreed to (QUESTIONS row 44).
+type PlatformPostSummary struct {
+	GlobalLetter string
+	GlobalPoints int
+	HasGlobal    bool
+	Policies     []PlatformPolicyLine
+}
+
+// PlatformPolicyLine is one resolved policy's row in the merge-request
+// comment's table. Letter is empty and FinalPoints zero for a policy the CLI
+// could not evaluate; the renderer prints that as "not evaluated" rather than
+// as a score of zero. Blocking is the platform's own gate answer for this
+// policy, never a CLI recomputation.
+type PlatformPolicyLine struct {
+	Name        string
+	Enforcement string
+	Letter      string
+	FinalPoints int
+	Blocking    bool
+}

--- a/control/platform_post.go
+++ b/control/platform_post.go
@@ -20,6 +20,22 @@ type PlatformPostSummary struct {
 	Policies     []PlatformPolicyLine
 }
 
+// hasPublishableGlobal reports whether the platform's global score may be
+// published as a headline and a badge. It is the single place both consumers
+// ask, so neither can publish what the other refuses.
+//
+// The letter is checked against the closed A-E set the Plumber Score has,
+// not merely for being non-empty. It arrives from the platform's push
+// response and is interpolated into a shields.io URL (ScoreBadgeURL) that
+// then goes into a Markdown image AND link target in a comment posted with
+// Plumber's identity: a value like "A)](https://elsewhere)" would close the
+// image and forge the link. Anything outside the set is treated exactly like
+// no score at all - "score unavailable", and the badge left on its last good
+// value - because that is what it is.
+func (s *PlatformPostSummary) hasPublishableGlobal() bool {
+	return s != nil && s.HasGlobal && ScoreLetterRank(s.GlobalLetter) > 0
+}
+
 // PlatformPolicyLine is one resolved policy's row in the merge-request
 // comment's table. Letter is empty and FinalPoints zero for a policy the CLI
 // could not evaluate; the renderer prints that as "not evaluated" rather than

--- a/control/platform_post_test.go
+++ b/control/platform_post_test.go
@@ -154,3 +154,69 @@ func TestManageProjectBadgePlatform_NoGlobalScoreLeavesTheBadgeAlone(t *testing.
 		}
 	}
 }
+
+// The global letter is platform-controlled text that reaches a Markdown
+// image AND link target ("[![Plumber](<url>)](<url>)") and the shields.io
+// badge URL, both built by string interpolation. Anything outside the closed
+// A-E set the score has is not a score: the comment says "score unavailable"
+// and the badge is left alone, rather than publishing a forged link with
+// Plumber's identity on it.
+func TestPlatformGlobalLetter_OutsideTheClosedSetIsNotAScore(t *testing.T) {
+	hostile := "A)](https://evil.example.com)"
+
+	t.Run("the merge-request comment refuses it", func(t *testing.T) {
+		s := platformSummaryFixture()
+		s.GlobalLetter = hostile
+
+		body := generateMRComment(&AnalysisResult{CiValid: true}, mrCommentPC(), true, "gate", nil, false, false, nil, nil, s)
+
+		if !strings.Contains(body, "score unavailable") {
+			t.Errorf("want the score-unavailable headline for a letter that is not one:\n%s", body)
+		}
+		if strings.Contains(body, "evil.example.com") {
+			t.Errorf("the hostile letter reached the comment:\n%s", body)
+		}
+		if strings.Contains(body, "img.shields.io") {
+			t.Errorf("no badge may be rendered from a letter that is not a score:\n%s", body)
+		}
+		// The per-policy table is the run's own answer and is unaffected.
+		if !strings.Contains(body, "| Baseline | report | C - 66 / 100 | no |") {
+			t.Errorf("the policy rows survive an unusable global letter:\n%s", body)
+		}
+	})
+
+	t.Run("the badge is not written", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Errorf("the badge API was called with a letter outside A-E: %s %s", r.Method, r.URL.Path)
+		}))
+		defer srv.Close()
+		conf := configuration.NewDefaultConfiguration()
+		conf.GitlabURL, conf.GitlabToken = srv.URL, "glpat-test"
+
+		s := platformSummaryFixture()
+		s.GlobalLetter = hostile
+
+		if err := ManageProjectBadgePlatform(42, conf, s); err != nil {
+			t.Fatalf("ManageProjectBadgePlatform: %v", err)
+		}
+	})
+
+	t.Run("every letter the score actually has is still published", func(t *testing.T) {
+		for _, letter := range []string{"A", "B", "C", "D", "E"} {
+			var published string
+			srv := badgeServer(t, &published)
+			conf := configuration.NewDefaultConfiguration()
+			conf.GitlabURL, conf.GitlabToken = srv.URL, "glpat-test"
+
+			s := platformSummaryFixture()
+			s.GlobalLetter = letter
+			if err := ManageProjectBadgePlatform(42, conf, s); err != nil {
+				t.Fatalf("%s: %v", letter, err)
+			}
+			if published != ScoreBadgeURL(letter) {
+				t.Errorf("letter %s published %q, want the badge for that letter", letter, published)
+			}
+			srv.Close()
+		}
+	})
+}

--- a/control/platform_post_test.go
+++ b/control/platform_post_test.go
@@ -1,0 +1,156 @@
+package control
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+)
+
+// platformSummaryFixture is a two-policy platform verdict: one evaluated and
+// not blocking, one the CLI could not evaluate and that the platform blocks
+// on anyway (its live monitoring, not this run).
+func platformSummaryFixture() *PlatformPostSummary {
+	return &PlatformPostSummary{
+		GlobalLetter: "B",
+		GlobalPoints: 83,
+		HasGlobal:    true,
+		Policies: []PlatformPolicyLine{
+			{Name: "Baseline", Enforcement: "report", Letter: "C", FinalPoints: 66},
+			{Name: "Prod", Enforcement: "block", Blocking: true},
+		},
+	}
+}
+
+// Spec s5: the merge-request comment's headline is the platform's global
+// score and the body is the per-policy table. No local grade appears, because
+// in platform mode there is none.
+func TestGenerateMRComment_PlatformMode_HeadlineAndPolicyTable(t *testing.T) {
+	body := generateMRComment(&AnalysisResult{CiValid: true}, mrCommentPC(), true,
+		"enforcement comes from the platform's policies", nil, false, false, nil, nil, platformSummaryFixture())
+
+	if !strings.Contains(body, ScoreBadgeURL("B")) {
+		t.Errorf("the badge must show the platform's global letter:\n%s", body)
+	}
+	for _, want := range []string{
+		"83 / 100",
+		"| Policy | Enforcement | Score | Blocking |",
+		"| Baseline | report | C - 66 / 100 | no |",
+		"| Prod | block | _not evaluated_ | **yes** |",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q in:\n%s", want, body)
+		}
+	}
+	// The local controls table and issue details describe the LOCAL
+	// configuration's evaluation, which platform mode does not publish.
+	if strings.Contains(body, "### Controls") {
+		t.Errorf("the local controls table must not be posted in platform mode:\n%s", body)
+	}
+}
+
+// A push that returned no global score says so; it never falls back to a
+// locally computed figure, and never prints a blank letter as if it were one.
+func TestGenerateMRComment_PlatformMode_ScoreUnavailable(t *testing.T) {
+	s := platformSummaryFixture()
+	s.HasGlobal, s.GlobalLetter, s.GlobalPoints = false, "", 0
+
+	body := generateMRComment(&AnalysisResult{CiValid: true}, mrCommentPC(), true, "gate", nil, false, false, nil, nil, s)
+
+	if !strings.Contains(body, "score unavailable") {
+		t.Errorf("want the score-unavailable headline:\n%s", body)
+	}
+	if strings.Contains(body, "img.shields.io") {
+		t.Errorf("no badge may be rendered without a platform score:\n%s", body)
+	}
+	// The policy rows are still the run's own answer and stay.
+	if !strings.Contains(body, "| Baseline | report | C - 66 / 100 | no |") {
+		t.Errorf("the per-policy table survives a missing global score:\n%s", body)
+	}
+}
+
+// A policy name is platform-controlled text landing in a Markdown table
+// posted with Plumber's identity: a pipe or a newline in it must not be able
+// to forge a row.
+func TestGenerateMRComment_PlatformMode_SanitizesPolicyNames(t *testing.T) {
+	s := &PlatformPostSummary{Policies: []PlatformPolicyLine{{Name: "a|b\nc", Enforcement: "report"}}}
+
+	body := generateMRComment(&AnalysisResult{CiValid: true}, mrCommentPC(), true, "gate", nil, false, false, nil, nil, s)
+
+	if strings.Contains(body, "| a|b") {
+		t.Errorf("an unescaped pipe forged a table cell:\n%s", body)
+	}
+}
+
+// A standalone comment is unchanged: no platform summary, no policy table.
+func TestGenerateMRComment_StandaloneUnchangedByThePlatformBranch(t *testing.T) {
+	body := generateMRComment(&AnalysisResult{CiValid: true}, mrCommentPC(), true, "gate",
+		&PlumberScoreResult{Score: "A", FinalPoints: 100}, true, false, nil, nil, nil)
+
+	if !strings.Contains(body, "### Controls") {
+		t.Errorf("the standalone comment keeps its controls table:\n%s", body)
+	}
+	if strings.Contains(body, "| Policy | Enforcement | Score | Blocking |") {
+		t.Errorf("a standalone run has no policy table:\n%s", body)
+	}
+}
+
+// badgeServer answers the two calls a badge write makes and records the image
+// URL it was asked to publish.
+func badgeServer(t *testing.T, got *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost {
+			var payload struct {
+				ImageURL string `json:"image_url"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&payload)
+			*got = payload.ImageURL
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"id":1}`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+}
+
+// Spec s5: the badge letter is the platform's global letter.
+func TestManageProjectBadgePlatform_UsesTheGlobalLetter(t *testing.T) {
+	var published string
+	srv := badgeServer(t, &published)
+	defer srv.Close()
+	conf := configuration.NewDefaultConfiguration()
+	conf.GitlabURL, conf.GitlabToken = srv.URL, "glpat-test"
+
+	if err := ManageProjectBadgePlatform(42, conf, platformSummaryFixture()); err != nil {
+		t.Fatalf("ManageProjectBadgePlatform: %v", err)
+	}
+	if published != ScoreBadgeURL("B") {
+		t.Fatalf("published badge = %q, want the platform's global letter B", published)
+	}
+}
+
+// No global score means NO badge write at all: the last good badge stays, and
+// nothing locally computed replaces it.
+func TestManageProjectBadgePlatform_NoGlobalScoreLeavesTheBadgeAlone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("the badge API was called with no platform score: %s %s", r.Method, r.URL.Path)
+	}))
+	defer srv.Close()
+	conf := configuration.NewDefaultConfiguration()
+	conf.GitlabURL, conf.GitlabToken = srv.URL, "glpat-test"
+
+	for name, s := range map[string]*PlatformPostSummary{
+		"no summary":   nil,
+		"no global":    {Policies: []PlatformPolicyLine{{Name: "A"}}},
+		"blank letter": {HasGlobal: true, GlobalLetter: ""},
+	} {
+		if err := ManageProjectBadgePlatform(42, conf, s); err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+	}
+}

--- a/docs/platform-push-testing.md
+++ b/docs/platform-push-testing.md
@@ -156,12 +156,12 @@ snapshot goes in `project_snapshots.data` using the shapes
 `platform/backend/snapshot/collector.go` writes (`branch_protection` is
 `{"protections": [...]}`, not a map of branch names).
 
-The one check worth doing on every change to the collection lanes: run the
-same commit with and without `--platform` and diff the per-control statuses.
-Every difference must be a control moving to `not_evaluable`. A control that
-gains findings under `--platform` is a false positive from a data lane that
-went missing, not a real detection - see `control/lanes.go` for why job
-attribution in particular fails that way.
+Since platform mode evaluates only the resolved policies, a run with and
+without `--platform` no longer evaluates the same control set, so diffing the
+two is not a lane check any more. To check a collection lane, compare a
+platform-mode run against the SAME policy evaluated locally by writing that
+policy's control tree into a `.plumber.yaml` and running without `--platform`:
+every difference must be a control moving to `not_evaluable`.
 
 `internal/platform/live_test.go` exercises the client against a running
 platform and skips unless `PLUMBER_E2E_PLATFORM`, `PLUMBER_E2E_TOKEN` and

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -143,6 +143,12 @@ The score is also the pass/fail gate for `plumber analyze` (exit code 1 on failu
 - `--min-score <A-E>`: fail when the letter is below the given one (e.g. `--min-score B` fails on C, D, E). When set without `--min-points`, the letter alone gates.
 - Both set: both must pass.
 
+**In platform mode (`--platform`) these flags are inert:** the exit code is the
+platform's gate verdict, computed per policy from each policy's `enforcement`
+and `min_points`; a locally supplied threshold prints an "ignored" notice. The
+JSON report then carries a `policies` array (one score per policy) and, at the
+top level, the platform's global score.
+
 A run where **zero controls were evaluated** fails the score gate rather than passing as an empty 100-point pipeline: a `.plumber.yaml` that enables no controls for the scanned provider (e.g. a `github:`-only config on a GitLab project), a filter that skips them all, and — on GitLab, where a missing or unparseable CI configuration leaves no control evaluated — a project with no usable CI. On GitLab this matches the historical default (compliance was 0 in those cases).
 
 **On GitHub, a repository with no workflows (or workflows Plumber cannot parse) passes the default gate** when its enabled controls report no findings — the pre-0.4.0 behavior, deliberately restored so fleet scanners can sweep repositories that have no CI without failing on them. Note the score is then computed over what could be checked; gate on findings, not on CI presence.

--- a/internal/engine/opa/engine.go
+++ b/internal/engine/opa/engine.go
@@ -57,8 +57,16 @@ type Finding struct {
 	// Dismissed is set by control.MarkDismissed when the platform served this finding's identity
 	// as dismissed (#447); never emitted by MarshalJSON (the platform hashes that object) and
 	// never a status: pass|fail|not_evaluable is frozen.
-	Dismissed bool           `json:"-"`
-	Data      map[string]any `json:"-"`
+	Dismissed bool `json:"-"`
+	// Policies names the platform policies that reported this finding, set
+	// only on the deduplicated union the security-report writers (SARIF, the
+	// GitLab SAST report) build for a platform-mode run: one alert per
+	// finding, tagged with every policy it belongs to. Empty on every
+	// evaluated finding, and never serialised - MarshalJSON below enumerates
+	// the fields it emits, so the finding object the platform hashes into an
+	// identity (#467) is untouched by this.
+	Policies []string       `json:"-"`
+	Data     map[string]any `json:"-"`
 }
 
 // MarshalJSON flattens the canonical fields and the Data payload into

--- a/internal/platform/client_test.go
+++ b/internal/platform/client_test.go
@@ -53,7 +53,7 @@ func TestFetchContext_DecodesFullShape(t *testing.T) {
 	  "project": "e2e/rail-proj",
 	  "policies": [
 	    {"id":"33333333-3333-3333-3333-333333339501","name":"Baseline","enforcement":"report"},
-	    {"id":"44444444-4444-4444-4444-444444449501","name":"Blocking","enforcement":"block"}
+	    {"id":"44444444-4444-4444-4444-444444449501","name":"Blocking","enforcement":"block","min_points":80}
 	  ],
 	  "snapshot": {
 	    "collected_at": "2026-08-24T07:57:30.32668Z",
@@ -89,6 +89,12 @@ func TestFetchContext_DecodesFullShape(t *testing.T) {
 	}
 	if !ctx.Policies[1].Enforcement.Blocking() || ctx.Policies[0].Enforcement.Blocking() {
 		t.Fatalf("enforcement dials misread: %+v", ctx.Policies)
+	}
+	if ctx.Policies[0].MinPoints != nil {
+		t.Fatalf("policy without min_points must decode nil, got %d", *ctx.Policies[0].MinPoints)
+	}
+	if ctx.Policies[1].MinPoints == nil || *ctx.Policies[1].MinPoints != 80 {
+		t.Fatalf("policy min_points: want 80, got %v", ctx.Policies[1].MinPoints)
 	}
 	if ctx.Snapshot.CollectedAt == nil {
 		t.Fatal("collected_at must decode: it is what the run reports as the snapshot's age")

--- a/internal/platform/types.go
+++ b/internal/platform/types.go
@@ -61,6 +61,14 @@ type Policy struct {
 	Name         string              `json:"name"`
 	Enforcement  Enforcement         `json:"enforcement"`
 	Requirements []PolicyRequirement `json:"requirements,omitempty"`
+
+	// MinPoints is the policy's enforcement threshold as the platform serves it
+	// (Policy.min_points on /context, nullable): a block-mode policy blocks when
+	// its recomputed FINAL points fall strictly below it. nil = unset, the
+	// platform's any-fail rule applies. Read by the platform-verdict renderer
+	// only; never a gate the CLI evaluates itself (the exit code is the
+	// platform's verdict).
+	MinPoints *int `json:"min_points,omitempty"`
 }
 
 // PolicyRequirement is one requirement grouping inside a policy's tree.

--- a/pbom/builders.go
+++ b/pbom/builders.go
@@ -105,6 +105,22 @@ func BuildPlumberScoreSummary(score *control.PlumberScoreResult, scoreMode bool)
 	}
 }
 
+// ApplyPlatformSummary stamps the platform-mode score block onto a document:
+// the per-policy verdicts and the platform's own global score. A no-op for a
+// standalone run (nil summary), which is what keeps those documents
+// byte-identical.
+//
+// It is the counterpart of BuildPlumberScoreSummary and deliberately does not
+// touch PlumberScore: in platform mode there is no run-level score to write
+// there, and the caller has already passed a nil one.
+func (p *PBOM) ApplyPlatformSummary(s *PlatformSummary) {
+	if p == nil || s == nil {
+		return
+	}
+	p.Policies = s.Policies
+	p.PlatformGlobalScore = s.GlobalScore
+}
+
 // normalizeIRImageRef builds the canonical image reference string from an
 // ir.Image, matching the format pbom uses as map keys.
 func normalizeIRImageRef(img ir.Image) string {

--- a/pbom/cyclonedx.go
+++ b/pbom/cyclonedx.go
@@ -115,6 +115,8 @@ func (p *PBOM) ToCycloneDX(plumberVersion string) *CycloneDX {
 		}
 	}
 
+	cdx.Metadata.Properties = append(cdx.Metadata.Properties, platformScoreProperties(p)...)
+
 	// Add container images as components
 	for i, img := range p.ContainerImages {
 		component := CycloneDXComponent{
@@ -307,6 +309,37 @@ func mapIncludeTypeToCycloneDX(includeType string) string {
 	default:
 		return "data"
 	}
+}
+
+// platformScoreProperties renders the platform-mode score block as CycloneDX
+// metadata properties (spec s5): one triple per policy, then the platform's
+// own global score. Returns nothing for a standalone run, so no existing
+// document gains a property.
+//
+// The per-policy letter and points are omitted for a policy the CLI could not
+// evaluate: CycloneDX property values are strings, and an empty or zero one
+// would read as a verdict rather than as the absence of one. The policy is
+// still listed by its enforcement, so a reader sees that it exists and was
+// not scored.
+func platformScoreProperties(p *PBOM) []CycloneDXProperty {
+	props := []CycloneDXProperty{}
+	for _, pol := range p.Policies {
+		prefix := "plumber:policy:" + pol.Name + ":"
+		props = append(props, CycloneDXProperty{Name: prefix + "enforcement", Value: pol.Enforcement})
+		if pol.Score != "" {
+			props = append(props, CycloneDXProperty{Name: prefix + "score", Value: pol.Score})
+		}
+		if pol.FinalPoints != nil {
+			props = append(props, CycloneDXProperty{Name: prefix + "points-final", Value: fmt.Sprintf("%d", *pol.FinalPoints)})
+		}
+	}
+	if g := p.PlatformGlobalScore; g != nil {
+		if g.Letter != "" {
+			props = append(props, CycloneDXProperty{Name: "plumber:platform-global-score", Value: g.Letter})
+		}
+		props = append(props, CycloneDXProperty{Name: "plumber:platform-global-points", Value: fmt.Sprintf("%d", g.Points)})
+	}
+	return props
 }
 
 // projectComponentProperties builds the project-level CycloneDX

--- a/pbom/platform_test.go
+++ b/pbom/platform_test.go
@@ -1,0 +1,112 @@
+package pbom
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// platformPBOM is a PBOM as a platform-mode run writes it: no run-level
+// score, one entry per policy, and the platform's own global score.
+func platformPBOM(t *testing.T) *PBOM {
+	t.Helper()
+	pb := NewGenerator("acme/target", 42, "https://gitlab.com", "main").Generate(nil, nil)
+	sixtySix := 66
+	pb.Policies = []PolicyScore{
+		{Name: "A", Enforcement: "report", Score: "C", FinalPoints: &sixtySix, Applied: true},
+		{Name: "Prod", Enforcement: "block", Applied: false, Reason: "control tree could not be applied"},
+	}
+	pb.PlatformGlobalScore = &PlatformGlobalScore{Letter: "B", Points: 83}
+	return pb
+}
+
+// Spec s5: the PBOM of a platform-mode run carries the per-policy scores and
+// the platform's global score, and NO top-level plumberScore - there is no
+// run-level grade in that mode, and emitting a locally computed one is the
+// wrong-verdict failure the mode removes (QUESTIONS row 44).
+func TestPBOM_PlatformMode_PoliciesAndNoRunLevelScore(t *testing.T) {
+	pb := platformPBOM(t)
+	// scoreMode is still true in platform mode; the score itself is nil, so
+	// the summary builder withholds the block rather than inventing one.
+	pb.PlumberScore = BuildPlumberScoreSummary(nil, true)
+
+	raw, err := json.Marshal(pb)
+	if err != nil {
+		t.Fatalf("marshal pbom: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("pbom is not valid JSON: %v", err)
+	}
+	if _, present := doc["plumberScore"]; present {
+		t.Errorf("plumberScore must be absent in platform mode, got %v", doc["plumberScore"])
+	}
+	policies, ok := doc["policies"].([]any)
+	if !ok || len(policies) != 2 {
+		t.Fatalf("policies: %#v", doc["policies"])
+	}
+	first, _ := policies[0].(map[string]any)
+	if first["name"] != "A" || first["enforcement"] != "report" || first["score"] != "C" || first["finalPoints"] != 66.0 {
+		t.Errorf("policy entry: %#v", first)
+	}
+	second, _ := policies[1].(map[string]any)
+	if _, present := second["score"]; present {
+		t.Errorf("a policy that evaluated nothing must carry no letter: %#v", second)
+	}
+	if _, present := second["finalPoints"]; present {
+		t.Errorf("a policy that evaluated nothing must carry no points: %#v", second)
+	}
+	global, ok := doc["platformGlobalScore"].(map[string]any)
+	if !ok || global["letter"] != "B" || global["points"] != 83.0 {
+		t.Fatalf("platformGlobalScore: %#v", doc["platformGlobalScore"])
+	}
+}
+
+// A standalone PBOM is unchanged: neither key appears.
+func TestPBOM_StandaloneCarriesNoPolicyKeys(t *testing.T) {
+	pb := NewGenerator("acme/target", 42, "https://gitlab.com", "main").Generate(nil, nil)
+	raw, err := json.Marshal(pb)
+	if err != nil {
+		t.Fatalf("marshal pbom: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("pbom is not valid JSON: %v", err)
+	}
+	for _, k := range []string{"policies", "platformGlobalScore"} {
+		if _, present := doc[k]; present {
+			t.Errorf("key %q must be absent outside platform mode", k)
+		}
+	}
+}
+
+// Spec s5 for CycloneDX: the same facts as properties, and no plumber:score
+// property, because there is no run-level score to name.
+func TestToCycloneDX_PlatformMode_PolicyProperties(t *testing.T) {
+	cdx := platformPBOM(t).ToCycloneDX("v0.0.0-test")
+
+	props := map[string]string{}
+	for _, p := range cdx.Metadata.Properties {
+		props[p.Name] = p.Value
+	}
+	if props["plumber:policy:A:score"] != "C" {
+		t.Errorf("plumber:policy:A:score = %q, want C", props["plumber:policy:A:score"])
+	}
+	if props["plumber:policy:A:enforcement"] != "report" {
+		t.Errorf("plumber:policy:A:enforcement = %q, want report", props["plumber:policy:A:enforcement"])
+	}
+	if props["plumber:policy:A:points-final"] != "66" {
+		t.Errorf("plumber:policy:A:points-final = %q, want 66", props["plumber:policy:A:points-final"])
+	}
+	if props["plumber:policy:Prod:enforcement"] != "block" {
+		t.Errorf("a policy that evaluated nothing is still listed: %#v", props)
+	}
+	if _, present := props["plumber:policy:Prod:score"]; present {
+		t.Errorf("a policy that evaluated nothing must carry no letter: %q", props["plumber:policy:Prod:score"])
+	}
+	if props["plumber:platform-global-score"] != "B" || props["plumber:platform-global-points"] != "83" {
+		t.Errorf("the platform's global score must be carried: %#v", props)
+	}
+	if _, present := props["plumber:score"]; present {
+		t.Errorf("plumber:score is the run-level grade and there is none in platform mode: %q", props["plumber:score"])
+	}
+}

--- a/pbom/types.go
+++ b/pbom/types.go
@@ -77,16 +77,24 @@ type PlatformGlobalScore struct {
 // per-policy verdicts and the platform's global score (nil when the push
 // returned none). nil itself outside platform mode.
 //
-// ImageControlsEvaluated is false when no resolved policy enables the image
-// controls. The per-image ForbiddenTag / Authorized booleans are a POSITIVE
-// claim - an image no finding names is published as authorized - so with no
-// policy asking for those controls the writers drop them entirely and the
-// image is reported as inventory alone. Both fields are already *bool, so
-// dropping them is the existing tri-state, not a schema change.
+// ForbiddenTagEvaluated and AuthorizedSourceEvaluated are false when no
+// resolved policy enables the control behind that per-image boolean. The
+// booleans are a POSITIVE claim - an image no finding names is published as
+// authorized, with no forbidden tag - so with no policy asking for a control
+// the writers drop ITS boolean and the image is reported as inventory alone
+// on that axis. Both fields are already *bool, so dropping one is the
+// existing tri-state, not a schema change.
+//
+// They are two flags rather than one because the two controls are
+// independent: a policy commonly pins tags without also restricting
+// registries. Answering for both at once published the other control's
+// positive verdict, which is exactly the claim-nobody-evaluated failure
+// these flags exist to prevent.
 type PlatformSummary struct {
-	Policies               []PolicyScore
-	GlobalScore            *PlatformGlobalScore
-	ImageControlsEvaluated bool
+	Policies                  []PolicyScore
+	GlobalScore               *PlatformGlobalScore
+	ForbiddenTagEvaluated     bool
+	AuthorizedSourceEvaluated bool
 }
 
 // PlumberScoreCounts is the number of issues per severity bucket.

--- a/pbom/types.go
+++ b/pbom/types.go
@@ -76,9 +76,17 @@ type PlatformGlobalScore struct {
 // PlatformSummary is what a platform-mode run hands the PBOM writers: the
 // per-policy verdicts and the platform's global score (nil when the push
 // returned none). nil itself outside platform mode.
+//
+// ImageControlsEvaluated is false when no resolved policy enables the image
+// controls. The per-image ForbiddenTag / Authorized booleans are a POSITIVE
+// claim - an image no finding names is published as authorized - so with no
+// policy asking for those controls the writers drop them entirely and the
+// image is reported as inventory alone. Both fields are already *bool, so
+// dropping them is the existing tri-state, not a schema change.
 type PlatformSummary struct {
-	Policies    []PolicyScore
-	GlobalScore *PlatformGlobalScore
+	Policies               []PolicyScore
+	GlobalScore            *PlatformGlobalScore
+	ImageControlsEvaluated bool
 }
 
 // PlumberScoreCounts is the number of issues per severity bucket.

--- a/pbom/types.go
+++ b/pbom/types.go
@@ -29,6 +29,15 @@ type PBOM struct {
 
 	PlumberScore *PlumberScoreSummary `json:"plumberScore,omitempty"`
 
+	// Policies and PlatformGlobalScore are the platform-mode score block
+	// (spec 2026-09-10-cli-platform-mode-policies-only s5). In that mode
+	// there is no run-level score to put in PlumberScore: every verdict
+	// belongs to one of the platform's policies, and the single global
+	// figure is the platform's own, present only when the push returned one.
+	// Both are absent from a standalone PBOM.
+	Policies            []PolicyScore        `json:"policies,omitempty"`
+	PlatformGlobalScore *PlatformGlobalScore `json:"platformGlobalScore,omitempty"`
+
 	ContainerImages []ContainerImage `json:"containerImages"`
 	Includes        []Include        `json:"includes"`
 }
@@ -42,6 +51,34 @@ type PlumberScoreSummary struct {
 	CriticalMalusApplied bool               `json:"criticalMalusApplied,omitempty"`
 	CriticalMalusMax     float64            `json:"criticalMalusMax,omitempty"`
 	Counts               PlumberScoreCounts `json:"counts"`
+}
+
+// PolicyScore is one resolved platform policy's own verdict over its own
+// control set. Score and FinalPoints are omitted for a policy the CLI could
+// not evaluate (Applied false, Reason says why): a letter-less zero would
+// read as a policy that scored badly rather than one that ran nothing.
+type PolicyScore struct {
+	Name        string `json:"name"`
+	Enforcement string `json:"enforcement"`
+	Score       string `json:"score,omitempty"`
+	FinalPoints *int   `json:"finalPoints,omitempty"`
+	Applied     bool   `json:"applied"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+// PlatformGlobalScore is the platform's own displayed score for the run, as
+// the push response returned it. It is never computed CLI-side.
+type PlatformGlobalScore struct {
+	Letter string `json:"letter,omitempty"`
+	Points int    `json:"points"`
+}
+
+// PlatformSummary is what a platform-mode run hands the PBOM writers: the
+// per-policy verdicts and the platform's global score (nil when the push
+// returned none). nil itself outside platform mode.
+type PlatformSummary struct {
+	Policies    []PolicyScore
+	GlobalScore *PlatformGlobalScore
 }
 
 // PlumberScoreCounts is the number of issues per severity bucket.

--- a/provider/github.go
+++ b/provider/github.go
@@ -92,7 +92,7 @@ func noControlsAwareGitHubCompliance(result *control.AnalysisResult, conf *confi
 	return pbom.BuildGitHubPBOMCompliance(result)
 }
 
-func (p *GitHubProvider) WritePBOM(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool) error {
+func (p *GitHubProvider) WritePBOM(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool, platform *pbom.PlatformSummary) error {
 	host := conf.GithubAPIHost
 	if host == "" {
 		host = "github.com"
@@ -102,6 +102,7 @@ func (p *GitHubProvider) WritePBOM(result *control.AnalysisResult, conf *configu
 		WithCommit(result.ArtifactCommitSHA, result.ArtifactRef)
 	bom := gen.GenerateFromGitHubIR(result.GitHubPipeline)
 	bom.PlumberScore = pbom.BuildPlumberScoreSummary(score, scoreMode)
+	bom.ApplyPlatformSummary(platform)
 
 	f, err := os.Create(filePath)
 	if err != nil {
@@ -113,7 +114,7 @@ func (p *GitHubProvider) WritePBOM(result *control.AnalysisResult, conf *configu
 	return enc.Encode(bom)
 }
 
-func (p *GitHubProvider) WritePBOMCycloneDX(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool) error {
+func (p *GitHubProvider) WritePBOMCycloneDX(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool, platform *pbom.PlatformSummary) error {
 	host := conf.GithubAPIHost
 	if host == "" {
 		host = "github.com"
@@ -123,6 +124,7 @@ func (p *GitHubProvider) WritePBOMCycloneDX(result *control.AnalysisResult, conf
 		WithCommit(result.ArtifactCommitSHA, result.ArtifactRef)
 	bom := gen.GenerateFromGitHubIR(result.GitHubPipeline)
 	bom.PlumberScore = pbom.BuildPlumberScoreSummary(score, scoreMode)
+	bom.ApplyPlatformSummary(platform)
 	cdx := bom.ToCycloneDX("")
 
 	f, err := os.Create(filePath)

--- a/provider/gitlab.go
+++ b/provider/gitlab.go
@@ -86,23 +86,33 @@ func (p *GitLabProvider) RunRemote(_ *configuration.Configuration) (*control.Ana
 	return nil, ErrNoRemote
 }
 
-// noControlsAwareImageCompliance returns the per-image compliance flags, or
-// nil when the run evaluated nothing. The flags are derived from findings,
-// not from the score, so an empty findings slice would otherwise mark every
-// image forbiddenTag:false / authorized:true and assert the very image
-// checks --no-controls skipped, inside the artifact the flag exists to
-// produce. With nil the PBOM records the inventory and claims nothing.
+// imageComplianceFor returns the per-image compliance flags, or nil when this
+// run may not claim them. The flags are derived from findings, not from the
+// score, so an empty findings slice would otherwise mark every image
+// forbiddenTag:false / authorized:true and assert the very image checks
+// nobody ran, inside the artifact the flag exists to produce. With nil the
+// PBOM records the inventory and claims nothing.
+//
+// Two runs may not claim them. --no-controls evaluated nothing at all. And a
+// platform-mode run whose resolved policies do not enable the image controls
+// (platform.ImageControlsEvaluated) evaluated them for no policy, which is
+// the same absence of a verdict; the findings it does have come from the
+// policy runs' union, so the flags it CAN claim are the policies' own.
+//
 // conf is required, as everywhere else on this path (the writers read
 // conf.GitlabURL unconditionally).
-func noControlsAwareImageCompliance(result *control.AnalysisResult, conf *configuration.Configuration) *pbom.ImageComplianceData {
+func imageComplianceFor(result *control.AnalysisResult, conf *configuration.Configuration, platform *pbom.PlatformSummary) *pbom.ImageComplianceData {
 	if conf.NoControls {
+		return nil
+	}
+	if platform != nil && !platform.ImageControlsEvaluated {
 		return nil
 	}
 	return pbom.BuildImageComplianceData(result)
 }
 
 func (p *GitLabProvider) WritePBOM(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool, platform *pbom.PlatformSummary) error {
-	complianceData := noControlsAwareImageCompliance(result, conf)
+	complianceData := imageComplianceFor(result, conf, platform)
 	overrideData := pbom.BuildIncludeOverrideData(result)
 	gen := pbom.NewGenerator(result.ProjectPath, result.ProjectID, conf.GitlabURL, conf.Branch).
 		WithComplianceData(complianceData).
@@ -126,7 +136,7 @@ func (p *GitLabProvider) WritePBOM(result *control.AnalysisResult, conf *configu
 }
 
 func (p *GitLabProvider) WritePBOMCycloneDX(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool, platform *pbom.PlatformSummary) error {
-	complianceData := noControlsAwareImageCompliance(result, conf)
+	complianceData := imageComplianceFor(result, conf, platform)
 	overrideData := pbom.BuildIncludeOverrideData(result)
 	gen := pbom.NewGenerator(result.ProjectPath, result.ProjectID, conf.GitlabURL, conf.Branch).
 		WithComplianceData(complianceData).

--- a/provider/gitlab.go
+++ b/provider/gitlab.go
@@ -101,7 +101,7 @@ func noControlsAwareImageCompliance(result *control.AnalysisResult, conf *config
 	return pbom.BuildImageComplianceData(result)
 }
 
-func (p *GitLabProvider) WritePBOM(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool) error {
+func (p *GitLabProvider) WritePBOM(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool, platform *pbom.PlatformSummary) error {
 	complianceData := noControlsAwareImageCompliance(result, conf)
 	overrideData := pbom.BuildIncludeOverrideData(result)
 	gen := pbom.NewGenerator(result.ProjectPath, result.ProjectID, conf.GitlabURL, conf.Branch).
@@ -113,6 +113,7 @@ func (p *GitLabProvider) WritePBOM(result *control.AnalysisResult, conf *configu
 	}
 	bom := gen.Generate(result.PipelineImageData, result.PipelineOriginData)
 	bom.PlumberScore = pbom.BuildPlumberScoreSummary(score, scoreMode)
+	bom.ApplyPlatformSummary(platform)
 
 	f, err := os.Create(filePath)
 	if err != nil {
@@ -124,7 +125,7 @@ func (p *GitLabProvider) WritePBOM(result *control.AnalysisResult, conf *configu
 	return enc.Encode(bom)
 }
 
-func (p *GitLabProvider) WritePBOMCycloneDX(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool) error {
+func (p *GitLabProvider) WritePBOMCycloneDX(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool, platform *pbom.PlatformSummary) error {
 	complianceData := noControlsAwareImageCompliance(result, conf)
 	overrideData := pbom.BuildIncludeOverrideData(result)
 	gen := pbom.NewGenerator(result.ProjectPath, result.ProjectID, conf.GitlabURL, conf.Branch).
@@ -136,6 +137,7 @@ func (p *GitLabProvider) WritePBOMCycloneDX(result *control.AnalysisResult, conf
 	}
 	bom := gen.Generate(result.PipelineImageData, result.PipelineOriginData)
 	bom.PlumberScore = pbom.BuildPlumberScoreSummary(score, scoreMode)
+	bom.ApplyPlatformSummary(platform)
 	cdx := bom.ToCycloneDX("")
 
 	f, err := os.Create(filePath)
@@ -157,7 +159,7 @@ func (p *GitLabProvider) PostAnalysisActions(cmd *cobra.Command, result *control
 			fmt.Fprintf(os.Stderr, "Skipping merge request comment: data collection was incomplete; not overwriting with a partial result.\n")
 		} else if mrIID := glabCI.DetectMergeRequestIID(); mrIID != 0 {
 			fmt.Fprintf(os.Stderr, "Merge request pipeline detected (MR !%d), posting Plumber comment...\n", mrIID)
-			if err := control.ManageMergeRequestComment(result.ProjectID, mrIID, result, conf.PlumberConfig, s.Passed, s.GateLine, conf, s.Score, s.ScoreMode, s.ScorePoint); err != nil {
+			if err := control.ManageMergeRequestComment(result.ProjectID, mrIID, result, conf.PlumberConfig, s.Passed, s.GateLine, conf, s.Score, s.ScoreMode, s.ScorePoint, s.Platform); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to post merge request comment: %v\n", err)
 			} else {
 				fmt.Fprintf(os.Stderr, "Merge request comment posted successfully\n")
@@ -170,7 +172,14 @@ func (p *GitLabProvider) PostAnalysisActions(cmd *cobra.Command, result *control
 			fmt.Fprintf(os.Stderr, "Skipping badge update (%s)\n", skipReason)
 		} else {
 			fmt.Fprintf(os.Stderr, "Updating project badge...\n")
-			if err := control.ManageProjectBadge(result.ProjectID, conf, s.Score); err != nil {
+			// In platform mode the letter is the platform's global one, and
+			// there is no local score to fall back on when it is missing:
+			// the badge is then left on its last good value (spec s5).
+			update := func() error { return control.ManageProjectBadge(result.ProjectID, conf, s.Score) }
+			if s.Platform != nil {
+				update = func() error { return control.ManageProjectBadgePlatform(result.ProjectID, conf, s.Platform) }
+			}
+			if err := update(); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: failed to update project badge: %v\n", err)
 			} else {
 				fmt.Fprintf(os.Stderr, "Project badge updated successfully\n")

--- a/provider/gitlab.go
+++ b/provider/gitlab.go
@@ -94,10 +94,17 @@ func (p *GitLabProvider) RunRemote(_ *configuration.Configuration) (*control.Ana
 // PBOM records the inventory and claims nothing.
 //
 // Two runs may not claim them. --no-controls evaluated nothing at all. And a
-// platform-mode run whose resolved policies do not enable the image controls
-// (platform.ImageControlsEvaluated) evaluated them for no policy, which is
-// the same absence of a verdict; the findings it does have come from the
-// policy runs' union, so the flags it CAN claim are the policies' own.
+// platform-mode run whose resolved policies do not enable an image control
+// evaluated it for no policy, which is the same absence of a verdict; the
+// findings it does have come from the policy runs' union, so the flags it
+// CAN claim are the policies' own.
+//
+// The answer is per control, not per pair: the forbidden-tag and the
+// authorized-source controls are independent, and a policy that pins tags
+// without restricting registries would otherwise publish "authorized" for
+// every image on the strength of the OTHER control having run. Dropping the
+// map of a control nobody enabled leaves that field out of every image (the
+// generator's existing tri-state), while the other one is still published.
 //
 // conf is required, as everywhere else on this path (the writers read
 // conf.GitlabURL unconditionally).
@@ -105,10 +112,22 @@ func imageComplianceFor(result *control.AnalysisResult, conf *configuration.Conf
 	if conf.NoControls {
 		return nil
 	}
-	if platform != nil && !platform.ImageControlsEvaluated {
+	data := pbom.BuildImageComplianceData(result)
+	if platform == nil {
+		return data
+	}
+	if !platform.ForbiddenTagEvaluated {
+		data.ForbiddenTagImages = nil
+	}
+	if !platform.AuthorizedSourceEvaluated {
+		data.UnauthorizedImages = nil
+	}
+	if data.ForbiddenTagImages == nil && data.UnauthorizedImages == nil {
+		// No image control at all: nil, exactly as before, so the generator
+		// takes its no-compliance-data path rather than an empty one.
 		return nil
 	}
-	return pbom.BuildImageComplianceData(result)
+	return data
 }
 
 func (p *GitLabProvider) WritePBOM(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool, platform *pbom.PlatformSummary) error {

--- a/provider/pbom_provenance_test.go
+++ b/provider/pbom_provenance_test.go
@@ -26,7 +26,7 @@ func TestGitLabWritePBOMCarriesCommit(t *testing.T) {
 
 	t.Run("native PBOM stamps project.commitSHA and project.ref", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "pbom.json")
-		if err := p.WritePBOM(result, conf, path, nil, false); err != nil {
+		if err := p.WritePBOM(result, conf, path, nil, false, nil); err != nil {
 			t.Fatalf("WritePBOM: %v", err)
 		}
 		raw, _ := os.ReadFile(path)
@@ -49,7 +49,7 @@ func TestGitLabWritePBOMCarriesCommit(t *testing.T) {
 
 	t.Run("CycloneDX stamps plumber:git:commit and plumber:git:ref", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "cdx.json")
-		if err := p.WritePBOMCycloneDX(result, conf, path, nil, false); err != nil {
+		if err := p.WritePBOMCycloneDX(result, conf, path, nil, false, nil); err != nil {
 			t.Fatalf("WritePBOMCycloneDX: %v", err)
 		}
 		raw, _ := os.ReadFile(path)
@@ -94,7 +94,7 @@ func TestGitHubWritePBOMCarriesCommit(t *testing.T) {
 
 	t.Run("native PBOM stamps project.commitSHA and project.ref", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "pbom.json")
-		if err := p.WritePBOM(result, conf, path, nil, false); err != nil {
+		if err := p.WritePBOM(result, conf, path, nil, false, nil); err != nil {
 			t.Fatalf("WritePBOM: %v", err)
 		}
 		raw, _ := os.ReadFile(path)
@@ -117,7 +117,7 @@ func TestGitHubWritePBOMCarriesCommit(t *testing.T) {
 
 	t.Run("CycloneDX stamps plumber:git:commit and plumber:git:ref", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "cdx.json")
-		if err := p.WritePBOMCycloneDX(result, conf, path, nil, false); err != nil {
+		if err := p.WritePBOMCycloneDX(result, conf, path, nil, false, nil); err != nil {
 			t.Fatalf("WritePBOMCycloneDX: %v", err)
 		}
 		raw, _ := os.ReadFile(path)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/getplumber/plumber/configuration"
 	"github.com/getplumber/plumber/control"
 	opaengine "github.com/getplumber/plumber/internal/engine/opa"
+	"github.com/getplumber/plumber/pbom"
 	"github.com/spf13/cobra"
 )
 
@@ -69,13 +70,29 @@ type CIEnvMapping struct {
 // PostActionSummary bundles the gate outcome needed by PostAnalysisActions
 // to avoid exceeding the parameter count limit. Passed is the active gate's
 // verdict; GateLine is its human-readable rendering for the MR comment.
+//
+// Platform is set only in platform mode (spec
+// 2026-09-10-cli-platform-mode-policies-only s5) and is then what the badge
+// and the merge-request comment report: Score is nil there by construction,
+// because the run has no run-level grade and a locally computed one would be
+// the figure that contradicts the platform's.
 type PostActionSummary struct {
 	Passed     bool
 	GateLine   string
 	Score      *control.PlumberScoreResult
 	ScoreMode  bool
 	ScorePoint bool
+	Platform   *PlatformPostSummary
 }
+
+// PlatformPostSummary and PlatformPolicyLine are control's types, re-exported
+// under this package's names because the post actions are named from here.
+// They live in control/ because that is where the badge and the comment that
+// render them live, and control cannot import provider.
+type (
+	PlatformPostSummary = control.PlatformPostSummary
+	PlatformPolicyLine  = control.PlatformPolicyLine
+)
 
 // Provider is the contract every CI platform must satisfy. The analyze
 // command resolves the active provider via Get() and delegates all
@@ -104,11 +121,13 @@ type Provider interface {
 	RunRemote(conf *configuration.Configuration) (*control.AnalysisResult, error)
 
 	// WritePBOM writes a Pipeline Bill of Materials to filePath in the
-	// provider's native PBOM format.
-	WritePBOM(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool) error
+	// provider's native PBOM format. platform is the platform-mode score
+	// block (per-policy verdicts plus the platform's global score), nil on
+	// every other run.
+	WritePBOM(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool, platform *pbom.PlatformSummary) error
 
 	// WritePBOMCycloneDX writes the PBOM in CycloneDX format.
-	WritePBOMCycloneDX(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool) error
+	WritePBOMCycloneDX(result *control.AnalysisResult, conf *configuration.Configuration, filePath string, score *control.PlumberScoreResult, scoreMode bool, platform *pbom.PlatformSummary) error
 
 	// PostAnalysisActions runs provider-specific post-analysis side-effects
 	// such as posting MR comments or updating the project badge. Providers

--- a/templates/plumber.yml
+++ b/templates/plumber.yml
@@ -32,13 +32,13 @@ spec:
 
     # Gate configuration
     min_points:
-      description: "Minimum Plumber Score points required to pass (0-100). Default: 100 — any finding fails, same as the previous default behavior. Leave empty to keep the default. Ignored when platform is set: enforcement then comes from the platform's policies."
+      description: "Minimum Plumber Score points required to pass (0-100). Default: 100 - any finding fails, same as the previous default behavior. Leave empty to keep the default. Ignored when `platform` is set: enforcement then comes from the platform's policies."
       default: ""
     min_score:
-      description: "Minimum Plumber Score letter required to pass (A-E), e.g. B fails on C, D, E. When set without min_points, the letter alone gates. Ignored when platform is set: enforcement then comes from the platform's policies."
+      description: "Minimum Plumber Score letter required to pass (A-E), e.g. B fails on C, D, E. When set without min_points, the letter alone gates. Ignored when `platform` is set: enforcement then comes from the platform's policies."
       default: ""
     threshold:
-      description: "Deprecated: minimum percentage of passing controls (0-100). Use min_points / min_score to gate on the Plumber Score instead. The default (100) is equivalent to the default score gate and is treated as unset. Ignored when platform is set: enforcement then comes from the platform's policies."
+      description: "Deprecated: minimum percentage of passing controls (0-100). Use min_points / min_score to gate on the Plumber Score instead. The default (100) is equivalent to the default score gate and is treated as unset. Ignored when `platform` is set: enforcement then comes from the platform's policies."
       type: number
       default: 100
 
@@ -99,7 +99,7 @@ spec:
       description: "Score service base URL. Override only for a self-hosted score service; the OIDC audience follows this value so it always matches the target."
       default: "https://score.getplumber.io"
     platform:
-      description: "Plumber platform base URL. Setting it pushes this run's full results there over CI OIDC, and takes precedence over score_push. The default is a placeholder (RFC 2606 .invalid) that never enables a push — GitLab requires the id_tokens audience to be non-empty, so this input cannot default to empty. In platform mode only the platform's policies are evaluated and the platform's gate decides the exit code."
+      description: "Plumber platform base URL. Setting it pushes this run's full results there over CI OIDC, and takes precedence over score_push. The default is a placeholder (RFC 2606 .invalid) that never enables a push - GitLab requires the id_tokens audience to be non-empty, so this input cannot default to empty. In platform mode only the platform's policies are evaluated and the platform's gate decides the exit code."
       default: "https://platform.invalid"
     controls:
       description: Run only listed controls (comma-separated control names). Cannot be used with skip_controls.

--- a/templates/plumber.yml
+++ b/templates/plumber.yml
@@ -32,13 +32,13 @@ spec:
 
     # Gate configuration
     min_points:
-      description: "Minimum Plumber Score points required to pass (0-100). Default: 100 — any finding fails, same as the previous default behavior. Leave empty to keep the default."
+      description: "Minimum Plumber Score points required to pass (0-100). Default: 100 — any finding fails, same as the previous default behavior. Leave empty to keep the default. Ignored when platform is set: enforcement then comes from the platform's policies."
       default: ""
     min_score:
-      description: "Minimum Plumber Score letter required to pass (A-E), e.g. B fails on C, D, E. When set without min_points, the letter alone gates."
+      description: "Minimum Plumber Score letter required to pass (A-E), e.g. B fails on C, D, E. When set without min_points, the letter alone gates. Ignored when platform is set: enforcement then comes from the platform's policies."
       default: ""
     threshold:
-      description: "Deprecated: minimum percentage of passing controls (0-100). Use min_points / min_score to gate on the Plumber Score instead. The default (100) is equivalent to the default score gate and is treated as unset."
+      description: "Deprecated: minimum percentage of passing controls (0-100). Use min_points / min_score to gate on the Plumber Score instead. The default (100) is equivalent to the default score gate and is treated as unset. Ignored when platform is set: enforcement then comes from the platform's policies."
       type: number
       default: 100
 
@@ -99,7 +99,7 @@ spec:
       description: "Score service base URL. Override only for a self-hosted score service; the OIDC audience follows this value so it always matches the target."
       default: "https://score.getplumber.io"
     platform:
-      description: "Plumber platform base URL. Setting it pushes this run's full results there over CI OIDC, and takes precedence over score_push. The default is a placeholder (RFC 2606 .invalid) that never enables a push — GitLab requires the id_tokens audience to be non-empty, so this input cannot default to empty."
+      description: "Plumber platform base URL. Setting it pushes this run's full results there over CI OIDC, and takes precedence over score_push. The default is a placeholder (RFC 2606 .invalid) that never enables a push — GitLab requires the id_tokens audience to be non-empty, so this input cannot default to empty. In platform mode only the platform's policies are evaluated and the platform's gate decides the exit code."
       default: "https://platform.invalid"
     controls:
       description: Run only listed controls (comma-separated control names). Cannot be used with skip_controls.


### PR DESCRIPTION
## What

A CLI linked to a platform (`--platform`) evaluates only the policies the platform resolved, and nothing else.

Ruling (platform decision queue row 44, 2026-09-10): "if the CLI is linked to a platform, then it must run only the policy received from the platform, nothing else." Design: monorepo `docs/superpowers/specs/2026-09-10-cli-platform-mode-policies-only-design.md`. Closes #466.

Before this change a platform-mode job graded the LOCAL configuration (the built-in default when no `.plumber.yaml` exists) for its banner and exit code, and only the per-policy re-evaluation fed the push. A project whose policy did not enable a control could read C and fail in the job while the platform showed A for the same push.

## Behaviour change (platform mode only)

- The local `.plumber.yaml` and the built-in default are never evaluated. A present file and any local threshold (`--min-points`, `--min-score`, `--threshold`, the component inputs) are ignored with a one-line notice.
- The job log prints one section per resolved policy (policies sharing a control configuration are evaluated once), then a `Platform verdict` block from the push response: per-policy blocking, the platform's global score, the exit line.
- The exit code is the platform's gate verdict only (per-policy `enforcement` and `min_points`). No local score gate. A degraded collection is pushed and gated by the platform, no local exit 3. `--fail-warnings` still applies.
- An unreachable platform, or zero resolved policies, evaluates nothing, prints one line, pushes nothing and exits 0.
- Artifacts: the JSON report carries a `policies` array (one entry per policy: enforcement, min_points, score, its findings, its not-evaluable marks, the finding objects themselves unchanged byte for byte) plus `platformMode: true` and the platform's global score as `plumberScore` when present; the legacy per-control `*Result` blocks and `plumberConfig` are OMITTED in platform mode (they described the local configuration), which is a breaking change for anything parsing a platform-mode `--output` file. PBOM/CycloneDX carry the same `policies` array, the global score as a property, and per-image compliance computed from the policies' findings (omitted when no policy evaluates the image controls). SARIF/GLSAST carry the union of the policies' findings with the policy names as a property. CSV gains a trailing `policies` column and OCSF a `policies` key in platform mode. The badge and the MR comment headline use the platform's global score.
- Order: in platform mode the push happens before the artifacts are written (the global score must be known), so a write error on an already-pushed run surfaces before the gate's exit code.
- `--no-controls` (inventory-only) runs are untouched.

Non-platform runs are byte-for-byte unchanged.

## Rulings taken while implementing (in the plan header, for review)

1. The derived `[Plumber default]` placeholder the platform serves when it has no policy evaluates the embedded default under that name (never a local file).
2. A real policy declaring no control evaluates an empty set (A / 100, labelled "declares no controls").
3. A policy whose control tree cannot be applied is not evaluated and not pushed; the section says why.
4. The assembled per-policy config version is the constant 2.0.
5. The verdict's reason text is rendered CLI-side from enforcement, `min_points` and the CLI's own final points; the blocking bit is the platform's.
6. A run with no retained pipeline IR reports "nothing evaluated" and is not pushed.

## Wire

`/context` policies now decode `min_points`; the push response's `global_score` is decoded. The push body is unchanged.

## Testing

TDD per task with RED/GREEN evidence in the per-task reports. `go test ./...` green, `go vet`, pinned golangci-lint v2.10.1 (0 issues), deadcode clean. End-to-end against demo.getplumber.tech in a real GitLab job on a demo project with the CLI built from this branch: policy section, verdict block and exit code verified (job links in the PR conversation).

## Release note (maintainer's call: the reviewer recommends marking this release breaking)

The commits are `feat(platform)` without `!`, so semantic-release would cut a minor. The whole-branch review recommends a breaking marker, or at least leading the release notes with these, because outcomes flip silently on already-linked projects:

1. Exit code: a linked run that passed its local gate can now exit 1 on the platform's verdict, and one that failed locally can now exit 0.
2. GitHub platform mode: the platform serves the `[Plumber default]` placeholder there (results-sink mode), which now means "evaluate the embedded default": a GitHub project with its own `.plumber.yaml` and `--platform` set is no longer evaluated against that file (ruling 1 above).
3. `--output` JSON keys removed in platform mode: `plumberConfig`, every `*Result` block, `notEvaluable`, `minPoints`/`minScore`/`threshold`; parsers read `policies` and `platformMode: true`.
4. No exit 3 on a degraded collection in platform mode; no artifacts at all on a zero-policy run (the component's declared artifact paths are then "no files to upload").
5. MR comment body and badge source changed; CSV gains a `policies` column, OCSF a `policies` key, SARIF/GLSAST a policy tag.

If you want the marker, squash-merge with `feat(platform)!:` or add a `BREAKING CHANGE:` footer; do not hand-edit CHANGELOG.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRHuGuptmc9Rd147CsC2se
