### PR TITLE
fix(platform): recognise the component job's checkout and use the resolve endpoint's includes

### DIFF
--- a/control/lanes.go
+++ b/control/lanes.go
@@ -144,10 +144,11 @@ func (r *AnalysisResult) MarkNotEvaluable(controlName, reason string) {
 }
 
 // MarkIncludeAttributionUnavailable flags every control that reasons about
-// include attribution as not evaluable. Used when the merged configuration
-// came from somewhere that does not carry per-include provenance — today,
-// the platform snapshot or its resolve endpoint, both of which return the
-// merged document only.
+// include attribution as not evaluable. Used when nothing supplied
+// per-include provenance for the merged configuration being evaluated: a
+// snapshot that carried no includes, or a resolve response that served
+// none. Attribution served for a DIFFERENT document does not count, and is
+// never substituted.
 func (r *AnalysisResult) MarkIncludeAttributionUnavailable(entries []ControlEntry) {
 	r.markIncludeControls(entries, ReasonIncludeAttributionUnavailable)
 }
@@ -262,16 +263,19 @@ func markPlatformLaneGapsFor(result *AnalysisResult, conf *configuration.Configu
 			}
 		}
 		result.MarkMergedConfigUnavailable(entries, reason)
-	} else if _, haveIncludes := conf.PlatformRun.SnapshotIncludes(); !haveIncludes || !conf.PlatformRun.ConfigAndIncludesAgree() {
+	} else if !conf.PlatformRun.ConfigAndIncludesAgree() {
 		// A merged configuration with no USABLE attribution alongside it.
 		// Two ways that happens, and both must degrade:
 		//
-		//   - the snapshot carried no includes at all, or
-		//   - it carried includes for a DIFFERENT configuration than the one
-		//     being evaluated. On a digest-divergent branch MergedYAML is the
-		//     branch's freshly resolved config while the includes still
-		//     describe the anchor's, and the resolve endpoint serves no
-		//     includes of its own (see RunContext.ConfigAndIncludesAgree).
+		//   - nothing served attribution for the document being evaluated:
+		//     a snapshot-sourced config whose snapshot carried no includes,
+		//     or a resolve-sourced one the endpoint served none for, or
+		//   - the only attribution available describes a DIFFERENT
+		//     configuration. On a digest-divergent branch MergedYAML is the
+		//     branch's freshly resolved config while the snapshot's
+		//     includes still describe the anchor's, and that list is never
+		//     lent to it (see RunContext.Includes, which pairs each source
+		//     with the attribution that belongs to it).
 		//
 		// Marking here is not merely withholding a verdict: without matching
 		// attribution the per-job origin is WRONG, not absent, so these

--- a/control/lanes_dispatch_test.go
+++ b/control/lanes_dispatch_test.go
@@ -109,6 +109,69 @@ func TestIncludeAttributionDegradesWhenTheConfigIsNotTheSnapshots(t *testing.T) 
 	}
 }
 
+// The other half of the same rule: attribution that DOES describe the
+// configuration in use must be used, wherever it came from.
+//
+// The resolve endpoint serves an includes list for the document it returns,
+// and the CLI dropped it, so every resolve-sourced run abstained on the
+// three include controls even though branch-accurate attribution had just
+// been handed to it. That is the normal shape of a CI job with no checkout
+// digest, so the abstention was permanent rather than exceptional. The
+// snapshot's list is still never borrowed: only what the resolve response
+// itself carried counts here.
+func TestResolveServedIncludesRestoreAttribution(t *testing.T) {
+	// The snapshot's own list is present throughout, and describes the
+	// anchor. It must not be what unblocks (or blocks) anything below.
+	anchorIncludes := oneInclude()
+	served := []json.RawMessage{json.RawMessage(`{"location":"gitlab.com/c/branch@2.0.0","type":"component"}`)}
+
+	attributionControls := []string{
+		"pipelineMustNotIncludeHardcodedJobs",
+		"includesMustBeUpToDate",
+		"externalRefsMustNotCollide",
+	}
+
+	// Whether the SNAPSHOT carries a list of its own is irrelevant to a
+	// resolve-sourced run, and both states are real: a project analysed
+	// before its first snapshot include collection has none. Only what the
+	// resolve response carried decides.
+	for _, snapshotState := range []struct {
+		name     string
+		includes []json.RawMessage
+	}{
+		{"snapshot carrying its own anchor list", anchorIncludes},
+		{"snapshot carrying no list at all", nil},
+	} {
+		t.Run("a resolved config with its own includes evaluates them, "+snapshotState.name, func(t *testing.T) {
+			result := &AnalysisResult{}
+			conf := confWithControls(platformRun(platform.SourceResolved, "stages: [build]", snapshotState.includes))
+			conf.PlatformRun.Config.Includes = served
+
+			markPlatformLaneGaps(result, conf)
+
+			for _, name := range attributionControls {
+				if reason, marked := result.NotEvaluable[name]; marked {
+					t.Errorf("%s marked %q: the resolve endpoint served attribution for the config being evaluated", name, reason)
+				}
+			}
+		})
+	}
+
+	t.Run("a resolved config the endpoint served no includes for still degrades", func(t *testing.T) {
+		result := &AnalysisResult{}
+		conf := confWithControls(platformRun(platform.SourceResolved, "stages: [build]", anchorIncludes))
+
+		markPlatformLaneGaps(result, conf)
+
+		for _, name := range attributionControls {
+			if reason := result.NotEvaluable[name]; reason != ReasonIncludeAttributionUnavailable {
+				t.Errorf("%s reason = %q, want %q: the snapshot's list describes the anchor, not this branch",
+					name, reason, ReasonIncludeAttributionUnavailable)
+			}
+		}
+	})
+}
+
 // The dispatcher chooses between three mutually exclusive treatments. A
 // swapped or inverted branch here would either degrade a healthy run
 // entirely or let an empty one report all-clean, and until now nothing

--- a/control/lanes_dispatch_test.go
+++ b/control/lanes_dispatch_test.go
@@ -172,6 +172,34 @@ func TestResolveServedIncludesRestoreAttribution(t *testing.T) {
 	})
 }
 
+// TestResolveServedEmptyIncludesIsCompleteAttribution pins the other half
+// of the fix: an EMPTY served includes list is a complete, known answer
+// (this branch's merged config has zero includes, every job is
+// project-authored) and must evaluate the include-reasoning controls
+// normally, exactly like a non-empty served list does. Before the fix, an
+// empty list read the same as no list at all and left these controls
+// abstaining with ReasonIncludeAttributionUnavailable forever.
+func TestResolveServedEmptyIncludesIsCompleteAttribution(t *testing.T) {
+	anchorIncludes := oneInclude()
+	attributionControls := []string{
+		"pipelineMustNotIncludeHardcodedJobs",
+		"includesMustBeUpToDate",
+		"externalRefsMustNotCollide",
+	}
+
+	result := &AnalysisResult{}
+	conf := confWithControls(platformRun(platform.SourceResolved, "stages: [build]", anchorIncludes))
+	conf.PlatformRun.Config.Includes = []json.RawMessage{}
+
+	markPlatformLaneGaps(result, conf)
+
+	for _, name := range attributionControls {
+		if reason, marked := result.NotEvaluable[name]; marked {
+			t.Errorf("%s marked %q: a served EMPTY list is a complete answer, not an unavailable one", name, reason)
+		}
+	}
+}
+
 // The dispatcher chooses between three mutually exclusive treatments. A
 // swapped or inverted branch here would either degrade a healthy run
 // entirely or let an empty one report all-clean, and until now nothing

--- a/gitlab/utilsCI.go
+++ b/gitlab/utilsCI.go
@@ -212,18 +212,22 @@ const maxServedRawConfigBytes = 2 << 20 // 2 MiB
 // the jobs that failed to merge.
 //
 // It applies only when the configuration being evaluated IS the snapshot's
-// - the same test the include attribution passes (see platformIncludes).
-// On a digest-divergent branch the merged document came from the resolve
-// endpoint for THIS branch while merged_yaml_status describes the anchor's,
-// and reporting one document's verdict about another is a diagnosis nothing
-// gathered. The resolve endpoint answers that case itself, through
-// ConfigInvalid.
+// own document (ConfigIsSnapshot). On a digest-divergent branch the merged
+// document came from the resolve endpoint for THIS branch while
+// merged_yaml_status describes the anchor's, and reporting one document's
+// verdict about another is a diagnosis nothing gathered. The resolve
+// endpoint answers that case itself, through ConfigInvalid.
+//
+// This is deliberately NOT the test the include attribution passes. The
+// endpoint can serve attribution for the document it returned, which makes
+// attribution available without making the snapshot's other statements
+// apply to it.
 //
 // Snapshots older than 2026-08-28 serve neither field, so the synthesis
 // stays the fallback rather than being replaced - and so does a status
 // outside the contract's closed set, which this CLI has no reading for.
 func platformMergeVerdict(conf *configuration.Configuration) (string, []string) {
-	if conf.PlatformRun.ConfigAndIncludesAgree() {
+	if conf.PlatformRun.ConfigIsSnapshot() {
 		if status, errs, served := conf.PlatformRun.SnapshotMergeVerdict(); served {
 			switch status {
 			case mergeStatusValid:
@@ -259,7 +263,7 @@ func platformMergeVerdict(conf *configuration.Configuration) (string, []string) 
 	return mergeStatusValid, nil
 }
 
-// platformIncludes decodes the snapshot's per-include attribution into the
+// platformIncludes decodes the platform's per-include attribution into the
 // CLI's own include shape. The platform carries these AS-IS - they ARE
 // MergedCIConfResponseInclude values, never a translation - so a decode
 // failure means the contract was broken, not that a field moved.
@@ -269,17 +273,15 @@ func platformMergeVerdict(conf *configuration.Configuration) (string, []string) 
 // project, and a half-decoded include produces a confidently wrong answer;
 // dropping it leaves the list short, which the caller detects as missing
 // attribution and degrades honestly.
-// It also returns nothing when the merged configuration in use did NOT come
-// from the same snapshot these includes did. The snapshot's attribution
-// describes the anchor's configuration; on a digest-divergent branch the
-// config being evaluated is the branch's own, and attaching the anchor's
-// attribution to it mis-classifies every job the branch's include changes
-// touched. See RunContext.ConfigAndIncludesAgree.
+// It returns only the attribution that belongs to the configuration in use:
+// the snapshot's list for a snapshot-sourced config, the resolve response's
+// own for a resolved one, and nothing when neither served any. The
+// snapshot's attribution describes the anchor's configuration; on a
+// digest-divergent branch the config being evaluated is the branch's own,
+// and attaching the anchor's attribution to it mis-classifies every job the
+// branch's include changes touched. See RunContext.Includes.
 func platformIncludes(conf *configuration.Configuration) []MergedCIConfResponseInclude {
-	if !conf.PlatformRun.ConfigAndIncludesAgree() {
-		return nil
-	}
-	raw, ok := conf.PlatformRun.SnapshotIncludes()
+	raw, ok := conf.PlatformRun.Includes()
 	if !ok {
 		return nil
 	}
@@ -287,7 +289,7 @@ func platformIncludes(conf *configuration.Configuration) []MergedCIConfResponseI
 	for _, r := range raw {
 		var inc MergedCIConfResponseInclude
 		if err := json.Unmarshal(r, &inc); err != nil {
-			logger.WithError(err).Warn("platform snapshot carried an include this CLI could not decode; dropping it")
+			logger.WithError(err).Warn("the platform carried an include this CLI could not decode; dropping it")
 			continue
 		}
 		out = append(out, inc)

--- a/gitlab/utilsCI_platform_test.go
+++ b/gitlab/utilsCI_platform_test.go
@@ -151,6 +151,25 @@ func TestPlatformIncludesOnlyServeTheirOwnConfig(t *testing.T) {
 	}
 }
 
+// TestPlatformIncludesServedEmptyIsNonNilAndUsed pins that a served EMPTY
+// includes list is used, not treated as missing attribution: it returns a
+// non-nil, zero-length slice, and the origin loop that ranges over it then
+// correctly attributes every job in the merged config to the project
+// (dataCollectionGitlabPipelineOrigin.go), which is the right answer when
+// there are genuinely zero includes.
+func TestPlatformIncludesServedEmptyIsNonNilAndUsed(t *testing.T) {
+	conf := platformConf(platform.SourceResolved, "stages: [build]")
+	conf.PlatformRun.Config.Includes = []json.RawMessage{}
+
+	got := platformIncludes(conf)
+	if got == nil {
+		t.Fatal("want a non-nil empty slice for a served-empty list, got nil")
+	}
+	if len(got) != 0 {
+		t.Fatalf("want zero entries, got %d", len(got))
+	}
+}
+
 // A malformed include is DROPPED, not partially applied. A half-decoded
 // include gives a confidently wrong origin; a short list is detected
 // upstream as missing attribution and degrades honestly.

--- a/gitlab/utilsCI_platform_test.go
+++ b/gitlab/utilsCI_platform_test.go
@@ -111,11 +111,26 @@ func TestPlatformMergedConfigReportsEmptyAsValidNotInvalid(t *testing.T) {
 
 // Attribution is only usable when it describes the configuration actually
 // being evaluated. On a digest-divergent branch the config comes from the
-// resolve endpoint (which serves no includes) while the snapshot's includes
-// still describe the anchor, so pairing them would mis-classify every job an
-// include the branch touched contributed.
+// resolve endpoint while the snapshot's includes still describe the anchor,
+// so pairing those two would mis-classify every job an include the branch
+// touched contributed. The endpoint's OWN list is a different matter: it
+// describes the document it came with, and is used.
 func TestPlatformIncludesOnlyServeTheirOwnConfig(t *testing.T) {
 	const inc = `{"location":"gitlab.com/c/x@1.0.0","type":"component"}`
+	const served = `{"location":"gitlab.com/c/branch@2.0.0","type":"component"}`
+
+	t.Run("a resolved config gets the includes the endpoint served for it", func(t *testing.T) {
+		conf := platformConf(platform.SourceResolved, "stages: [build]", inc)
+		conf.PlatformRun.Config.Includes = []json.RawMessage{json.RawMessage(served)}
+
+		got := platformIncludes(conf)
+		if len(got) != 1 {
+			t.Fatalf("want the served include, got %d", len(got))
+		}
+		if got[0].Location != "gitlab.com/c/branch@2.0.0" {
+			t.Fatalf("include location = %q, want the resolve response's own, not the anchor's", got[0].Location)
+		}
+	})
 
 	t.Run("snapshot config gets the snapshot's includes", func(t *testing.T) {
 		got := platformIncludes(platformConf(platform.SourceSnapshot, "stages: [build]", inc))
@@ -283,6 +298,33 @@ func TestPlatformMergedConfigUsesTheServedMergeVerdict(t *testing.T) {
 		resp, _ := platformMergedConfig(conf)
 		if resp.CiConfig.Status != "VALID" {
 			t.Errorf("status = %q: the resolve endpoint judged THIS branch's config valid", resp.CiConfig.Status)
+		}
+		if len(resp.CiConfig.Errors) != 0 {
+			t.Errorf("errors = %v, want none: these describe the anchor's configuration", resp.CiConfig.Errors)
+		}
+	})
+
+	// Served attribution does not drag the anchor's verdict along with it.
+	// The two questions were once answered by the same predicate, because
+	// only a snapshot-sourced config could have attribution at all. Now
+	// that the resolve endpoint serves its own includes, the predicates
+	// have to be separate: "this config has attribution" is not "this
+	// config IS the snapshot's document", and only the second licenses
+	// merged_yaml_status. A resolve-sourced config has its own verdict,
+	// through ConfigInvalid.
+	t.Run("served includes do not license the anchor's verdict", func(t *testing.T) {
+		conf := snapshotMergeVerdict(
+			platformConf(platform.SourceResolved, "job:\n  script: echo\n"),
+			"INVALID",
+			"the anchor's own merge error",
+		)
+		conf.PlatformRun.Config.Includes = []json.RawMessage{
+			json.RawMessage(`{"location":"gitlab.com/c/branch@2.0.0","type":"component"}`),
+		}
+
+		resp, _ := platformMergedConfig(conf)
+		if resp.CiConfig.Status != "VALID" {
+			t.Errorf("status = %q: attribution for this branch says nothing about the anchor's merge", resp.CiConfig.Status)
 		}
 		if len(resp.CiConfig.Errors) != 0 {
 			t.Errorf("errors = %v, want none: these describe the anchor's configuration", resp.CiConfig.Errors)

--- a/internal/platform/client_test.go
+++ b/internal/platform/client_test.go
@@ -322,6 +322,62 @@ func TestResolveConfig_DecodesIncludesFromTheWire(t *testing.T) {
 	}
 }
 
+// TestResolveConfig_IncludesPresenceSurvivesTheWire pins the decode this
+// fix depends on: ResolvedConfig.Includes must tell "the key was absent"
+// apart from "the key was served empty", because the platform is moving to
+// serve an explicit includes: [] for a configuration with zero includes,
+// and that is a complete, known answer rather than an unknown one.
+//
+// encoding/json already draws this line on a plain slice field (nil when
+// the key never appeared, a non-nil zero-length slice when it appeared as
+// []), so this test pins that wire-level behaviour rather than a type
+// change: present/empty/populated, by nil-ness and length together.
+func TestResolveConfig_IncludesPresenceSurvivesTheWire(t *testing.T) {
+	const merged = `"merged_yaml":"x\n","resolved_sha":"cafe","valid":true,"source":"resolved"`
+
+	t.Run("includes key absent decodes nil: unknown", func(t *testing.T) {
+		c, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, `{`+merged+`}`)
+		})
+		got, err := c.ResolveConfig("a/b", "cafe", "", "")
+		if err != nil {
+			t.Fatalf("ResolveConfig: %v", err)
+		}
+		if got.Includes != nil {
+			t.Fatalf("want nil (absent), got %#v", got.Includes)
+		}
+	})
+
+	t.Run("includes key served empty decodes non-nil, zero-length: known empty", func(t *testing.T) {
+		c, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, `{`+merged+`,"includes":[]}`)
+		})
+		got, err := c.ResolveConfig("a/b", "cafe", "", "")
+		if err != nil {
+			t.Fatalf("ResolveConfig: %v", err)
+		}
+		if got.Includes == nil {
+			t.Fatal("want a non-nil empty slice (known: zero includes), got nil (unknown)")
+		}
+		if len(got.Includes) != 0 {
+			t.Fatalf("want zero entries, got %d", len(got.Includes))
+		}
+	})
+
+	t.Run("includes key served populated decodes non-nil, non-empty", func(t *testing.T) {
+		c, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.WriteString(w, `{`+merged+`,"includes":[{"location":"gitlab.com/c/x@1.0.0","type":"component"}]}`)
+		})
+		got, err := c.ResolveConfig("a/b", "cafe", "", "")
+		if err != nil {
+			t.Fatalf("ResolveConfig: %v", err)
+		}
+		if len(got.Includes) != 1 {
+			t.Fatalf("want 1 entry, got %d", len(got.Includes))
+		}
+	})
+}
+
 func TestResolveConfig_503IsTypedAndNeverFatal(t *testing.T) {
 	for _, tc := range []struct {
 		name, body, wantReason string

--- a/internal/platform/client_test.go
+++ b/internal/platform/client_test.go
@@ -253,6 +253,75 @@ func TestResolveConfig_InvalidConfigIsA200(t *testing.T) {
 	}
 }
 
+// TestResolveConfig_DecodesIncludesFromTheWire pins the wire-level decode
+// of the resolve response's includes list, in the same per-entry shape as
+// snapshot.data.includes (location, raw, blob, contextProject, type,
+// extra, jobs, jobs_known). Absence of the key must decode to an empty
+// list, not a JSON error and not a defaulted non-nil slice.
+func TestResolveConfig_DecodesIncludesFromTheWire(t *testing.T) {
+	const body = `{
+	  "merged_yaml": "stages: [a]\n",
+	  "resolved_sha": "cafe",
+	  "valid": true,
+	  "source": "resolved",
+	  "includes": [
+	    {
+	      "location": "gitlab.com/c/anchor@1.0.0",
+	      "raw": "raw-anchor",
+	      "blob": "sha-anchor",
+	      "contextProject": "grp/anchor",
+	      "type": "component",
+	      "extra": {"project": "grp/anchor", "ref": "1.0.0"},
+	      "jobs": ["build"],
+	      "jobs_known": true
+	    },
+	    {
+	      "location": "gitlab.com/c/branch@2.0.0",
+	      "raw": "raw-branch",
+	      "blob": "sha-branch",
+	      "contextProject": "grp/branch",
+	      "type": "component",
+	      "extra": {"project": "grp/branch", "ref": "2.0.0"},
+	      "jobs": ["test"],
+	      "jobs_known": true
+	    }
+	  ]
+	}`
+	c, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, body)
+	})
+	got, err := c.ResolveConfig("a/b", "cafe", "", "")
+	if err != nil {
+		t.Fatalf("ResolveConfig: %v", err)
+	}
+	if len(got.Includes) != 2 {
+		t.Fatalf("want 2 includes, got %d: %+v", len(got.Includes), got.Includes)
+	}
+	var first struct {
+		Location string `json:"location"`
+	}
+	if err := json.Unmarshal(got.Includes[0], &first); err != nil {
+		t.Fatalf("include[0] must round-trip as JSON: %v", err)
+	}
+	if first.Location != "gitlab.com/c/anchor@1.0.0" {
+		t.Fatalf("include[0].location = %q", first.Location)
+	}
+	if !bytesContain(got.Includes[1], "gitlab.com/c/branch@2.0.0") {
+		t.Fatalf("include[1] carried verbatim? got %s", got.Includes[1])
+	}
+
+	c2, _ := newTestClient(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"merged_yaml":"x\n","resolved_sha":"cafe","valid":true,"source":"resolved"}`)
+	})
+	got2, err := c2.ResolveConfig("a/b", "cafe", "", "")
+	if err != nil {
+		t.Fatalf("ResolveConfig: %v", err)
+	}
+	if len(got2.Includes) != 0 {
+		t.Fatalf("a body without the includes key must decode empty, got %+v", got2.Includes)
+	}
+}
+
 func TestResolveConfig_503IsTypedAndNeverFatal(t *testing.T) {
 	for _, tc := range []struct {
 		name, body, wantReason string

--- a/internal/platform/resolution.go
+++ b/internal/platform/resolution.go
@@ -120,9 +120,14 @@ type ConfigResolution struct {
 	FromCache bool
 
 	// Includes is the per-include attribution the resolve endpoint served
-	// for MergedYAML, empty when it served none or when the config came
-	// from the snapshot (whose own list the snapshot carries). Read through
-	// RunContext.Includes, which pairs each source with its attribution.
+	// for MergedYAML. It is nil when the config came from the snapshot
+	// (whose own list the snapshot carries) or when the resolve endpoint
+	// served no "includes" key at all (an older platform). It is non-nil,
+	// possibly empty, when the endpoint DID serve the key: a served empty
+	// list is a complete answer (this merged_yaml has zero includes), not
+	// an unknown one, and must not be collapsed into the nil case. Read
+	// through RunContext.Includes, which pairs each source with its
+	// attribution and preserves this nil/non-nil distinction.
 	Includes []json.RawMessage
 
 	// Valid is false when the git host reported the CI config merge as
@@ -315,8 +320,10 @@ func completeFromResolve(out *ConfigResolution, c resolver, projectPath, sha str
 	out.ResolvedSha = resolved.ResolvedSha
 	out.FromCache = resolved.Source == "cache"
 	out.Valid = resolved.Valid
-	// Attribution for the document just returned, when the platform served
-	// it. It describes THIS merged_yaml, so it travels with it.
+	// Attribution for the document just returned. It describes THIS
+	// merged_yaml, so it travels with it, and the assignment carries the
+	// wire decode's nil (key absent) vs non-nil (key served, zero entries
+	// included) distinction straight through - see ResolvedConfig.Includes.
 	out.Includes = resolved.Includes
 	// An INVALID merge is a real answer about the user's own config, not an
 	// unavailable resolution: keep Source as resolved so the run reports

--- a/internal/platform/resolution.go
+++ b/internal/platform/resolution.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"encoding/json"
 	"strings"
 	"time"
 )
@@ -117,6 +118,12 @@ type ConfigResolution struct {
 	// FromCache reports whether a SourceResolved result was served from the
 	// platform's cache rather than freshly resolved.
 	FromCache bool
+
+	// Includes is the per-include attribution the resolve endpoint served
+	// for MergedYAML, empty when it served none or when the config came
+	// from the snapshot (whose own list the snapshot carries). Read through
+	// RunContext.Includes, which pairs each source with its attribution.
+	Includes []json.RawMessage
 
 	// Valid is false when the git host reported the CI config merge as
 	// INVALID. That is a user error in their own config, not a resolution
@@ -308,6 +315,9 @@ func completeFromResolve(out *ConfigResolution, c resolver, projectPath, sha str
 	out.ResolvedSha = resolved.ResolvedSha
 	out.FromCache = resolved.Source == "cache"
 	out.Valid = resolved.Valid
+	// Attribution for the document just returned, when the platform served
+	// it. It describes THIS merged_yaml, so it travels with it.
+	out.Includes = resolved.Includes
 	// An INVALID merge is a real answer about the user's own config, not an
 	// unavailable resolution: keep Source as resolved so the run reports
 	// "your CI config does not merge", which is actionable, rather than

--- a/internal/platform/resolution_test.go
+++ b/internal/platform/resolution_test.go
@@ -241,6 +241,83 @@ func TestResolveRunConfig_InvalidMergeIsReportedAsResolved(t *testing.T) {
 	}
 }
 
+// TestResolveRunConfig_ServedIncludesTravelWithTheirConfig pins the
+// attribution half of the resolve response.
+//
+// The endpoint has served an "includes" array (the same per-entry shape as
+// snapshot.data.includes) since 2026-08-27, and the CLI dropped it on the
+// floor: ResolvedConfig had no field for it, so every resolve-sourced run
+// reported include_attribution_unavailable even though branch-accurate
+// attribution had just been handed to it. A resolve-sourced run is the
+// NORMAL shape of a CI job with no digest, so the three include controls
+// abstained on every one of them.
+//
+// The attribution stays paired with the document it describes: a response
+// that serves none leaves attribution unavailable rather than borrowing the
+// snapshot's, which describes the anchor.
+func TestResolveRunConfig_ServedIncludesTravelWithTheirConfig(t *testing.T) {
+	const served = `{"location":"gitlab.com/c/branch@2.0.0","type":"component"}`
+	snap := snapWith(t, "b: 2\n", "aaa", "1", "s0", "main")
+	snap.Data.Includes = []json.RawMessage{json.RawMessage(`{"location":"gitlab.com/c/anchor@1.0.0","type":"component"}`)}
+
+	t.Run("a served list is carried onto the resolution", func(t *testing.T) {
+		f := &fakeResolver{result: &ResolvedConfig{
+			MergedYaml: "a: 1\n", ResolvedSha: "s", Valid: true, Source: "resolved",
+			Includes: []json.RawMessage{json.RawMessage(served)},
+		}}
+
+		got := resolveRunConfigSync(f, snap, "grp/proj", "s", "bbb", "")
+
+		if len(got.Includes) != 1 {
+			t.Fatalf("want the served include carried, got %d", len(got.Includes))
+		}
+		if !bytesContain(got.Includes[0], "gitlab.com/c/branch@2.0.0") {
+			t.Fatalf("the resolution must carry the RESOLVED config's include, got %s", got.Includes[0])
+		}
+
+		rc := &RunContext{Context: &ProjectContext{Snapshot: snap}, Config: got}
+		inc, ok := rc.Includes()
+		if !ok || len(inc) != 1 || !bytesContain(inc[0], "gitlab.com/c/branch@2.0.0") {
+			t.Fatalf("Includes() = (%v, %v), want the resolve endpoint's own list", inc, ok)
+		}
+		if !rc.ConfigAndIncludesAgree() {
+			t.Error("the served attribution describes the config in use, so it agrees with it")
+		}
+		if rc.ConfigIsSnapshot() {
+			t.Error("a resolve-sourced config is not the snapshot's own document")
+		}
+	})
+
+	t.Run("no served list leaves attribution unavailable", func(t *testing.T) {
+		f := &fakeResolver{result: &ResolvedConfig{MergedYaml: "a: 1\n", ResolvedSha: "s", Valid: true, Source: "resolved"}}
+
+		got := resolveRunConfigSync(f, snap, "grp/proj", "s", "bbb", "")
+
+		rc := &RunContext{Context: &ProjectContext{Snapshot: snap}, Config: got}
+		if inc, ok := rc.Includes(); ok || inc != nil {
+			t.Fatalf("Includes() = (%v, %v), want none: the snapshot's list describes the anchor, not this branch", inc, ok)
+		}
+		if rc.ConfigAndIncludesAgree() {
+			t.Error("with nothing served there is no attribution for the config in use")
+		}
+	})
+
+	t.Run("a snapshot-sourced config keeps the snapshot's own list", func(t *testing.T) {
+		f := &fakeResolver{}
+
+		got := resolveRunConfigSync(f, snap, "grp/proj", "s0", "aaa", "")
+
+		rc := &RunContext{Context: &ProjectContext{Snapshot: snap}, Config: got}
+		inc, ok := rc.Includes()
+		if !ok || len(inc) != 1 || !bytesContain(inc[0], "gitlab.com/c/anchor@1.0.0") {
+			t.Fatalf("Includes() = (%v, %v), want the snapshot's own list", inc, ok)
+		}
+		if !rc.ConfigIsSnapshot() {
+			t.Error("a digest match evaluates the snapshot's own document")
+		}
+	})
+}
+
 // TestResolveRunConfig_CacheHitShaMayDiffer pins that a cache hit's
 // resolved_sha is recorded as-is. Asserting equality with the requested sha
 // would reject every legitimate cache hit.

--- a/internal/platform/resolution_test.go
+++ b/internal/platform/resolution_test.go
@@ -288,6 +288,38 @@ func TestResolveRunConfig_ServedIncludesTravelWithTheirConfig(t *testing.T) {
 		}
 	})
 
+	// A served EMPTY list is a real, complete answer (this branch's config
+	// has zero includes) and must not read the same as "nothing served".
+	// Before this fix, RunContext.Includes and ConfigAndIncludesAgree keyed
+	// on len(...) == 0, which collapsed "served empty" into "not served"
+	// and left this branch's include controls abstaining forever.
+	t.Run("a served EMPTY list is complete attribution, not unavailable", func(t *testing.T) {
+		f := &fakeResolver{result: &ResolvedConfig{
+			MergedYaml: "a: 1\n", ResolvedSha: "s", Valid: true, Source: "resolved",
+			Includes: []json.RawMessage{},
+		}}
+
+		got := resolveRunConfigSync(f, snap, "grp/proj", "s", "bbb", "")
+		if got.Includes == nil {
+			t.Fatal("ConfigResolution.Includes must stay non-nil for a served-empty response")
+		}
+
+		rc := &RunContext{Context: &ProjectContext{Snapshot: snap}, Config: got}
+		inc, ok := rc.Includes()
+		if !ok {
+			t.Fatalf("Includes() ok = false, want true: the resolve endpoint served the key, zero entries included")
+		}
+		if inc == nil {
+			t.Fatal("Includes() returned a nil list for a served-empty response, want non-nil empty")
+		}
+		if len(inc) != 0 {
+			t.Fatalf("want zero entries, got %d", len(inc))
+		}
+		if !rc.ConfigAndIncludesAgree() {
+			t.Error("a served empty list agrees with the config in use: zero includes is a complete answer")
+		}
+	})
+
 	t.Run("no served list leaves attribution unavailable", func(t *testing.T) {
 		f := &fakeResolver{result: &ResolvedConfig{MergedYaml: "a: 1\n", ResolvedSha: "s", Valid: true, Source: "resolved"}}
 
@@ -314,6 +346,26 @@ func TestResolveRunConfig_ServedIncludesTravelWithTheirConfig(t *testing.T) {
 		}
 		if !rc.ConfigIsSnapshot() {
 			t.Error("a digest match evaluates the snapshot's own document")
+		}
+	})
+
+	t.Run("a snapshot served an empty list is complete attribution too", func(t *testing.T) {
+		emptySnap := snapWith(t, "b: 2\n", "aaa", "1", "s0", "main")
+		emptySnap.Data.Includes = []json.RawMessage{}
+		f := &fakeResolver{}
+
+		got := resolveRunConfigSync(f, emptySnap, "grp/proj", "s0", "aaa", "")
+
+		rc := &RunContext{Context: &ProjectContext{Snapshot: emptySnap}, Config: got}
+		inc, ok := rc.Includes()
+		if !ok {
+			t.Fatal("Includes() ok = false, want true: the snapshot served the key, zero entries included")
+		}
+		if inc == nil || len(inc) != 0 {
+			t.Fatalf("want a non-nil empty list, got %#v", inc)
+		}
+		if !rc.ConfigAndIncludesAgree() {
+			t.Error("a served empty list agrees with the snapshot's own document: zero includes is a complete answer")
 		}
 	})
 }

--- a/internal/platform/run.go
+++ b/internal/platform/run.go
@@ -112,25 +112,65 @@ func (r *RunContext) ConfigInvalid() bool {
 	return r.Config != nil && r.Config.Available() && !r.Config.Valid
 }
 
-// ConfigAndIncludesAgree reports whether the merged configuration in use and
-// the snapshot's include attribution describe the SAME configuration.
+// Includes returns the per-include attribution for the configuration this
+// run actually evaluates, and whether any is available.
 //
-// They come from two independent lanes and only agree in one case. When the
-// checkout's digest equals the anchor, MergedYAML is the snapshot's own
-// merged_yaml and the snapshot's includes attribute exactly it
-// (SourceSnapshot). When the digests diverge, MergedYAML is the config the
-// platform resolved for THIS branch, while SnapshotIncludes still holds
-// attribution resolved against the anchor - the default branch. The resolve
-// endpoint returns no includes at all (see ResolvedConfig), so on a
-// divergent branch there is no branch-accurate attribution to be had.
+// Attribution and merged document come from two lanes, and each document
+// has exactly one list that describes it:
 //
-// Pairing them anyway is worse than having neither. A branch that adds,
-// removes or re-pins an include gets every job from that include classified
-// against the OLD attribution, so upstream jobs read as project-authored and
+//   - SourceSnapshot: MergedYAML is the snapshot's own merged_yaml, so the
+//     snapshot's includes attribute exactly it.
+//   - SourceResolved: MergedYAML is what the platform resolved for THIS
+//     branch, so only the includes the resolve response carried describe
+//     it. The endpoint serves them when it can; when it does not, there is
+//     no branch-accurate attribution to be had and this returns false.
+//
+// The snapshot's list is never lent to a resolved config. It was resolved
+// against the anchor, the default branch, and a branch that adds, removes
+// or re-pins an include would get every job from that include classified
+// against the OLD attribution: upstream jobs read as project-authored and
 // vice versa. That is the fabricated-finding mode attribution exists to
 // prevent, landing on precisely the divergent branch the digest exists to
-// detect. Callers must treat attribution as unavailable when this is false.
+// detect. Callers must treat attribution as unavailable when ok is false.
+func (r *RunContext) Includes() ([]json.RawMessage, bool) {
+	if r == nil {
+		return nil, false
+	}
+	r.Config.join()
+	if r.Config == nil {
+		return nil, false
+	}
+	switch r.Config.Source {
+	case SourceSnapshot:
+		return r.SnapshotIncludes()
+	case SourceResolved:
+		if len(r.Config.Includes) == 0 {
+			return nil, false
+		}
+		return r.Config.Includes, true
+	}
+	return nil, false
+}
+
+// ConfigAndIncludesAgree reports whether the configuration in use has
+// attribution that describes IT. It is the question the include-reasoning
+// controls ask, and it is answered by Includes alone: the two are served
+// together or not at all.
 func (r *RunContext) ConfigAndIncludesAgree() bool {
+	_, ok := r.Includes()
+	return ok
+}
+
+// ConfigIsSnapshot reports whether the document this run evaluates IS the
+// snapshot's own merged_yaml.
+//
+// It is a narrower question than ConfigAndIncludesAgree and must not be
+// collapsed into it. Everything else the snapshot says ABOUT its document -
+// the git host's merge verdict above all - applies only to that document. A
+// resolve-sourced config can now arrive with attribution of its own, which
+// makes attribution available without making the snapshot's other verdicts
+// apply; it has its own, through ConfigInvalid.
+func (r *RunContext) ConfigIsSnapshot() bool {
 	if r == nil {
 		return false
 	}
@@ -255,10 +295,11 @@ func (r *RunContext) LaneMissing(field string) bool {
 }
 
 // SnapshotIncludes returns the snapshot's per-include attribution, and
-// whether the platform supplied any. A false second return is the state
-// that forces the include-reasoning controls to not_evaluable: without
-// attribution a component's job is indistinguishable from one the project
-// wrote, which fabricates findings rather than merely hiding them.
+// whether the platform supplied any. It describes the SNAPSHOT's document,
+// so callers evaluating a configuration want Includes, which pairs each
+// source with the attribution that belongs to it. Without attribution a
+// component's job is indistinguishable from one the project wrote, which
+// fabricates findings rather than merely hiding them.
 func (r *RunContext) SnapshotIncludes() ([]json.RawMessage, bool) {
 	snap := r.Snapshot()
 	if snap.Data == nil || len(snap.Data.Includes) == 0 {
@@ -292,9 +333,8 @@ func (r *RunContext) SnapshotCIConfigPath() string {
 //
 // The verdict describes the SNAPSHOT's document. A caller evaluating a
 // different one (a digest-divergent branch, resolved by the platform for
-// this run) must not attach it - see RunContext.ConfigAndIncludesAgree,
-// which decides exactly that question for the include attribution served
-// beside it.
+// this run) must not attach it - see RunContext.ConfigIsSnapshot, which
+// decides exactly that question.
 //
 // The error slice is copied: the snapshot is shared for the whole run and
 // a caller that appends to what it is handed would edit it.
@@ -541,6 +581,12 @@ func (r *RunContext) describeConfig() []string {
 			how = "served from the platform cache"
 		}
 		line := fmt.Sprintf("ci config source: platform resolve endpoint, %s at %s", how, shortDigest(c.ResolvedSha))
+		// Whether attribution came with it decides whether the include
+		// controls could run, which is the next thing the reader of this
+		// line wants to know.
+		if len(c.Includes) > 0 {
+			line += ", includes served"
+		}
 		if !c.Valid {
 			line += " - the git host reports this config as INVALID"
 		}

--- a/internal/platform/run.go
+++ b/internal/platform/run.go
@@ -125,6 +125,14 @@ func (r *RunContext) ConfigInvalid() bool {
 //     it. The endpoint serves them when it can; when it does not, there is
 //     no branch-accurate attribution to be had and this returns false.
 //
+// ok is keyed on PRESENCE, not on how many entries came back. A source that
+// served the key with zero entries is a complete answer - every job in the
+// merged document is project-authored, nothing to attribute upstream - and
+// returns ok=true with a non-nil, empty list. Only an ABSENT key (the
+// source never served attribution at all) returns ok=false. Collapsing
+// "served empty" into "not served" would abstain the include-reasoning
+// controls on a project that legitimately has no includes.
+//
 // The snapshot's list is never lent to a resolved config. It was resolved
 // against the anchor, the default branch, and a branch that adds, removes
 // or re-pins an include would get every job from that include classified
@@ -144,7 +152,7 @@ func (r *RunContext) Includes() ([]json.RawMessage, bool) {
 	case SourceSnapshot:
 		return r.SnapshotIncludes()
 	case SourceResolved:
-		if len(r.Config.Includes) == 0 {
+		if r.Config.Includes == nil {
 			return nil, false
 		}
 		return r.Config.Includes, true
@@ -300,9 +308,15 @@ func (r *RunContext) LaneMissing(field string) bool {
 // source with the attribution that belongs to it. Without attribution a
 // component's job is indistinguishable from one the project wrote, which
 // fabricates findings rather than merely hiding them.
+//
+// ok answers whether the snapshot carries the key at all, not whether it
+// carries any entries: a snapshot served with includes: [] is a complete,
+// known-empty answer and returns ok=true with a non-nil empty list. Only a
+// snapshot with no Data, or one whose Includes key was never served
+// (nil), returns ok=false.
 func (r *RunContext) SnapshotIncludes() ([]json.RawMessage, bool) {
 	snap := r.Snapshot()
-	if snap.Data == nil || len(snap.Data.Includes) == 0 {
+	if snap.Data == nil || snap.Data.Includes == nil {
 		return nil, false
 	}
 	return snap.Data.Includes, true
@@ -583,8 +597,9 @@ func (r *RunContext) describeConfig() []string {
 		line := fmt.Sprintf("ci config source: platform resolve endpoint, %s at %s", how, shortDigest(c.ResolvedSha))
 		// Whether attribution came with it decides whether the include
 		// controls could run, which is the next thing the reader of this
-		// line wants to know.
-		if len(c.Includes) > 0 {
+		// line wants to know. A non-nil Includes means the endpoint served
+		// the key, zero entries included; a nil one means it did not.
+		if c.Includes != nil {
 			line += ", includes served"
 		}
 		if !c.Valid {

--- a/internal/platform/run_test.go
+++ b/internal/platform/run_test.go
@@ -152,9 +152,10 @@ func TestDescribe_ReportsTheFactsTheRunObserved(t *testing.T) {
 	}
 
 	cases := []struct {
-		name     string
-		cfg      *ConfigResolution
-		contains []string
+		name        string
+		cfg         *ConfigResolution
+		contains    []string
+		notContains []string
 	}{
 		{
 			name: "digest match uses the snapshot",
@@ -183,6 +184,19 @@ func TestDescribe_ReportsTheFactsTheRunObserved(t *testing.T) {
 				Includes: []json.RawMessage{json.RawMessage(`{"location":"gitlab.com/c/x@1.0.0","type":"component"}`)},
 			},
 			contains: []string{"platform resolve endpoint", "includes served"},
+		},
+		{
+			// The divergence case above leaves Includes nil incidentally;
+			// this case pins that on purpose so an inverted or dropped
+			// condition on c.Includes cannot slip the string in here too.
+			name: "a resolved config with no attribution does not say includes served",
+			cfg: &ConfigResolution{
+				Source: SourceResolved, Digest: DigestDiverged, Valid: true,
+				LocalDigest: "a", DigestVersion: "1", AnchorDigest: "b", ResolvedSha: "s",
+				Includes: nil,
+			},
+			contains:    []string{"platform resolve endpoint, resolved at"},
+			notContains: []string{"includes served"},
 		},
 		{
 			name: "a cache hit says so",
@@ -230,6 +244,11 @@ func TestDescribe_ReportsTheFactsTheRunObserved(t *testing.T) {
 			for _, want := range tc.contains {
 				if !strings.Contains(out, want) {
 					t.Fatalf("Describe() missing %q:\n%s", want, out)
+				}
+			}
+			for _, unwanted := range tc.notContains {
+				if strings.Contains(out, unwanted) {
+					t.Fatalf("Describe() unexpectedly contains %q:\n%s", unwanted, out)
 				}
 			}
 			// The policy set and snapshot age are reported on every path.

--- a/internal/platform/run_test.go
+++ b/internal/platform/run_test.go
@@ -43,6 +43,12 @@ func TestNilRunContextIsStandalone(t *testing.T) {
 	if got := r.MissingSnapshotFields(); got != nil {
 		t.Fatalf("MissingSnapshotFields: %v", got)
 	}
+	if inc, ok := r.Includes(); ok || inc != nil {
+		t.Fatalf("Includes: (%v, %v)", inc, ok)
+	}
+	if r.ConfigIsSnapshot() {
+		t.Fatal("ConfigIsSnapshot: a nil RunContext evaluates no document at all")
+	}
 	if got := r.Describe(); got != nil {
 		t.Fatalf("Describe: %v", got)
 	}
@@ -165,6 +171,18 @@ func TestDescribe_ReportsTheFactsTheRunObserved(t *testing.T) {
 				LocalDigest: "aaaaaaaaaaaabbbb", DigestVersion: "1", AnchorDigest: "ccccccccccccdddd", ResolvedSha: "1234567890abcdef",
 			},
 			contains: []string{"diverges from the snapshot anchor", "local:  aaaaaaaaaaaabbbb", "anchor: ccccccccccccdddd", "platform resolve endpoint, resolved at"},
+		},
+		{
+			// The operator reading this line is deciding whether the three
+			// include controls should have run. "resolve endpoint" alone
+			// used to mean they could not; it no longer does.
+			name: "a resolved config that carried attribution says so",
+			cfg: &ConfigResolution{
+				Source: SourceResolved, Digest: DigestDiverged, Valid: true,
+				LocalDigest: "a", DigestVersion: "1", AnchorDigest: "b", ResolvedSha: "s",
+				Includes: []json.RawMessage{json.RawMessage(`{"location":"gitlab.com/c/x@1.0.0","type":"component"}`)},
+			},
+			contains: []string{"platform resolve endpoint", "includes served"},
 		},
 		{
 			name: "a cache hit says so",

--- a/internal/platform/types.go
+++ b/internal/platform/types.go
@@ -472,4 +472,14 @@ type ResolvedConfig struct {
 	// sent is a diagnostic, never an error.
 	ConfigDigest  string `json:"config_digest,omitempty"`
 	DigestVersion string `json:"digest_version,omitempty"`
+
+	// Includes is the per-include attribution for THIS merged_yaml, in the
+	// same per-entry shape as snapshot.data.includes. Left raw for the same
+	// reason the snapshot's list is: the provider package owns that type,
+	// and a field added upstream must travel through untouched.
+	//
+	// It is absent on an older platform, and absence is not emptiness: a
+	// run with no attribution reports the include controls not_evaluable
+	// rather than reading the config as having no includes.
+	Includes []json.RawMessage `json:"includes,omitempty"`
 }

--- a/internal/platform/types.go
+++ b/internal/platform/types.go
@@ -267,6 +267,14 @@ type SnapshotData struct {
 	// guessing the project wrote it; see control.controlsRequiringIncludeAttribution
 	// for what depends on it. Present only alongside a resolved MergedYaml,
 	// the same presence rule as ResolutionAnchor. Raw: decoded by gitlab.
+	//
+	// Carries the same nil-vs-non-nil presence distinction as
+	// ResolvedConfig.Includes, for the same reason: a snapshot collected
+	// with the key absent decodes nil (unknown), one collected with
+	// "includes": [] decodes to a non-nil, zero-length slice (known, zero
+	// includes - a complete answer, not an unknown one). Callers must read
+	// nil-ness, never length, to tell the two apart - see
+	// RunContext.SnapshotIncludes.
 	Includes []json.RawMessage `json:"includes,omitempty"`
 
 	// CiConfigPath is the project's OWN configured CI config path, defaulting
@@ -478,8 +486,23 @@ type ResolvedConfig struct {
 	// reason the snapshot's list is: the provider package owns that type,
 	// and a field added upstream must travel through untouched.
 	//
-	// It is absent on an older platform, and absence is not emptiness: a
-	// run with no attribution reports the include controls not_evaluable
-	// rather than reading the config as having no includes.
+	// PRESENCE is the fact that matters, not just content, and the plain
+	// slice already carries it through encoding/json's own decode rules: a
+	// body with no "includes" key leaves this nil (Go never touches a
+	// field it did not find), while a body with "includes": [] decodes to
+	// a non-nil, zero-length slice (encoding/json replaces the field with
+	// a fresh empty slice for an empty JSON array). So:
+	//
+	//   - nil: absent on an older platform, or the endpoint genuinely has
+	//     nothing to say about this document. Not emptiness - a run with no
+	//     attribution reports the include controls not_evaluable rather
+	//     than reading the config as having no includes.
+	//   - non-nil, len 0: served and complete - the platform positively
+	//     knows this merged_yaml has zero includes, which is a real answer
+	//     ("every job here is project-authored"), not an unknown one.
+	//   - non-nil, len > 0: served attribution for each include.
+	//
+	// Callers must read this field's nil-ness, never its length, to tell
+	// "unknown" apart from "known empty" - see RunContext.Includes.
 	Includes []json.RawMessage `json:"includes,omitempty"`
 }

--- a/utils/gitremote.go
+++ b/utils/gitremote.go
@@ -276,14 +276,16 @@ func ParseGitRemoteURL(remoteURL string) *GitRemoteInfo {
 	//
 	// A CI runner clones with the job token embedded as userinfo
 	// (gitlab-ci-token:<token>@host on GitLab, x-access-token:<token>@host
-	// on GitHub), and the optional `(?:[^@/]+@)?` drops it before the host
+	// on GitHub), and the optional `(?:[^/]*@)?` drops it before the host
 	// is captured (platform row 51): a host that kept it would never equal
 	// the plain server URL the pipeline is configured with, so the checkout
 	// would never be recognized as the analyzed project and the include
 	// controls that depend on that match would never evaluate. Every field
 	// this constructs (Host, URL) flows through newGitRemoteInfo, so every
-	// consumer inherits the fix.
-	httpsRegex := regexp.MustCompile(`^https?://(?:[^@/]+@)?([^/]+)/(.+?)(?:\.git)?$`)
+	// consumer inherits the fix. The group is greedy up to the LAST "@" before
+	// the first "/", so an unencoded "@" inside the password still leaves the
+	// bare host behind instead of splitting the password off as a bogus host.
+	httpsRegex := regexp.MustCompile(`^https?://(?:[^/]*@)?([^/]+)/(.+?)(?:\.git)?$`)
 	if matches := httpsRegex.FindStringSubmatch(remoteURL); matches != nil {
 		return newGitRemoteInfo(matches[1], matches[2])
 	}
@@ -293,8 +295,8 @@ func ParseGitRemoteURL(remoteURL string) *GitRemoteInfo {
 	// The git:// protocol carries no authentication of its own, so userinfo
 	// here is not a known real-world case, but stripping it defensively
 	// keeps this branch consistent with the HTTPS one instead of relying on
-	// that absence.
-	gitRegex := regexp.MustCompile(`^git://(?:[^@/]+@)?([^/:]+)(?::\d+)?/(.+?)(?:\.git)?$`)
+	// that absence. Same last-"@" greediness as the HTTPS branch above.
+	gitRegex := regexp.MustCompile(`^git://(?:[^/]*@)?([^/:]+)(?::\d+)?/(.+?)(?:\.git)?$`)
 	if matches := gitRegex.FindStringSubmatch(remoteURL); matches != nil {
 		return newGitRemoteInfo(matches[1], matches[2])
 	}

--- a/utils/gitremote_test.go
+++ b/utils/gitremote_test.go
@@ -216,6 +216,80 @@ func TestParseGitRemoteURL(t *testing.T) {
 	}
 }
 
+// TestParseGitRemoteURLStripsCredentialsUpToTheLastAt pins the parse of the remote a CI
+// runner actually leaves behind. GitLab's runner rewrites origin to
+// CI_REPOSITORY_URL, which embeds the job token as userinfo
+// (https://gitlab-ci-token:<token>@host/path.git). Keeping that userinfo in
+// Host made every derived value wrong: URL became
+// https://gitlab-ci-token:<token>@gitlab.com, which can never equal the
+// instance URL, so the checkout was never recognised as the analyzed
+// project and the CI config digest was never computed. Every component job
+// then ran as digest-divergent and lost its include attribution. Provider
+// detection saw the same mangled host and fell through to its default.
+//
+// Credentials are transport, not identity: they are stripped, and the host
+// keeps its port.
+func TestParseGitRemoteURLStripsCredentialsUpToTheLastAt(t *testing.T) {
+	cases := []struct {
+		name         string
+		remoteURL    string
+		wantHost     string
+		wantProject  string
+		wantURL      string
+		wantProvider string
+	}{
+		{
+			// An unencoded "@" inside the password is invalid per the URL
+			// spec but is exactly what a hand-typed or generated token can
+			// contain. The userinfo group must still eat everything up to
+			// the LAST "@" before the first "/", not stop at the first one
+			// it sees, or "ss" would be misread as the host.
+			name:         "HTTPS with an unencoded @ inside the password",
+			remoteURL:    "https://user:p@ss@gitlab.example.com/group/proj.git",
+			wantHost:     "gitlab.example.com",
+			wantProject:  "group/proj",
+			wantURL:      "https://gitlab.example.com",
+			wantProvider: "gitlab",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ParseGitRemoteURL(c.remoteURL)
+			if got == nil {
+				t.Fatalf("ParseGitRemoteURL(%q) = nil, want a parsed remote", c.remoteURL)
+			}
+			if got.Host != c.wantHost {
+				t.Errorf("Host = %q, want %q", got.Host, c.wantHost)
+			}
+			if got.ProjectPath != c.wantProject {
+				t.Errorf("ProjectPath = %q, want %q", got.ProjectPath, c.wantProject)
+			}
+			if got.URL != c.wantURL {
+				t.Errorf("URL = %q, want %q", got.URL, c.wantURL)
+			}
+			if got.Provider != c.wantProvider {
+				t.Errorf("Provider = %q, want %q", got.Provider, c.wantProvider)
+			}
+		})
+	}
+}
+
+// An @ inside the path is not userinfo. Stripping it would eat the first
+// path segment of a legitimate project.
+func TestParseGitRemoteURLKeepsAnAtInThePath(t *testing.T) {
+	got := ParseGitRemoteURL("https://gitlab.com/group/proj@1.0.0.git")
+	if got == nil {
+		t.Fatal("ParseGitRemoteURL = nil, want a parsed remote")
+	}
+	if got.Host != "gitlab.com" {
+		t.Errorf("Host = %q, want %q", got.Host, "gitlab.com")
+	}
+	if got.ProjectPath != "group/proj@1.0.0" {
+		t.Errorf("ProjectPath = %q, want %q", got.ProjectPath, "group/proj@1.0.0")
+	}
+}
+
 func TestDetectProvider(t *testing.T) {
 	// Build a repo root that contains a GitHub Actions workflow file, so the
 	// .github/workflows positive signal is exercised against the real FS.


### PR DESCRIPTION
## What

Two defects that together leave the three include-attribution controls (`pipelineMustNotIncludeHardcodedJobs`, `includesMustBeUpToDate`, `securityJobsMustNotBeWeakened`) not evaluable on every GitLab component job in platform mode.

Observed on v0.4.60 (bigtech-150/backend/node-customer-api-6, job 16441934001):

```
ci config digest: not computed (no checkout of the analyzed project) - treated as divergent
ci config source: platform resolve endpoint (request in flight; collected when evaluation needs it)
Not Evaluated (3)
  ? Pipeline must not include hardcoded jobs (include_attribution_unavailable)
  ? Includes must be up to date (include_attribution_unavailable)
  ? Security jobs must not be weakened (include_attribution_unavailable)
```

## Defect 1: the checkout is never recognised as the analysed project (landed on main via #472)

GitLab runner rewrites `origin` to `CI_REPOSITORY_URL` (`https://gitlab-ci-token:...@gitlab.com/group/project.git`). `ParseGitRemoteURL` kept the userinfo inside `Host` and `URL`, so the comparison with the instance URL never matched, `CheckoutIsAnalyzedProject` stayed false, the CI config digest was never computed and every job was treated as digest-divergent. The git layer itself was fine: #464's per-invocation `safe.directory` works inside the image.

The same root cause was ruled as platform decision row 51 and fixed on main by #472 (released in v0.4.61, first-`@` form). After rebasing on v0.4.61 this branch drops its duplicate and keeps only one refinement: the userinfo group is greedy up to the LAST `@` before the path, so an unencoded `@` inside a password still leaves the bare host (one added test case; main's cases stay as they are).

## Defect 2: the resolve endpoint's includes were dropped

The platform's resolve response carries `includes` (same per-entry shape as the snapshot's, contract since 2026-08-27), but the CLI's response type had no such field and `ConfigAndIncludesAgree` accepted attribution only for a snapshot-sourced config, with a comment claiming the endpoint serves none. On a resolve-sourced config the CLI threw away the branch-accurate attribution it was given.

Fix: decode `includes`, expose the attribution that describes the configuration in use (snapshot's for a snapshot-sourced config, the response's for a resolve-sourced one), and split the predicate so the snapshot's merge verdict still applies only when the config in use is the snapshot's own document.

## Companion: a served empty include list is complete attribution

The platform is moving to serve an explicit empty `includes` array when a configuration has no includes (today the key is absent, which the CLI must read as unknown). This branch now distinguishes the two downstream: `includes` absent stays unavailable, `includes: []` is a real answer (every job is project-authored), so a project without any include evaluates the three controls. Same rule for the snapshot's `data.includes`.

## Effect

- Default-branch component jobs now compute the digest; when it matches the snapshot anchor the three controls are evaluated from the snapshot's attribution, which carries each include's `jobs` / `jobs_known` (the tier-C include probe), so no per-include fetch is needed and the job token suffices.
- Digest-divergent runs (a merge request pipeline, a throwaway branch, or a push that changes the CI file before the snapshot refreshes) now accept the resolve endpoint's attribution instead of discarding it. The endpoint's include entries carry no `jobs_known` today, so the CLI still tries its own per-include merge request, which a job token cannot make: those runs degrade with the honest `include_resolution_failed` instead of `include_attribution_unavailable`. Closing that last gap is platform work (attach include jobs on the resolve endpoint the way the snapshot collector does); tracked separately.
- Fewer forced resolutions on the platform (the digest now exists on every component job).
- Non-platform runs are byte-for-byte unchanged.

## Testing

TDD per defect. `go test ./... -race`, `go vet`, pinned golangci-lint (0 issues), deadcode clean. End to end in a real GitLab job on a throwaway branch of a demo project against demo.getplumber.tech with the CLI built from this branch. Before: `ci config digest: not computed (no checkout of the analyzed project)` and `include_attribution_unavailable` (job 16441934001 on v0.4.60). After: `ci config digest: diverges from the snapshot anchor` with the local and anchor digests printed (job 16443086610), and with a local include committed on the branch the platform served the attribution and the reason moved to `include_resolution_failed` (job 16443152507), the expected divergent-branch outcome described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRHuGuptmc9Rd147CsC2se
