### PR TITLE
fix: token clones match the analyzed project, no score without evaluated controls, opt-in for plain-http platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,14 @@ Display it with a badge in your README (swap in your platform/owner/repo):
 Without `--platform` nothing changes: Plumber collects everything itself and
 evaluates one policy, exactly as it always has.
 
+A plain-http `--platform` URL is refused unless its host is loopback
+(`localhost`, `127.0.0.0/8`, `::1`): the push carries the CI OIDC id-token
+and the response carries the run's own verdict, and either can be read or
+rewritten by anyone on the network path between the job and a plain-http
+endpoint. Pass `--platform-allow-http` (or `PLUMBER_ANALYZE_PLATFORM_ALLOW_HTTP=1`)
+to opt in for a trusted internal instance that has no TLS in front of it;
+`https://` and loopback `http://` need no opt-in.
+
 With `--platform`, Plumber first reads the project's context from the
 platform - the resolved policy set and a cached settings snapshot - and uses
 it to decide what to collect and what to report:

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,9 @@ inputs:
   platform:
     description: "Plumber platform base URL. Setting it pushes this run's full results there over CI OIDC, and takes precedence over score-push. The calling workflow MUST grant 'permissions: id-token: write'."
     default: ""
+  platform-allow-http:
+    description: "Allow platform to be plain http for a non-loopback host. Without it, http to anything but localhost/127.0.0.0/8/::1 is refused before any credential is sent; https and loopback http need no opt-in."
+    default: "false"
   fail-warnings:
     description: "Fail the run on warnings: unknown configuration keys (exit 2) and 'could not verify' checks such as a skipped known-CVE lookup when an action version cannot be resolved (exit 3). soft-fail does not mask exit 3."
     default: "false"
@@ -177,6 +180,7 @@ runs:
         IN_SCORE_PUSH: ${{ inputs.score-push }}
         IN_SCORE_ENDPOINT: ${{ inputs.score-endpoint }}
         IN_PLATFORM: ${{ inputs.platform }}
+        IN_PLATFORM_ALLOW_HTTP: ${{ inputs.platform-allow-http }}
         IN_FAIL_WARNINGS: ${{ inputs.fail-warnings }}
         IN_OUTPUT: ${{ inputs.output }}
         IN_PBOM: ${{ inputs.pbom }}
@@ -213,6 +217,7 @@ runs:
         [ "$IN_SCORE_PUSH" = "true" ] && args+=(--score-push)
         [ -n "$IN_SCORE_ENDPOINT" ] && args+=(--score-endpoint "$IN_SCORE_ENDPOINT")
         [ -n "$IN_PLATFORM" ] && args+=(--platform "$IN_PLATFORM")
+        [ "$IN_PLATFORM_ALLOW_HTTP" = "true" ] && args+=(--platform-allow-http)
         [ "$IN_FAIL_WARNINGS" = "true" ] && args+=(--fail-warnings)
         [ -n "$IN_OUTPUT" ]         && args+=(--output "$IN_OUTPUT")
         [ -n "$IN_PBOM" ]           && args+=(--pbom "$IN_PBOM")

--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -64,6 +64,10 @@ var (
 	pushScore         bool
 	scoreEndpoint     string
 	platformURL       string
+	// platformAllowHTTP opts in to a plain-http --platform endpoint whose
+	// host is not loopback (row 46). Without it such an endpoint is refused
+	// before any credential is sent; https and loopback http are unaffected.
+	platformAllowHTTP bool
 	controlsFilter    string
 	skipControls      string
 	// noControls (--no-controls) turns off control evaluation for the run.
@@ -206,6 +210,7 @@ func init() {
 	analyzeCmd.Flags().BoolVar(&pushScore, "score-push", false, "Publish this repo's Plumber Score to the hosted badge service (CI only; needs a CI OIDC id-token, so a local run is a no-op)")
 	analyzeCmd.Flags().StringVar(&scoreEndpoint, "score-endpoint", "", "Score service base URL (default https://score.getplumber.io); override only for a self-hosted score service")
 	analyzeCmd.Flags().StringVar(&platformURL, "platform", "", "Plumber platform base URL; turns on platform mode (policies and collected data come from the platform) and pushes this run's full results there over CI OIDC, taking precedence over --score-push")
+	analyzeCmd.Flags().BoolVar(&platformAllowHTTP, "platform-allow-http", false, "Allow --platform to be plain http for a non-loopback host; without it, http to anything but localhost/127.0.0.0/8/::1 is refused before any credential is sent")
 	analyzeCmd.Flags().StringVar(&controlsFilter, "controls", "", "Run only listed controls (comma-separated)")
 	analyzeCmd.Flags().StringVar(&skipControls, "skip-controls", "", "Skip listed controls (comma-separated)")
 	analyzeCmd.Flags().BoolVar(&noControls, "no-controls", false, "Run no controls at all: collect the pipeline and write the requested inventory artifacts (PBOM, JSON, CSV, OCSF), skip evaluation, withhold the score, and never fail the gate")
@@ -568,36 +573,37 @@ func buildGitLabConf(
 // envKeys maps each analyze flag to the environment variable that overrides it
 // when the flag is not set explicitly on the command line (flags always win).
 var envKeys = map[string]string{
-	"gitlab-url":     "PLUMBER_ANALYZE_GITLAB_URL",
-	"github-url":     "PLUMBER_ANALYZE_GITHUB_URL",
-	"project":        "PLUMBER_ANALYZE_PROJECT",
-	"provider":       "PLUMBER_ANALYZE_PROVIDER",
-	"branch":         "PLUMBER_ANALYZE_BRANCH",
-	"config":         "PLUMBER_ANALYZE_CONFIG",
-	"threshold":      "PLUMBER_ANALYZE_THRESHOLD",
-	"min-score":      "PLUMBER_ANALYZE_MIN_SCORE",
-	"min-points":     "PLUMBER_ANALYZE_MIN_POINTS",
-	"print":          "PLUMBER_ANALYZE_PRINT",
-	"output":         "PLUMBER_ANALYZE_OUTPUT",
-	"pbom":           "PLUMBER_ANALYZE_PBOM",
-	"pbom-cyclonedx": "PLUMBER_ANALYZE_PBOM_CYCLONEDX",
-	"sarif":          "PLUMBER_ANALYZE_SARIF",
-	"glsast":         "PLUMBER_ANALYZE_GLSAST",
-	"csv":            "PLUMBER_ANALYZE_CSV",
-	"ocsf":           "PLUMBER_ANALYZE_OCSF",
-	"mr-comment":     "PLUMBER_ANALYZE_MR_COMMENT",
-	"badge":          "PLUMBER_ANALYZE_BADGE",
-	"score":          "PLUMBER_ANALYZE_SCORE",
-	"score-point":    "PLUMBER_ANALYZE_SCORE_POINT",
-	"score-push":     "PLUMBER_ANALYZE_SCORE_PUSH",
-	"score-endpoint": "PLUMBER_ANALYZE_SCORE_ENDPOINT",
-	"platform":       "PLUMBER_ANALYZE_PLATFORM",
-	"controls":       "PLUMBER_ANALYZE_CONTROLS",
-	"skip-controls":  "PLUMBER_ANALYZE_SKIP_CONTROLS",
-	"no-controls":    "PLUMBER_ANALYZE_NO_CONTROLS",
-	"fail-warnings":  "PLUMBER_ANALYZE_FAIL_WARNINGS",
-	"ci-config-path": "PLUMBER_ANALYZE_CI_CONFIG_PATH",
-	"verbose":        "PLUMBER_ANALYZE_VERBOSE",
+	"gitlab-url":          "PLUMBER_ANALYZE_GITLAB_URL",
+	"github-url":          "PLUMBER_ANALYZE_GITHUB_URL",
+	"project":             "PLUMBER_ANALYZE_PROJECT",
+	"provider":            "PLUMBER_ANALYZE_PROVIDER",
+	"branch":              "PLUMBER_ANALYZE_BRANCH",
+	"config":              "PLUMBER_ANALYZE_CONFIG",
+	"threshold":           "PLUMBER_ANALYZE_THRESHOLD",
+	"min-score":           "PLUMBER_ANALYZE_MIN_SCORE",
+	"min-points":          "PLUMBER_ANALYZE_MIN_POINTS",
+	"print":               "PLUMBER_ANALYZE_PRINT",
+	"output":              "PLUMBER_ANALYZE_OUTPUT",
+	"pbom":                "PLUMBER_ANALYZE_PBOM",
+	"pbom-cyclonedx":      "PLUMBER_ANALYZE_PBOM_CYCLONEDX",
+	"sarif":               "PLUMBER_ANALYZE_SARIF",
+	"glsast":              "PLUMBER_ANALYZE_GLSAST",
+	"csv":                 "PLUMBER_ANALYZE_CSV",
+	"ocsf":                "PLUMBER_ANALYZE_OCSF",
+	"mr-comment":          "PLUMBER_ANALYZE_MR_COMMENT",
+	"badge":               "PLUMBER_ANALYZE_BADGE",
+	"score":               "PLUMBER_ANALYZE_SCORE",
+	"score-point":         "PLUMBER_ANALYZE_SCORE_POINT",
+	"score-push":          "PLUMBER_ANALYZE_SCORE_PUSH",
+	"score-endpoint":      "PLUMBER_ANALYZE_SCORE_ENDPOINT",
+	"platform":            "PLUMBER_ANALYZE_PLATFORM",
+	"platform-allow-http": "PLUMBER_ANALYZE_PLATFORM_ALLOW_HTTP",
+	"controls":            "PLUMBER_ANALYZE_CONTROLS",
+	"skip-controls":       "PLUMBER_ANALYZE_SKIP_CONTROLS",
+	"no-controls":         "PLUMBER_ANALYZE_NO_CONTROLS",
+	"fail-warnings":       "PLUMBER_ANALYZE_FAIL_WARNINGS",
+	"ci-config-path":      "PLUMBER_ANALYZE_CI_CONFIG_PATH",
+	"verbose":             "PLUMBER_ANALYZE_VERBOSE",
 }
 
 func envStringFallback(cmd *cobra.Command, flag, envKey string, dest *string) error {
@@ -711,6 +717,9 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 			return envStringFallback(cmd, "score-endpoint", envKeys["score-endpoint"], &scoreEndpoint)
 		},
 		func() error { return envStringFallback(cmd, "platform", envKeys["platform"], &platformURL) },
+		func() error {
+			return envBoolFallback(cmd, "platform-allow-http", envKeys["platform-allow-http"], &platformAllowHTTP)
+		},
 		func() error { return envStringFallback(cmd, "controls", envKeys["controls"], &controlsFilter) },
 		func() error { return envStringFallback(cmd, "skip-controls", envKeys["skip-controls"], &skipControls) },
 		func() error {
@@ -800,8 +809,14 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	// Platform mode resolves its policy set, snapshot and CI configuration
 	// BEFORE collection, because what it resolves decides which lanes
 	// collection needs to run at all. Returns nil (and changes nothing)
-	// unless --platform is set.
-	conf.PlatformRun = setupPlatformMode(p, conf)
+	// unless --platform is set. A non-nil error is a configuration error
+	// (row 46: a plain-http endpoint refused without --platform-allow-http)
+	// and fails the run before any credential is sent.
+	rc, err := setupPlatformMode(p, conf)
+	if err != nil {
+		return err
+	}
+	conf.PlatformRun = rc
 	reportPlatformMode(conf.PlatformRun)
 
 	return runWithProvider(p, cmd, conf, controlsFilterList, skipControlsList)

--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -1147,7 +1147,14 @@ func platformPolicyReportEntries(runs []policyRun) []map[string]any {
 		var findings any
 		var notEvaluable any
 		if run.Applied {
-			score = platformScoreFrom(run.Score)
+			// run.Score is nil when this run's own control set evaluated
+			// nothing real (row 45: an empty tree, or every declared
+			// control config_required) - platformScoreFrom(nil) would send
+			// the zero-value {"points":0}, a fabricated score for a run
+			// that never produced one, so it is left absent instead.
+			if run.Score != nil {
+				score = platformScoreFrom(run.Score)
+			}
 			findings = projectFindings(run.Result.Findings, "job")
 			marks := make(map[string]string, len(run.Result.NotEvaluable))
 			for controlName, reason := range run.Result.NotEvaluable {
@@ -1160,7 +1167,7 @@ func platformPolicyReportEntries(runs []policyRun) []map[string]any {
 			if pol.MinPoints != nil {
 				minPoints = *pol.MinPoints
 			}
-			out = append(out, map[string]any{
+			entry := map[string]any{
 				"name": pol.Name,
 				// Only a real policy id is stamped, never the nil uuid the
 				// derived "[Plumber default]" placeholder carries: it is not
@@ -1170,10 +1177,22 @@ func platformPolicyReportEntries(runs []policyRun) []map[string]any {
 				"min_points":   minPoints,
 				"applied":      run.Applied,
 				"reason":       run.Reason,
-				"score":        score,
 				"findings":     findings,
 				"notEvaluable": notEvaluable,
-			})
+			}
+			// An un-applied policy keeps the "score" key present with a
+			// null value (it never had the chance to evaluate anything,
+			// same as findings/notEvaluable above). An applied one that
+			// genuinely produced no score (row 45) omits the key entirely
+			// instead: null would read as "the platform decoded an absent
+			// score", which is not what happened here.
+			switch {
+			case !run.Applied:
+				entry["score"] = nil
+			case score != nil:
+				entry["score"] = score
+			}
+			out = append(out, entry)
 		}
 	}
 	return out
@@ -1584,8 +1603,14 @@ func (s complianceSummary) gateLine() string {
 	if s.controlCount == 0 {
 		return "no controls evaluated, nothing to score"
 	}
+	// controlCount alone is not proof that anything real was checked: on
+	// GitHub it counts enabled controls whether or not their lane ever fed
+	// them, so a run whose enabled controls are all config_required carries
+	// a nonzero controlCount and a nil score. Say so in the same words as
+	// the zero-controlCount case above, rather than leaving the gate line
+	// blank (platform decision row 45).
 	if s.score == nil {
-		return ""
+		return "no control was evaluated, nothing to score"
 	}
 	requirements := []string{}
 	if s.pointsGateActive() {
@@ -1956,7 +1981,28 @@ func printNoControlsSummary() {
 }
 
 func printSummaryScoreBanner(score *control.PlumberScoreResult, scoreMode, degraded bool) {
-	if score == nil || !scoreMode {
+	if !scoreMode {
+		return
+	}
+
+	// A nil score here is never the --no-controls case (scoreMode is false
+	// then, caught above): it means score mode was on but nothing was
+	// actually evaluated, e.g. every enabled control turned out
+	// config_required. Zero findings over that empty set would otherwise
+	// deduction-score a perfect 100/A, which reads as a clean pass rather
+	// than as nothing having been checked. Say so in the same withheld
+	// wording family as the degraded case below (platform decision row 45).
+	if score == nil {
+		sep := styleRule.Render(strings.Repeat("─", hrWidth))
+		fmt.Println()
+		fmt.Println(" " + sep)
+		fmt.Println(" " + styleMuted.Render("Plumber Score"))
+		fmt.Println()
+		fmt.Printf(" %s\n", styleFail.Render("Score withheld: no control was evaluated"))
+		fmt.Printf(" %s\n", styleMuted.Render("Nothing was checked, so this run makes no claim about the pipeline."))
+		fmt.Println()
+		fmt.Println(" " + sep)
+		fmt.Println()
 		return
 	}
 

--- a/cmd/analyze_gitlab.go
+++ b/cmd/analyze_gitlab.go
@@ -2000,30 +2000,16 @@ func printSummaryScoreBanner(score *control.PlumberScoreResult, scoreMode, degra
 		return
 	}
 
-	// A nil score here is never the --no-controls case (scoreMode is false
-	// then, caught above): it means score mode was on but nothing was
-	// actually evaluated, e.g. every enabled control turned out
-	// config_required. Zero findings over that empty set would otherwise
-	// deduction-score a perfect 100/A, which reads as a clean pass rather
-	// than as nothing having been checked. Say so in the same withheld
-	// wording family as the degraded case below (platform decision row 45).
-	if score == nil {
-		sep := styleRule.Render(strings.Repeat("─", hrWidth))
-		fmt.Println()
-		fmt.Println(" " + sep)
-		fmt.Println(" " + styleMuted.Render("Plumber Score"))
-		fmt.Println()
-		fmt.Printf(" %s\n", styleFail.Render("Score withheld: no control was evaluated"))
-		fmt.Printf(" %s\n", styleMuted.Render("Nothing was checked, so this run makes no claim about the pipeline."))
-		fmt.Println()
-		fmt.Println(" " + sep)
-		fmt.Println()
-		return
-	}
-
 	// When data collection was degraded the score ran on incomplete data, so
 	// the letter grade would be meaningless (an empty pipeline reads as a clean
 	// A). Withhold the badge and say so plainly (#220).
+	//
+	// Checked before the generic nil-score case below: a degraded run also
+	// evaluates nothing trustworthy (every content control reports
+	// StatusError, so EvaluatedControlCount is zero and score is nil too),
+	// and the degraded wording is the accurate one here ("collection
+	// failed"), not the generic "nothing was checked" (review finding
+	// 6c38fbc735473281, platform decision row 45).
 	if degraded {
 		sep := styleRule.Render(strings.Repeat("─", hrWidth))
 		fmt.Println()
@@ -2032,6 +2018,28 @@ func printSummaryScoreBanner(score *control.PlumberScoreResult, scoreMode, degra
 		fmt.Println()
 		fmt.Printf(" %s\n", styleFail.Render("Score withheld — analysis ran on incomplete data"))
 		fmt.Printf(" %s\n", styleMuted.Render("Resolve the data-collection warnings above, then re-run for a grade."))
+		fmt.Println()
+		fmt.Println(" " + sep)
+		fmt.Println()
+		return
+	}
+
+	// A nil score here is never the --no-controls case (scoreMode is false
+	// then, caught above) and never the degraded case (caught above): it
+	// means score mode was on, collection was not degraded, but nothing was
+	// actually evaluated, e.g. every enabled control turned out
+	// config_required. Zero findings over that empty set would otherwise
+	// deduction-score a perfect 100/A, which reads as a clean pass rather
+	// than as nothing having been checked. Say so in the same withheld
+	// wording family as the degraded case above (platform decision row 45).
+	if score == nil {
+		sep := styleRule.Render(strings.Repeat("─", hrWidth))
+		fmt.Println()
+		fmt.Println(" " + sep)
+		fmt.Println(" " + styleMuted.Render("Plumber Score"))
+		fmt.Println()
+		fmt.Printf(" %s\n", styleFail.Render("Score withheld: no control was evaluated"))
+		fmt.Printf(" %s\n", styleMuted.Render("Nothing was checked, so this run makes no claim about the pipeline."))
 		fmt.Println()
 		fmt.Println(" " + sep)
 		fmt.Println()

--- a/cmd/analyze_gitlab_test.go
+++ b/cmd/analyze_gitlab_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/getplumber/plumber/control"
+	"github.com/getplumber/plumber/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -477,4 +478,38 @@ func TestLoadEmbeddedDefaultConfig_NoControlsUnderPlatformKeepsTheNotice(t *test
 	out := captureStderr(t, func() { _, _, _, _ = loadEmbeddedDefaultConfig() })
 
 	assertContains(t, out, "No .plumber.yaml found; using Plumber's built-in default configuration.")
+}
+
+// TestCheckoutIsAnalyzedProject_Row51UserinfoStripped pins the GitLab CI
+// runner scenario behind platform row 51: the job clones with the job token
+// embedded in the remote (gitlab-ci-token:<token>@host), and that checkout
+// must still be recognized as the analyzed project.
+//
+// Before the fix, ParseGitRemoteURL kept the userinfo in Host and URL, so
+// the parsed remote URL never equaled the plain --gitlab-url the pipeline
+// passes in, CheckoutIsAnalyzedProject stayed false, and the include
+// controls that depend on it never evaluated.
+func TestCheckoutIsAnalyzedProject_Row51UserinfoStripped(t *testing.T) {
+	const rawRemote = "https://gitlab-ci-token:glcbt-xxxx@gitlab.example.com/group/project.git"
+	const cleanURL = "https://gitlab.example.com"
+
+	parsed := utils.ParseGitRemoteURL(rawRemote)
+	if parsed == nil {
+		t.Fatalf("ParseGitRemoteURL(%q) = nil", rawRemote)
+	}
+
+	saved := projectPath
+	projectPath = parsed.ProjectPath
+	t.Cleanup(func() { projectPath = saved })
+
+	remote := gitLabRemoteInfo{
+		repoRoot:    "/src/project",
+		remoteURL:   parsed.URL,
+		projectPath: parsed.ProjectPath,
+	}
+
+	conf := buildGitLabConf(cleanURL, "glcbt-xxxx", analyzeFlags{}, remote, nil, nil, nil)
+	if !conf.CheckoutIsAnalyzedProject {
+		t.Errorf("CheckoutIsAnalyzedProject = false, want true (parsed remote URL %q vs %q)", parsed.URL, cleanURL)
+	}
 }

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -704,7 +704,11 @@ func presentResultWithProvider(p provider.Provider, cmd *cobra.Command, result *
 	// policy set for the push and the operator-facing report. GitHub lane
 	// wiring is a separate piece of work.
 	if conf != nil && conf.PlatformRun == nil {
-		conf.PlatformRun = setupPlatformMode(p, conf)
+		rc, err := setupPlatformMode(p, conf)
+		if err != nil {
+			return err
+		}
+		conf.PlatformRun = rc
 		reportPlatformMode(conf.PlatformRun)
 	}
 

--- a/cmd/analyze_shared.go
+++ b/cmd/analyze_shared.go
@@ -387,7 +387,16 @@ func buildComplianceSummary(p provider.Provider, result *control.AnalysisResult,
 	// there is no score. Every consumer of the score already guards on nil
 	// (the JSON report, the PBOM writers, the banner, the badge, the MR
 	// comment, the gate), so a nil here withholds rather than crashes.
-	score := computeScoreResult(result, scoreMode)
+	//
+	// controlCount (from ComputeCompliance) is not the right gauge for this:
+	// GitLab's own compliance already excludes not_evaluable controls, but
+	// GitHub's does not, so a run whose enabled controls are all
+	// config_required can carry a nonzero controlCount while nothing was
+	// actually checked. evaluatedCount reads each entry's real StatusFor
+	// instead (platform decision row 45): pass or fail only, the same
+	// definition of "evaluated" the render and push layers use.
+	evaluatedCount := control.EvaluatedControlCount(providerControlEntries(p, conf), result)
+	score := computeScoreResult(result, scoreMode, evaluatedCount)
 	if platformMode {
 		score = nil
 	}
@@ -742,10 +751,15 @@ func shouldShowProgress(printOutput, verbose, stderrIsTerminal bool) bool {
 	return printOutput && !verbose && stderrIsTerminal
 }
 
-// computeScoreResult computes the Plumber score when score mode is active.
-// Returns nil when scoreMode is false.
-func computeScoreResult(result *control.AnalysisResult, scoreMode bool) *control.PlumberScoreResult {
-	if !scoreMode {
+// computeScoreResult computes the Plumber score when score mode is active
+// and at least one control was actually evaluated. Returns nil when
+// scoreMode is false (--no-controls) or when evaluatedCount is zero: a run
+// that checked nothing has no basis for a score, and zero findings over an
+// empty or all-not_evaluable control set would otherwise compute a
+// deduction-based 100/A that reads as a clean pass rather than as nothing
+// having been checked (platform decision row 45).
+func computeScoreResult(result *control.AnalysisResult, scoreMode bool, evaluatedCount int) *control.PlumberScoreResult {
+	if !scoreMode || evaluatedCount == 0 {
 		return nil
 	}
 	s := control.ComputePlumberScore(control.AggregateIssueCodeCounts(result))

--- a/cmd/analyze_shared_test.go
+++ b/cmd/analyze_shared_test.go
@@ -76,3 +76,25 @@ func TestOutputText_Row45WithholdsScoreWhenNothingEvaluated(t *testing.T) {
 		t.Fatalf("must not print the graded letter-score badge, got:\n%s", out)
 	}
 }
+
+// TestPrintSummaryScoreBanner_Row45DegradedTakesPrecedenceOverWithheldScore
+// covers review finding 6c38fbc735473281 (row 45): a degraded run
+// (DataCollectionDegraded, every content control StatusError) also has a nil
+// score, since nothing it evaluated is trustworthy enough to count as
+// evaluated. The degraded wording is the accurate one ("analysis ran on
+// incomplete data, resolve the warnings above"); the generic
+// "no control was evaluated" line would be wrong here (it reads as "there
+// was nothing to check", not "collection failed"), so degraded must be
+// checked first.
+func TestPrintSummaryScoreBanner_Row45DegradedTakesPrecedenceOverWithheldScore(t *testing.T) {
+	out := captureStdout(t, func() {
+		printSummaryScoreBanner(nil, true, true)
+	})
+
+	if !strings.Contains(out, "Score withheld — analysis ran on incomplete data") {
+		t.Fatalf("a degraded run with nothing evaluated must print the degraded wording, got:\n%s", out)
+	}
+	if strings.Contains(out, "no control was evaluated") {
+		t.Fatalf("a degraded run must not print the generic withheld-score line, got:\n%s", out)
+	}
+}

--- a/cmd/analyze_shared_test.go
+++ b/cmd/analyze_shared_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/control"
+	"github.com/getplumber/plumber/provider"
+)
+
+// ---------------------------------------------------------------------------
+// computeScoreResult / outputTextWithProvider, row 45: withhold the score
+// when no control was evaluated, instead of reporting a perfect 100/A.
+// ---------------------------------------------------------------------------
+
+// TestComputeScoreResult_Row45WithholdsWhenNothingEvaluated pins the rule at
+// its lowest level: a zero evaluated-control count withholds the score
+// regardless of scoreMode, and scoreMode off withholds it regardless of the
+// evaluated count (the existing --no-controls behaviour, unchanged).
+func TestComputeScoreResult_Row45WithholdsWhenNothingEvaluated(t *testing.T) {
+	result := &control.AnalysisResult{CiValid: true}
+
+	if got := computeScoreResult(result, true, 0); got != nil {
+		t.Fatalf("zero evaluated controls must withhold the score even with scoreMode on, got %+v", got)
+	}
+	if got := computeScoreResult(result, false, 3); got != nil {
+		t.Fatalf("scoreMode off must withhold the score regardless of evaluatedCount, got %+v", got)
+	}
+	if got := computeScoreResult(result, true, 1); got == nil {
+		t.Fatal("at least one evaluated control must still produce a score")
+	}
+}
+
+// TestOutputText_Row45WithholdsScoreWhenNothingEvaluated exercises the full
+// terminal render for a run whose only enabled control is config_required
+// (#459): GitHub's own ComputeCompliance still counts it (unlike GitLab's,
+// which excludes not_evaluable controls), so this is the shape that used to
+// print a perfect 100/A grade on a run that checked nothing real. It must
+// now print the withheld line and no graded letter badge.
+func TestOutputText_Row45WithholdsScoreWhenNothingEvaluated(t *testing.T) {
+	oPrint := printOutput
+	defer func() { printOutput = oPrint }()
+	printOutput = true
+	newGateFlagsCmd(t)
+
+	gh := &provider.GitHubProvider{}
+	enabled := true
+	conf := configuration.NewDefaultConfiguration()
+	conf.PlumberConfig = &configuration.PlumberConfig{
+		GitHub: &configuration.ProviderConfig{
+			Controls: configuration.ControlsConfig{
+				ActionsMustBePinnedByCommitSha: &configuration.ActionsPinnedByShaControlConfig{Enabled: &enabled},
+			},
+		},
+	}
+	result := &control.AnalysisResult{
+		CiValid:     true,
+		ProjectPath: "group/project",
+		NotEvaluable: map[string]string{
+			"actionsMustBePinnedByCommitSha": control.ReasonConfigRequired,
+		},
+	}
+
+	s := buildComplianceSummary(gh, result, conf)
+	out := captureStdout(t, func() {
+		if err := outputTextWithProvider(gh, result, conf, s, nil, nil); err != nil {
+			t.Fatalf("render: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Score withheld: no control was evaluated") {
+		t.Fatalf("must print the withheld line, got:\n%s", out)
+	}
+	if strings.Contains(out, "/ 100 pts") {
+		t.Fatalf("must not print the graded letter-score badge, got:\n%s", out)
+	}
+}

--- a/cmd/gate_test.go
+++ b/cmd/gate_test.go
@@ -483,6 +483,75 @@ func TestBuildComplianceSummary_CiWiring(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// buildComplianceSummary, row 45: withhold the score when nothing was
+// evaluated, even when the provider's own control count is not zero.
+// ---------------------------------------------------------------------------
+
+// TestBuildComplianceSummary_Row45GitHubWithholdsScoreOnAllNotEvaluable pins
+// the gap GitLab's own compliance count does not have: GitHub's
+// ComputeCompliance counts every non-skipped entry regardless of whether it
+// was actually evaluated, so a control that is enabled but config_required
+// still inflates the control count while contributing nothing real. Before
+// this fix that read as a clean 100/A; now the score is withheld, and the
+// gate outcome is unchanged (it already passed on the old fake 100).
+func TestBuildComplianceSummary_Row45GitHubWithholdsScoreOnAllNotEvaluable(t *testing.T) {
+	newGateFlagsCmd(t)
+	gh := &provider.GitHubProvider{}
+	enabled := true
+	conf := configuration.NewDefaultConfiguration()
+	conf.PlumberConfig = &configuration.PlumberConfig{
+		GitHub: &configuration.ProviderConfig{
+			Controls: configuration.ControlsConfig{
+				ActionsMustBePinnedByCommitSha: &configuration.ActionsPinnedByShaControlConfig{Enabled: &enabled},
+			},
+		},
+	}
+	result := &control.AnalysisResult{
+		CiValid: true,
+		NotEvaluable: map[string]string{
+			"actionsMustBePinnedByCommitSha": control.ReasonConfigRequired,
+		},
+	}
+
+	s := buildComplianceSummary(gh, result, conf)
+	if s.controlCount == 0 {
+		t.Fatalf("GitHub's compliance count does not exclude not_evaluable controls, so it must stay nonzero here (got 0), or this test no longer exercises the gap")
+	}
+	if s.score != nil {
+		t.Fatalf("nothing was actually evaluated, the score must be withheld, got %+v", s.score)
+	}
+	if err := s.gateErr(); err != nil {
+		t.Fatalf("the exit code must stay unchanged: this shape passed the gate before (fake 100/A), it must still pass now, got %v", err)
+	}
+}
+
+// TestBuildComplianceSummary_Row45GitLabWithholdsScoreOnAllNotEvaluable is
+// the GitLab counterpart: GitLab's own ComputeCompliance already excludes
+// not_evaluable controls from controlCount, so this shape fails via the
+// existing zero-control gate (unchanged), and the score itself must also be
+// nil rather than the old perfect 100/A.
+func TestBuildComplianceSummary_Row45GitLabWithholdsScoreOnAllNotEvaluable(t *testing.T) {
+	newGateFlagsCmd(t)
+	gl := &provider.GitLabProvider{}
+	conf := confWithDebugTrace()
+	result := &control.AnalysisResult{
+		CiValid: true,
+		NotEvaluable: map[string]string{
+			"pipelineMustNotEnableDebugTrace": control.ReasonConfigRequired,
+		},
+	}
+
+	s := buildComplianceSummary(gl, result, conf)
+	if s.score != nil {
+		t.Fatalf("nothing was actually evaluated, the score must be withheld, got %+v", s.score)
+	}
+	var gateErr *ScoreGateError
+	if !errors.As(s.gateErr(), &gateErr) || !gateErr.NoControls {
+		t.Fatalf("GitLab's compliance count already excludes not_evaluable, so this must still fail via ScoreGateError{NoControls}, got %v", s.gateErr())
+	}
+}
+
+// ---------------------------------------------------------------------------
 // buildAnalysisJSONReport — the machine contract action.yml and the job
 // summary parse: conditional minPoints/minScore/threshold keys + passed
 // ---------------------------------------------------------------------------
@@ -773,5 +842,47 @@ func TestBuildAnalysisJSONReport_PlatformMode_PerPolicy(t *testing.T) {
 	blocked := decode(t, &platformVerdict{Gate: &platformGate{Evaluated: true, Blocking: true}})
 	if blocked["passed"] != false {
 		t.Errorf("passed = %v, want false: the platform's gate blocked", blocked["passed"])
+	}
+}
+
+// TestBuildAnalysisJSONReport_Row45PerPolicyOmitsScoreWhenNothingEvaluated
+// pins platform decision row 45 at the report layer: a policy whose only
+// declared control is config_required is Applied over a real config, but
+// nothing in it was actually evaluated, so its entry must have no "score"
+// key at all, distinct from an un-applied policy, which keeps the key
+// present with a null value (TestBuildAnalysisJSONReport_PlatformMode_PerPolicy
+// covers that shape and must keep passing unchanged).
+func TestBuildAnalysisJSONReport_Row45PerPolicyOmitsScoreWhenNothingEvaluated(t *testing.T) {
+	unconfigured := policyWithTree("Unconfigured", "pipelineMustNotEnableDebugTrace", `{"enabled":true}`)
+	conf := confWithPolicies(t, unconfigured)
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+	if runs[0].Score != nil {
+		t.Fatalf("test setup: expected the run's score already withheld, got %+v", runs[0].Score)
+	}
+	s := complianceSummary{platformMode: true, scoreMode: true}
+	params := jsonOutputParams{provider: "gitlab"}
+
+	payload, err := buildAnalysisJSONReport(debugTraceResult(), conf.PlumberConfig, s, params, runs, nil)
+	if err != nil {
+		t.Fatalf("buildAnalysisJSONReport: %v", err)
+	}
+	var report map[string]any
+	if err := json.Unmarshal(payload, &report); err != nil {
+		t.Fatalf("report is not valid JSON: %v", err)
+	}
+	pols, ok := report["policies"].([]any)
+	if !ok || len(pols) != 1 {
+		t.Fatalf("policies: %#v", report["policies"])
+	}
+	entry, _ := pols[0].(map[string]any)
+	if entry["applied"] != true {
+		t.Fatalf("the policy is applied over its own real (if unconfigured) config: %#v", entry)
+	}
+	if _, present := entry["score"]; present {
+		t.Errorf("a policy that evaluated nothing must have no score key at all, got %#v", entry["score"])
+	}
+	marks, ok := entry["notEvaluable"].(map[string]any)
+	if !ok || marks["pipelineMustNotEnableDebugTrace"] != control.ReasonConfigRequired {
+		t.Errorf("the control's own config_required mark must still be reported, got %#v", entry["notEvaluable"])
 	}
 }

--- a/cmd/gate_test.go
+++ b/cmd/gate_test.go
@@ -523,6 +523,27 @@ func TestBuildComplianceSummary_Row45GitHubWithholdsScoreOnAllNotEvaluable(t *te
 	if err := s.gateErr(); err != nil {
 		t.Fatalf("the exit code must stay unchanged: this shape passed the gate before (fake 100/A), it must still pass now, got %v", err)
 	}
+
+	// Review finding c20a70b26b847830 (row 45): the gateLine() branch that
+	// handles a nonzero controlCount alongside a nil score had no assertion
+	// pinning its exact text, even though this test already builds that
+	// summary shape.
+	const wantGateLine = "no control was evaluated, nothing to score"
+	if got := s.gateLine(); got != wantGateLine {
+		t.Fatalf("gateLine() = %q, want %q", got, wantGateLine)
+	}
+
+	oPrint := printOutput
+	defer func() { printOutput = oPrint }()
+	printOutput = true
+	out := captureStdout(t, func() {
+		if err := outputTextWithProvider(gh, result, conf, s, nil, nil); err != nil {
+			t.Fatalf("render: %v", err)
+		}
+	})
+	if !strings.Contains(out, wantGateLine) {
+		t.Fatalf("the status line must carry the withheld gate line, got:\n%s", out)
+	}
 }
 
 // TestBuildComplianceSummary_Row45GitLabWithholdsScoreOnAllNotEvaluable is

--- a/cmd/no_controls_test.go
+++ b/cmd/no_controls_test.go
@@ -42,9 +42,16 @@ func TestBuildComplianceSummary_NoControlsWithholdsScore(t *testing.T) {
 
 // A run WITHOUT the flag keeps computing a score: the default behaviour is
 // untouched by this feature.
+//
+// The fixture must declare at least one enabled control: a bare
+// &configuration.Configuration{} (nil PlumberConfig) declares none, which
+// evaluates nothing regardless of the --no-controls flag and must withhold
+// the score just the same (platform decision row 45) - it would not be
+// testing "the flag is off" any more, only reproducing the exact bug this
+// row exists to close.
 func TestBuildComplianceSummary_ScoreStillComputedByDefault(t *testing.T) {
 	result := &control.AnalysisResult{CiValid: true}
-	conf := &configuration.Configuration{}
+	conf := confWithDebugTrace()
 	s := buildComplianceSummary(&provider.GitLabProvider{}, result, conf)
 	if s.score == nil || !s.scoreMode {
 		t.Fatal("without --no-controls the score must still be computed")

--- a/cmd/platform_eval.go
+++ b/cmd/platform_eval.go
@@ -118,6 +118,20 @@ func evaluatePlatformPolicies(p providerPkg.Provider, conf *configuration.Config
 				// so annotate here (same linker, same order).
 				newLocationLinker(conf, scoped, p.Name()).Annotate(scoped.Findings)
 				run.Result, run.Score, run.Applied = scoped, &score, true
+				// Row 45: a nonzero control count on this policy's own tree
+				// is not proof anything was actually evaluated - an
+				// enabled-but-unconfigured control counts as declared but
+				// reports config_required (#459), and reasonNoControls's
+				// empty tree declares nothing at all. Either way the
+				// deduction-based score over an empty findings list would
+				// read as a clean pass, so it is withheld instead.
+				entries := p.Controls(cfg)
+				if conf != nil {
+					control.MarkSkippedByFilter(entries, conf.ControlsFilter, conf.SkipControlsFilter)
+				}
+				if control.EvaluatedControlCount(entries, scoped) == 0 {
+					run.Score = nil
+				}
 			}
 		}
 		groups[key] = run

--- a/cmd/platform_eval_test.go
+++ b/cmd/platform_eval_test.go
@@ -100,8 +100,36 @@ func TestEvaluatePlatformPolicies_NoControlsDeclared_EvaluatesEmptySet(t *testin
 	if len(runs) != 1 || !runs[0].Applied || runs[0].Reason != reasonNoControls {
 		t.Fatalf("want one applied run with the declares-no-controls reason, got %+v", runs)
 	}
-	if len(runs[0].Result.Findings) != 0 || runs[0].Score.Score != "A" {
-		t.Fatalf("empty set must yield no findings and A, got %d findings, %s", len(runs[0].Result.Findings), runs[0].Score.Score)
+	// Row 45: an empty control set evaluates nothing, so it has no score to
+	// report - not the perfect A a zero-finding empty set used to produce.
+	if len(runs[0].Result.Findings) != 0 || runs[0].Score != nil {
+		t.Fatalf("empty set must yield no findings and no score, got %d findings, score %+v", len(runs[0].Result.Findings), runs[0].Score)
+	}
+}
+
+// TestEvaluatePlatformPolicies_Row45AllUnconfiguredWithholdsScore covers the
+// real-control counterpart of the empty-set case above: a policy that
+// declares a control but leaves it with no substantive field is
+// config_required (#459), not evaluated, so the run still has nothing to
+// score even though it is Applied and its config is real.
+func TestEvaluatePlatformPolicies_Row45AllUnconfiguredWithholdsScore(t *testing.T) {
+	// debugTraceControlConfig's own doc comment: {"enabled":true} alone,
+	// with no forbiddenVariables, is exactly the unconfigured shape
+	// MarkUnconfiguredControls marks config_required.
+	unconfigured := policyWithTree("Unconfigured", "pipelineMustNotEnableDebugTrace", `{"enabled":true}`)
+	conf := confWithPolicies(t, unconfigured)
+
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+
+	if len(runs) != 1 || !runs[0].Applied {
+		t.Fatalf("want one applied run, got %+v", runs)
+	}
+	if runs[0].Score != nil {
+		t.Fatalf("every declared control is config_required, nothing was evaluated, score must be withheld, got %+v", runs[0].Score)
+	}
+	reason, marked := runs[0].Result.NotEvaluableReason("pipelineMustNotEnableDebugTrace")
+	if !marked || reason != control.ReasonConfigRequired {
+		t.Fatalf("the control must carry its own config_required mark regardless of the withheld score, got (%q, %v)", reason, marked)
 	}
 }
 

--- a/cmd/platform_mode.go
+++ b/cmd/platform_mode.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"strings"
 
@@ -33,20 +35,68 @@ func platformPolicyMode(noControlsRun bool) bool {
 	return push
 }
 
+// validatePlatformScheme refuses a plain-http --platform endpoint whose host
+// is not loopback, unless --platform-allow-http opts in.
+//
+// The push carries the CI OIDC id-token, and the platform's response carries
+// the run's own verdict (the gate) and served dismissals that move the
+// score. Over plain http both travel in the clear to any on-path attacker,
+// who can read the token and rewrite the response to change the job's exit
+// code and score (platform decision row 46). https is unaffected, and
+// loopback http (localhost, 127.0.0.0/8, ::1) stays allowed without the flag:
+// it never leaves the machine running the job.
+//
+// It runs before scoreOIDCToken mints anything and before platform.NewClient
+// is built, so a refusal here mints no token and opens no connection.
+func validatePlatformScheme(endpoint string) error {
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Scheme != "http" {
+		return nil
+	}
+	if platformAllowHTTP || isLoopbackPlatformHost(u.Hostname()) {
+		return nil
+	}
+	return fmt.Errorf(
+		"refusing to send platform credentials over plain http to %s: pass --platform-allow-http (PLUMBER_ANALYZE_PLATFORM_ALLOW_HTTP=1) for a trusted internal instance",
+		u.Host,
+	)
+}
+
+// isLoopbackPlatformHost reports whether host names the local machine: the
+// literal "localhost", or an IP in net.IP.IsLoopback's range (127.0.0.0/8,
+// ::1). host is already the URL's hostname with any port stripped.
+func isLoopbackPlatformHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
 // setupPlatformMode resolves everything platform mode needs BEFORE
 // collection begins, and returns the run context to hang on conf. It
-// returns nil when --platform is not set, which is the CLI's default and
-// leaves every downstream path exactly as it is in standalone mode.
+// returns (nil, nil) when --platform is not set, which is the CLI's default
+// and leaves every downstream path exactly as it is in standalone mode.
 //
-// Nothing here can fail a run. A platform that is unreachable, forbidden or
-// out of date degrades to a stated warning and a standalone collection: the
-// pipeline is never coupled to a third party's availability. The one
-// exception is the token, which is minted against the CI provider's OWN
-// infrastructure and is handled by the push path exactly as before.
-func setupPlatformMode(p providerPkg.Provider, conf *configuration.Configuration) *platform.RunContext {
+// Nothing past the scheme check can fail a run. A platform that is
+// unreachable, forbidden or out of date degrades to a stated warning and a
+// standalone collection: the pipeline is never coupled to a third party's
+// availability. The one exception is the token, which is minted against the
+// CI provider's OWN infrastructure and is handled by the push path exactly
+// as before.
+//
+// The scheme check (row 46) is different in kind: a plain-http endpoint that
+// is not loopback is a configuration error, not a degradation, so a
+// non-nil error here fails the run outright (the caller must propagate it)
+// rather than becoming a ContextErr warning.
+func setupPlatformMode(p providerPkg.Provider, conf *configuration.Configuration) (*platform.RunContext, error) {
 	push, endpoint := effectivePlatformPush()
 	if !push {
-		return nil
+		return nil, nil
+	}
+
+	if err := validatePlatformScheme(endpoint); err != nil {
+		return nil, err
 	}
 
 	rc := &platform.RunContext{Endpoint: endpoint}
@@ -58,13 +108,13 @@ func setupPlatformMode(p providerPkg.Provider, conf *configuration.Configuration
 		// context could not be fetched and lets the run proceed. Reporting
 		// it twice would double up on the same diagnosis.
 		rc.ContextErr = fmt.Errorf("no CI OIDC id-token available")
-		return rc
+		return rc, nil
 	}
 
 	_, projectPath, ok := resolveScoreTarget(p, conf)
 	if !ok {
 		rc.ContextErr = fmt.Errorf("could not resolve the project path")
-		return rc
+		return rc, nil
 	}
 	rc.ProjectPath = projectPath
 
@@ -74,7 +124,7 @@ func setupPlatformMode(p providerPkg.Provider, conf *configuration.Configuration
 	ctx, err := client.FetchContext(projectPath)
 	if err != nil {
 		rc.ContextErr = err
-		return rc
+		return rc, nil
 	}
 	rc.Context = ctx
 
@@ -90,7 +140,7 @@ func setupPlatformMode(p providerPkg.Provider, conf *configuration.Configuration
 	// endpoint costs its timeout in parallel rather than before any of it.
 	rc.Config = platform.StartRunConfigResolution(client, ctx.Snapshot, projectPath, sha, localDigest, abortReason)
 	rc.Config.ShaFromAnchor = shaFromAnchor
-	return rc
+	return rc, nil
 }
 
 // computeLocalCIDigest computes this checkout's CI config digest, the key

--- a/cmd/platform_mode_test.go
+++ b/cmd/platform_mode_test.go
@@ -139,10 +139,101 @@ func TestSetupPlatformMode_NilWithoutTheFlag(t *testing.T) {
 
 	for _, v := range []string{"", "   ", platformSentinelURL} {
 		platformURL = v
-		if got := setupPlatformMode(testProvider(t), &configuration.Configuration{}); got != nil {
+		got, err := setupPlatformMode(testProvider(t), &configuration.Configuration{})
+		if err != nil {
+			t.Fatalf("platformURL=%q: unexpected error %v", v, err)
+		}
+		if got != nil {
 			t.Fatalf("platformURL=%q must not enter platform mode, got %+v", v, got)
 		}
 	}
+}
+
+// TestSetupPlatformMode_Row46_PlainHTTPRequiresOptIn covers platform
+// decision row 46: a plain-http --platform endpoint whose host is not
+// loopback lets an on-path attacker read the CI OIDC id-token and rewrite
+// the response that carries the run's own verdict and served dismissals, so
+// it must be refused before any token is minted or client built, unless the
+// operator opts in with --platform-allow-http.
+func TestSetupPlatformMode_Row46_PlainHTTPRequiresOptIn(t *testing.T) {
+	restoreURL, restoreAllow := platformURL, platformAllowHTTP
+	t.Cleanup(func() {
+		platformURL = restoreURL
+		platformAllowHTTP = restoreAllow
+	})
+	// No token env set: a run that (wrongly) got past the scheme check would
+	// still fail here with "no CI OIDC id-token available", a DIFFERENT
+	// error than the refusal this test checks for. That keeps the two
+	// failure modes from being confused with one another.
+	_ = os.Unsetenv(gitlabPlatformTokenEnv)
+
+	const wantRefusalPrefix = "refusing to send platform credentials over plain http to "
+
+	t.Run("plain http to a non-loopback host is refused without the flag", func(t *testing.T) {
+		platformURL = "http://platform.example.com"
+		platformAllowHTTP = false
+
+		got, err := setupPlatformMode(testProvider(t), &configuration.Configuration{})
+		if got != nil {
+			t.Fatalf("want no run context on refusal, got %+v", got)
+		}
+		if err == nil {
+			t.Fatal("want a refusal error, got nil")
+		}
+		if !strings.HasPrefix(err.Error(), wantRefusalPrefix) {
+			t.Fatalf("error = %q, want prefix %q", err.Error(), wantRefusalPrefix)
+		}
+		if !strings.Contains(err.Error(), "platform.example.com") {
+			t.Fatalf("error = %q, want it to name the refused host", err.Error())
+		}
+		if !strings.Contains(err.Error(), "--platform-allow-http") || !strings.Contains(err.Error(), "PLUMBER_ANALYZE_PLATFORM_ALLOW_HTTP=1") {
+			t.Fatalf("error = %q, want it to name the opt-in", err.Error())
+		}
+	})
+
+	t.Run("plain http to loopback is allowed without the flag", func(t *testing.T) {
+		for _, host := range []string{"http://127.0.0.1:8080", "http://localhost:8080", "http://[::1]:8080"} {
+			platformURL = host
+			platformAllowHTTP = false
+
+			got, err := setupPlatformMode(testProvider(t), &configuration.Configuration{})
+			if err != nil {
+				t.Fatalf("host %q: unexpected refusal: %v", host, err)
+			}
+			// No token was supplied, so the run degrades to a ContextErr
+			// rather than being refused outright - proving the scheme check
+			// let it through.
+			if got == nil || got.ContextErr == nil {
+				t.Fatalf("host %q: want a degraded run context (no token supplied), got %+v", host, got)
+			}
+		}
+	})
+
+	t.Run("plain http to a non-loopback host is allowed with the flag", func(t *testing.T) {
+		platformURL = "http://platform.example.com"
+		platformAllowHTTP = true
+
+		got, err := setupPlatformMode(testProvider(t), &configuration.Configuration{})
+		if err != nil {
+			t.Fatalf("unexpected refusal with --platform-allow-http: %v", err)
+		}
+		if got == nil || got.ContextErr == nil {
+			t.Fatalf("want a degraded run context (no token supplied), got %+v", got)
+		}
+	})
+
+	t.Run("https is unaffected by the flag", func(t *testing.T) {
+		platformURL = "https://platform.example.com"
+		platformAllowHTTP = false
+
+		got, err := setupPlatformMode(testProvider(t), &configuration.Configuration{})
+		if err != nil {
+			t.Fatalf("https must never be refused: %v", err)
+		}
+		if got == nil || got.ContextErr == nil {
+			t.Fatalf("want a degraded run context (no token supplied), got %+v", got)
+		}
+	})
 }
 
 // TestReportPlatformMode_AlwaysReportsProvenance pins that the platform

--- a/cmd/platform_mode_test.go
+++ b/cmd/platform_mode_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 
 	"github.com/getplumber/plumber/configuration"
+	"github.com/getplumber/plumber/control"
 	"github.com/getplumber/plumber/internal/cidigest"
 	"github.com/getplumber/plumber/internal/platform"
+	providerPkg "github.com/getplumber/plumber/provider"
 )
 
 // TestLocalDigestVersionMatchesCidigest pins the two halves of the pair
@@ -232,6 +234,85 @@ func TestSetupPlatformMode_Row46_PlainHTTPRequiresOptIn(t *testing.T) {
 		}
 		if got == nil || got.ContextErr == nil {
 			t.Fatalf("want a degraded run context (no token supplied), got %+v", got)
+		}
+	})
+}
+
+// TestPresentResultWithProvider_Row46_GitHubPathRefusesPlainHTTP pins the
+// SAME row-46 refusal on the OTHER of setupPlatformMode's two call sites:
+// presentResultWithProvider (analyze_shared.go), which is the only path a
+// GitHub run reaches it through - a GitLab run reaches it via runAnalyze in
+// analyze_gitlab.go instead, already covered by
+// TestSetupPlatformMode_Row46_PlainHTTPRequiresOptIn above. Without a test
+// exercising THIS call site, a change that swallowed or bypassed the
+// returned error here would send the CI OIDC id-token to a plain-http
+// platform in the clear on a GitHub run, with nothing to catch it.
+func TestPresentResultWithProvider_Row46_GitHubPathRefusesPlainHTTP(t *testing.T) {
+	restoreURL, restoreAllow := platformURL, platformAllowHTTP
+	t.Cleanup(func() {
+		platformURL = restoreURL
+		platformAllowHTTP = restoreAllow
+	})
+	// Unset: a run that (wrongly) got past the scheme check then degrades to
+	// "no CI OIDC id-token available" (err == nil, a ContextErr instead)
+	// rather than an HTTP round trip - the same no-network guarantee
+	// TestSetupPlatformMode_Row46_PlainHTTPRequiresOptIn relies on, and what
+	// keeps a bypass from being confused with a refusal below.
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "")
+
+	gh, ok := providerPkg.Get("github")
+	if !ok {
+		t.Skip("github provider not registered")
+	}
+	pc := testDefaultPlumberConfig(t)
+
+	const wantRefusalPrefix = "refusing to send platform credentials over plain http to "
+
+	t.Run("plain http to a non-loopback host is refused without the flag", func(t *testing.T) {
+		platformURL = "http://platform.example.com"
+		platformAllowHTTP = false
+		conf := &configuration.Configuration{PlumberConfig: pc}
+
+		err := presentResultWithProvider(gh, nil, &control.AnalysisResult{}, conf)
+		if err == nil {
+			t.Fatal("want a refusal error, got nil")
+		}
+		if !strings.HasPrefix(err.Error(), wantRefusalPrefix) {
+			t.Fatalf("error = %q, want prefix %q", err.Error(), wantRefusalPrefix)
+		}
+		if !strings.Contains(err.Error(), "platform.example.com") {
+			t.Fatalf("error = %q, want it to name the refused host", err.Error())
+		}
+		if !strings.Contains(err.Error(), "--platform-allow-http") || !strings.Contains(err.Error(), "PLUMBER_ANALYZE_PLATFORM_ALLOW_HTTP=1") {
+			t.Fatalf("error = %q, want it to name the opt-in", err.Error())
+		}
+		// A refusal must leave no run context (and so no token, no client)
+		// behind: setupPlatformMode returns (nil, err), never (rc, err).
+		if conf.PlatformRun != nil {
+			t.Fatalf("want no run context on refusal, got %+v", conf.PlatformRun)
+		}
+	})
+
+	t.Run("plain http to loopback is allowed without the flag", func(t *testing.T) {
+		platformURL = "http://127.0.0.1:8080"
+		platformAllowHTTP = false
+		conf := &configuration.Configuration{PlumberConfig: pc}
+
+		var err error
+		_ = captureStdoutAll(t, func() {
+			_ = captureStderr(t, func() {
+				err = presentResultWithProvider(gh, nil, &control.AnalysisResult{}, conf)
+			})
+		})
+		if err != nil {
+			t.Fatalf("loopback http must not be refused: %v", err)
+		}
+		// No token was supplied (ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN unset),
+		// so the run degrades to a ContextErr rather than being refused
+		// outright - proving the scheme check let it through.
+		if conf.PlatformRun == nil || conf.PlatformRun.ContextErr == nil {
+			t.Fatalf("want a degraded run context (no token supplied), got %+v", conf.PlatformRun)
 		}
 	})
 }

--- a/cmd/platform_push.go
+++ b/cmd/platform_push.go
@@ -132,7 +132,15 @@ type platformPolicyResult struct {
 	PolicyID        string            `json:"policy_id,omitempty"`
 	EffectiveConfig json.RawMessage   `json:"effective_config,omitempty"`
 	Findings        []platformFinding `json:"findings"`
-	Score           platformScore     `json:"score"`
+	// Score is a pointer so a run that evaluated nothing real (row 45: an
+	// empty control set, or every declared control config_required) can
+	// omit it from the wire entirely. platformScoreFrom itself still takes
+	// and tolerates a nil *control.PlumberScoreResult by returning the
+	// zero value (existing callers that always have a real score keep
+	// working unchanged); it is the caller's job to leave this field nil
+	// rather than call it when there is genuinely no score to send. The
+	// platform's contract accepts an absent policy score.
+	Score *platformScore `json:"score,omitempty"`
 }
 
 // platformFinding is one EXPLICIT per-control result entry — see
@@ -270,9 +278,11 @@ func roundJSONScorePoints(v any) (int, error) {
 // contract's Score.Points type actually is. FinalPoints carries the
 // malus-capped final figure (floored at 0, capped at 30 while any Critical
 // exists) so the platform can cross-check its own recompute against the
-// CLI's exact formula. Tolerates a nil score (no production caller passes
-// one today, but a best-effort push should never panic a run over a nil
-// pointer) by sending the zero value, with FinalPoints left nil.
+// CLI's exact formula. Tolerates a nil score (a best-effort push should
+// never panic a run over a nil pointer) by returning the zero value, with
+// FinalPoints left nil; every caller that can genuinely have no score to
+// send (row 45: nothing was evaluated) checks for nil itself and leaves the
+// wire field absent instead of calling this with one.
 func platformScoreFrom(score *control.PlumberScoreResult) platformScore {
 	if score == nil {
 		return platformScore{}

--- a/cmd/platform_push_test.go
+++ b/cmd/platform_push_test.go
@@ -985,9 +985,10 @@ func TestMaybePushPlatform_NegativeScorePointsReachTheWire(t *testing.T) {
 	}
 }
 
-// No production caller passes a nil score (scoreMode is always on in
-// buildComplianceSummary), but a best-effort push crashing the run over a nil
-// pointer would be strictly worse than sending the zero value.
+// A nil score reaches maybePushPlatform for real now (row 45:
+// buildComplianceSummary withholds it whenever nothing was evaluated), and a
+// best-effort push crashing the run over a nil pointer would be strictly
+// worse than sending no score at all.
 func TestMaybePushPlatform_NilScoreDoesNotPanic(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
@@ -998,6 +999,38 @@ func TestMaybePushPlatform_NilScoreDoesNotPanic(t *testing.T) {
 
 	if _, err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil, nil); err != nil {
 		t.Fatalf("maybePushPlatform: %v", err)
+	}
+}
+
+// TestMaybePushPlatform_Row45OmitsScoreWhenNil is the standalone-push
+// counterpart of TestBuildPolicyResults_Row45OmitsScoreWhenNothingEvaluated:
+// a nil score must reach the wire as an absent "score" key, never as
+// platformScoreFrom's zero-value fallback ({"points":0}), which would read
+// as a real, if empty, score rather than as none at all.
+func TestMaybePushPlatform_Row45OmitsScoreWhenNil(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	restore := withPlatformTestEnv(t, srv.URL, "tok-123")
+	defer restore()
+
+	if _, err := maybePushPlatform(testProvider(t), nil, &control.AnalysisResult{}, nil, nil); err != nil {
+		t.Fatalf("maybePushPlatform: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(gotBody, &raw); err != nil {
+		t.Fatal(err)
+	}
+	results, ok := raw["results"].([]any)
+	if !ok || len(results) != 1 {
+		t.Fatalf("results: %#v", raw["results"])
+	}
+	entry, _ := results[0].(map[string]any)
+	if _, present := entry["score"]; present {
+		t.Errorf("a nil score must be omitted from the push, not sent as a zero-value object, got %#v", entry["score"])
 	}
 }
 

--- a/cmd/platform_render.go
+++ b/cmd/platform_render.go
@@ -77,7 +77,12 @@ func renderPolicySections(p providerPkg.Provider, conf *configuration.Configurat
 			continue
 		}
 		if r.Reason == reasonNoControls {
+			// An empty control set evaluated nothing (row 45: run.Score is
+			// already nil for this reason), and the line above already
+			// says so - printing the withheld banner underneath it would
+			// be a second way of saying the same thing.
 			fmt.Println("  declares no controls, nothing evaluated")
+			continue
 		}
 		var controls []controlSummary
 		var groups []findingGroup

--- a/cmd/platform_render_test.go
+++ b/cmd/platform_render_test.go
@@ -111,6 +111,29 @@ func TestRenderPolicySections_NoControlsDeclared(t *testing.T) {
 
 	assertContains(t, out, "== Policy: Empty  [report]")
 	assertContains(t, out, "declares no controls, nothing evaluated")
+	// Row 45: an empty control set evaluated nothing, so no score banner
+	// follows the reason line - the same absence R3's un-applied case gets.
+	if strings.Contains(out, "Plumber Score") {
+		t.Fatalf("a policy declaring no controls must print no score banner, got:\n%s", out)
+	}
+}
+
+// Row 45: a policy whose only declared control is config_required (#459)
+// evaluated nothing real either, even though it is Applied over a real
+// config and not the reasonNoControls empty-set case above. Its section
+// prints the withheld line rather than a perfect 100/A grade.
+func TestRenderPolicySections_Row45AllUnconfiguredPrintsWithheldLine(t *testing.T) {
+	unconfigured := policyWithTree("Unconfigured", "pipelineMustNotEnableDebugTrace", `{"enabled":true}`)
+	conf := confWithPolicies(t, unconfigured)
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+
+	out := captureStdoutAll(t, func() { renderPolicySections(testProvider(t), conf, runs, nil, nil) })
+
+	assertContains(t, out, "== Policy: Unconfigured  [report]")
+	assertContains(t, out, "Score withheld: no control was evaluated")
+	if strings.Contains(out, "/ 100 pts") {
+		t.Fatalf("must not print a graded letter-score badge, got:\n%s", out)
+	}
 }
 
 // --no-controls is a request for NO verdict, and platform mode does not

--- a/cmd/platform_results.go
+++ b/cmd/platform_results.go
@@ -39,7 +39,15 @@ func buildPolicyResults(runs []policyRun, p providerPkg.Provider, conf *configur
 		}
 		findings := platformFindingsFor(p, run.Result, run.Config, includeOnly, skip)
 		effective := platformEffectiveConfigRaw(run.Config, p.Name())
-		score := platformScoreFrom(run.Score)
+		// run.Score is nil when this run's own control set evaluated
+		// nothing real (row 45), and the wire's score must then be
+		// genuinely absent rather than platformScoreFrom's zero-value
+		// fallback for a nil input.
+		var score *platformScore
+		if run.Score != nil {
+			s := platformScoreFrom(run.Score)
+			score = &s
+		}
 		for _, pol := range run.Policies {
 			out = append(out, platformPolicyResult{
 				Policy: pol.Name,
@@ -252,10 +260,18 @@ func standalonePolicyResult(
 		pc = conf.PlumberConfig
 		includeOnly, skip = conf.ControlsFilter, conf.SkipControlsFilter
 	}
+	// A nil score (row 45: nothing was evaluated, or the deliberate
+	// --no-controls/best-effort nil) must reach the wire as an absent
+	// "score" key, not platformScoreFrom's zero-value fallback.
+	var wireScore *platformScore
+	if score != nil {
+		s := platformScoreFrom(score)
+		wireScore = &s
+	}
 	return platformPolicyResult{
 		Policy:          platformPolicyNameFor(configPath),
 		EffectiveConfig: platformEffectiveConfigRaw(pc, p.Name()),
 		Findings:        platformFindingsFor(p, result, pc, includeOnly, skip),
-		Score:           platformScoreFrom(score),
+		Score:           wireScore,
 	}
 }

--- a/cmd/platform_results_test.go
+++ b/cmd/platform_results_test.go
@@ -195,6 +195,42 @@ func TestBuildPolicyResults_StandaloneFallsBackToTheLocalPolicy(t *testing.T) {
 	}
 }
 
+// TestBuildPolicyResults_Row45OmitsScoreWhenNothingEvaluated pins platform
+// decision row 45 at the push layer: a policy whose only declared control is
+// config_required (#459) is Applied (evaluatePlatformPolicies already
+// withholds its Score), and the pushed entry's score must be genuinely
+// absent from the wire rather than the zero-value {"points":0}
+// platformScoreFrom(nil) would otherwise send for a run that evaluated
+// nothing real.
+func TestBuildPolicyResults_Row45OmitsScoreWhenNothingEvaluated(t *testing.T) {
+	unconfigured := policyWithTree("Unconfigured", "pipelineMustNotEnableDebugTrace", `{"enabled":true}`)
+	conf := confWithPolicies(t, unconfigured)
+	runs := evaluatePlatformPolicies(testProvider(t), conf, debugTraceResult())
+	if !runs[0].Applied || runs[0].Score != nil {
+		t.Fatalf("test setup: want an applied run with an already-withheld score, got %+v", runs[0])
+	}
+
+	got := buildPolicyResults(runs, testProvider(t), conf)
+	if len(got) != 1 {
+		t.Fatalf("want one entry, got %d", len(got))
+	}
+	if got[0].Score != nil {
+		t.Fatalf("the entry's score must be nil (absent on the wire), got %+v", got[0].Score)
+	}
+
+	raw, err := json.Marshal(got[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, present := m["score"]; present {
+		t.Errorf("score must be omitted from the wire, not sent as a zero-value object, got %#v", m["score"])
+	}
+}
+
 func TestConfigFingerprint(t *testing.T) {
 	a, _, _, err := configuration.LoadPlumberConfigFromBytes([]byte("version: \"2.0\"\n"), "a")
 	if err != nil {

--- a/cmd/testdata/catalog_golden.json
+++ b/cmd/testdata/catalog_golden.json
@@ -47,6 +47,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -72,6 +73,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
@@ -107,6 +109,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -132,6 +135,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -171,6 +175,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -199,6 +204,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
@@ -215,30 +221,35 @@
             "name": "defaultMustBeProtected",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Requires the default branch to be protected."
           },
           {
             "name": "allowForcePush",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "When false, force push must be disabled on protected branches."
           },
           {
             "name": "codeOwnerApprovalRequired",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "When true, code owner approval is required."
           },
           {
             "name": "minMergeAccessLevel",
             "type": "integer",
             "optional": true,
+            "nullable": true,
             "description": "Minimum access level required to merge (0 = No one, 30 = Developer, 40 = Maintainer)."
           },
           {
             "name": "minPushAccessLevel",
             "type": "integer",
             "optional": true,
+            "nullable": true,
             "description": "Minimum access level required to push (0 = No one, 30 = Developer, 40 = Maintainer)."
           }
         ]
@@ -265,6 +276,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -291,6 +303,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -316,6 +329,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -356,6 +370,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
@@ -372,12 +387,14 @@
             "name": "trustDockerHubOfficialImages",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Trusts official Docker Hub images, such as nginx or alpine."
           },
           {
             "name": "includePlumberDefaults",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "In overlay mode, unions Plumber's curated default trusted list with trustedUrls; set false to trust only the listed entries; ignored in legacy mode.",
             "default": "true"
           }
@@ -405,6 +422,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
@@ -421,6 +439,7 @@
             "name": "containerImagesMustBePinnedByDigest",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "When true, all images must use immutable digest references, taking precedence over the forbidden tags list."
           }
         ]
@@ -504,6 +523,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -529,12 +549,14 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
             "name": "trustGithubOfficialActions",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Trusts first-party GitHub-owned actions (actions/*, github/*); defaults to true when unset.",
             "default": "true"
           },
@@ -542,6 +564,7 @@
             "name": "trustSameOrgActions",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Trusts actions whose owner is the same org or user as the scanned repository; defaults to true when unset.",
             "default": "true"
           },
@@ -566,6 +589,7 @@
             "name": "includePlumberDefaults",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "In overlay mode, unions Plumber's curated default trusted list with trustedGithubActions; set false to trust only the listed entries; ignored in legacy mode.",
             "default": "true"
           }
@@ -607,6 +631,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -633,6 +658,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
@@ -649,6 +675,7 @@
             "name": "defaultBranchIsForbiddenVersion",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "When true, adds the project's default branch to the forbidden versions list."
           }
         ]
@@ -674,6 +701,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -699,12 +727,14 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
             "name": "minimumRequiredApprovals",
             "type": "integer",
             "optional": true,
+            "nullable": true,
             "description": "Fewest approvals a rule covering all protected branches must require; a covering rule below this is flagged. Unset asserts nothing."
           }
         ]
@@ -730,36 +760,42 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
             "name": "preventApprovalByAuthor",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "When true, expects that merge request authors cannot approve their own merge requests."
           },
           {
             "name": "preventApprovalsByCommitters",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "When true, expects that users who committed to a merge request cannot approve it."
           },
           {
             "name": "preventEditingApprovalRulesInMR",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "When true, expects that approval rules cannot be overridden per merge request."
           },
           {
             "name": "requireReAuthToApprove",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "When true, expects that approving a merge request requires re-authentication."
           },
           {
             "name": "behaviorWhenCommitIsAdded",
             "type": "string",
             "optional": true,
+            "nullable": true,
             "description": "Minimum required strictness for what happens to existing approvals when a commit is added to an open merge request; a project below the configured rung is flagged.",
             "enum": [
               "keep_approvals",
@@ -790,12 +826,14 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
             "name": "mergeMethod",
             "type": "string",
             "optional": true,
+            "nullable": true,
             "description": "Expected merge method; any other value fails config validation.",
             "enum": [
               "merge",
@@ -807,6 +845,7 @@
             "name": "squashOption",
             "type": "string",
             "optional": true,
+            "nullable": true,
             "description": "Expected squash policy; any other value fails config validation.",
             "enum": [
               "never",
@@ -819,36 +858,42 @@
             "name": "mergePipelinesEnabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Expected merged-results-pipelines setting."
           },
           {
             "name": "mergeTrainsEnabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Expected merge-trains setting."
           },
           {
             "name": "allowMergeOnSkippedPipeline",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Expected allow-merge-when-pipeline-is-skipped setting."
           },
           {
             "name": "resolveOutdatedDiffDiscussions",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Expected auto-resolve-outdated-discussions setting."
           },
           {
             "name": "printingMergeRequestLinkEnabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Expected print-merge-request-link-on-push setting."
           },
           {
             "name": "removeSourceBranchAfterMerge",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Expected delete-source-branch-after-merge default."
           }
         ]
@@ -875,6 +920,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
@@ -922,6 +968,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
@@ -969,6 +1016,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
@@ -1005,6 +1053,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
@@ -1041,6 +1090,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -1067,6 +1117,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
@@ -1103,12 +1154,14 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
             "name": "detectInsecureDaemon",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "When true, also flags insecure daemon configuration in jobs that use a Docker-in-Docker service."
           }
         ]
@@ -1136,6 +1189,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
@@ -1181,18 +1235,21 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
             "name": "expectedProjectId",
             "type": "integer",
             "optional": true,
+            "nullable": true,
             "description": "Numeric GitLab project ID the linked security policy project must match; unset requires only that some policy project is linked."
           },
           {
             "name": "expectedProjectPath",
             "type": "string",
             "optional": true,
+            "nullable": true,
             "description": "Full namespace/project path the linked security policy project must match, compared case-insensitively; ignored when expectedProjectId is also set."
           }
         ]
@@ -1232,6 +1289,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -1257,6 +1315,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
@@ -1305,6 +1364,7 @@
                   "name": "disableValue",
                   "type": "bool",
                   "optional": true,
+                  "nullable": true,
                   "description": "For mode default, the value of disableInput that turns caching off."
                 },
                 {
@@ -1431,6 +1491,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -1457,6 +1518,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
@@ -1473,12 +1535,14 @@
             "name": "allowFailureMustBeFalse",
             "type": "object",
             "optional": true,
+            "nullable": true,
             "description": "Sub-control toggle requiring allow_failure to be false on matched security jobs.",
             "fields": [
               {
                 "name": "enabled",
                 "type": "bool",
                 "optional": true,
+                "nullable": true,
                 "description": "Turns the control on; when false or absent the control is skipped."
               }
             ]
@@ -1487,12 +1551,14 @@
             "name": "rulesMustNotBeRedefined",
             "type": "object",
             "optional": true,
+            "nullable": true,
             "description": "Sub-control toggle requiring rules to not be redefined on matched security jobs.",
             "fields": [
               {
                 "name": "enabled",
                 "type": "bool",
                 "optional": true,
+                "nullable": true,
                 "description": "Turns the control on; when false or absent the control is skipped."
               }
             ]
@@ -1501,12 +1567,14 @@
             "name": "whenMustNotBeManual",
             "type": "object",
             "optional": true,
+            "nullable": true,
             "description": "Sub-control toggle requiring when to not be set to manual on matched security jobs.",
             "fields": [
               {
                 "name": "enabled",
                 "type": "bool",
                 "optional": true,
+                "nullable": true,
                 "description": "Turns the control on; when false or absent the control is skipped."
               }
             ]
@@ -1562,6 +1630,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           },
           {
@@ -1635,6 +1704,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -1660,6 +1730,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -1699,6 +1770,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -1780,6 +1852,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -1819,6 +1892,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]
@@ -1872,6 +1946,7 @@
             "name": "enabled",
             "type": "bool",
             "optional": true,
+            "nullable": true,
             "description": "Turns the control on; when false or absent the control is skipped."
           }
         ]

--- a/configuration/schema.go
+++ b/configuration/schema.go
@@ -11,10 +11,24 @@ import (
 // pointers/omitempty. Structure is REFLECTED from the real config structs
 // so it can never drift from the code; Description/Enum/Default are welded
 // on from the authored table in schema_docs.go (#458).
+//
+// Optional is true for a pointer field OR a plain field with an omitempty
+// yaml tag, and that conflates two different things: on a plain field,
+// unset and the zero value are indistinguishable, so nothing is lost by
+// omitting it; on a pointer field, unset is a distinct, meaningful state
+// (the caller made no choice) from a present zero value. Nullable
+// disambiguates that: it is true iff the Go field itself is a pointer, so a
+// consumer (an editor rendering a config form) knows which optional fields
+// can legitimately be left blank versus which are just conventionally
+// omitted. Nested struct fields inherit Nullable through the same
+// recursion structFields already does for Optional. A pointer-typed slice
+// element or map value is out of scope: Elem never carries Nullable, only
+// the field that holds the slice or map itself can.
 type SchemaField struct {
 	Name        string        `json:"name,omitempty"`
 	Type        string        `json:"type"`
 	Optional    bool          `json:"optional"`
+	Nullable    bool          `json:"nullable,omitempty"`
 	Description string        `json:"description,omitempty"`
 	Elem        *SchemaField  `json:"elem,omitempty"`
 	Fields      []SchemaField `json:"fields,omitempty"`
@@ -90,7 +104,10 @@ func structFields(t reflect.Type) []SchemaField {
 		}
 		sf := typeToField(f.Type)
 		sf.Name = name
-		if f.Type.Kind() == reflect.Ptr || yamlOmitempty(f) {
+		if f.Type.Kind() == reflect.Ptr {
+			sf.Optional = true
+			sf.Nullable = true
+		} else if yamlOmitempty(f) {
 			sf.Optional = true
 		}
 		fields = append(fields, sf)

--- a/configuration/schema_test.go
+++ b/configuration/schema_test.go
@@ -74,6 +74,50 @@ func TestReflectControlSchemas(t *testing.T) {
 	})
 }
 
+// nullableFixture pins the difference Optional cannot express: A is optional
+// because it is a pointer (unset is meaningful, distinct from the zero
+// value), B is optional only because of the omitempty yaml tag on a plain
+// int (unset and zero are indistinguishable, so nothing is lost by omitting
+// it) (platform row 52).
+type nullableFixture struct {
+	A *int `yaml:"a,omitempty"`
+	B int  `yaml:"b,omitempty"`
+}
+
+func TestStructFields_NullableTracksPointerness(t *testing.T) {
+	fields := structFields(reflect.TypeOf(nullableFixture{}))
+	byName := map[string]SchemaField{}
+	for _, f := range fields {
+		byName[f.Name] = f
+	}
+
+	a, ok := byName["a"]
+	if !ok || !a.Optional || !a.Nullable {
+		t.Errorf("a = %+v, ok=%v, want optional and nullable (pointer field)", a, ok)
+	}
+	b, ok := byName["b"]
+	if !ok || !b.Optional || b.Nullable {
+		t.Errorf("b = %+v, ok=%v, want optional and NOT nullable (omitempty non-pointer field)", b, ok)
+	}
+}
+
+// TestConfigSchemaFor_PointerFieldIsNullable pins the real-world case:
+// cicdVariablesMustBeProtected's only field, Enabled, is a *bool, so the
+// welded schema the platform reflects on GET /controls must mark it
+// nullable so an editor knows absence is meaningful, not just "optional".
+func TestConfigSchemaFor_PointerFieldIsNullable(t *testing.T) {
+	s, ok := ConfigSchemaFor("cicdVariablesMustBeProtected")
+	if !ok {
+		t.Fatalf("cicdVariablesMustBeProtected: no schema")
+	}
+	if len(s.Fields) != 1 || s.Fields[0].Name != "enabled" {
+		t.Fatalf("fields = %+v, want exactly one field named enabled", s.Fields)
+	}
+	if !s.Fields[0].Nullable {
+		t.Errorf("enabled.Nullable = false, want true: the field is a *bool")
+	}
+}
+
 // controlBlockGuardFixture stands in for a ControlsConfig that has drifted: every control block
 // is a pointer to a struct today, and the two other shapes below are what a future field could
 // look like. Reflection cannot be type-checked at compile time, so the guard needs a fixture

--- a/control/lanes.go
+++ b/control/lanes.go
@@ -763,13 +763,11 @@ func ReEvaluateForConfig(
 		MarkDismissed(scopedResult.Findings, conf.PlatformRun.Context.DismissedIssues)
 	}
 
-	counts := map[ErrorCode]int{}
-	for _, f := range scopedResult.Findings {
-		if f.Dismissed {
-			continue
-		}
-		counts[ErrorCode(f.Code)]++
-	}
+	// codeCountsForFindings (control/scoring.go) counts one per distinct
+	// identity per code (row 41), the same rule AggregateIssueCodeCounts
+	// applies to the run-level score, so a policy's own score and the
+	// platform's recompute over the same findings never disagree.
+	counts := codeCountsForFindings(scopedResult.Findings)
 	// The whole scoped result is returned, not just its findings. The marks
 	// computed just above are what StatusFor reads to report a control as
 	// not_evaluable, and DropNotEvaluableFindings has already removed the

--- a/control/lanes_test.go
+++ b/control/lanes_test.go
@@ -617,6 +617,111 @@ func TestReEvaluateForConfigWorksForGitHub(t *testing.T) {
 	}
 }
 
+// TestReEvaluateForConfig_Row41CollapsesIdentityCollision pins row 41 in the
+// per-policy path. action-unpinned (ISSUE-701, declared identity {file, job,
+// uses, step}) has two separate deny blocks in its rego file: one for
+// step-level `uses:` and one for a job-level `reusableWorkflowUses:` call. A
+// job that (synthetically, for this test) carries both an unpinned step and
+// an unpinned reusable-workflow call with the SAME ref produces two raw
+// findings that differ in Message (the only thing keeping OPA's deny set
+// from collapsing them before Go ever sees them) but share every declared
+// identity field: same File (both resolve from job.OriginFile), same Job,
+// same uses string, and neither gets a resolved step (Line is 0 on both, and
+// enrichFindingsWithJobLocation only resolves step from a nonzero Line). The
+// per-policy score must count this pair once, the same as
+// AggregateIssueCodeCounts would for the run-level score.
+func TestReEvaluateForConfig_Row41CollapsesIdentityCollision(t *testing.T) {
+	pc := &configuration.PlumberConfig{
+		Version: "2.0",
+		GitHub: &configuration.ProviderConfig{
+			Controls: configuration.ControlsConfig{
+				ActionsMustBePinnedByCommitSha: &configuration.ActionsPinnedByShaControlConfig{
+					Enabled: boolPtr(true),
+				},
+			},
+		},
+	}
+	pipeline := &ir.NormalizedPipeline{
+		Provider: ir.ProviderGitHub,
+		Jobs: []ir.Job{{
+			Name:                 "build",
+			OriginFile:           "workflows/ci.yml",
+			Uses:                 []ir.Action{{Uses: "acme/repo@main"}},
+			ReusableWorkflowUses: "acme/repo@main",
+		}},
+	}
+
+	conf := &configuration.Configuration{PlumberConfig: pc}
+	scoped, score, ok := ReEvaluateForConfig(&AnalysisResult{CiValid: true, GitHubPipeline: pipeline}, conf, "github", pc)
+	if !ok {
+		t.Fatal("re-evaluation must succeed")
+	}
+
+	var unpinned []opaengine.Finding
+	for _, f := range scoped.Findings {
+		if f.Code == string(CodeActionUnpinned) {
+			unpinned = append(unpinned, f)
+		}
+	}
+	if len(unpinned) != 2 {
+		t.Fatalf("fixture must produce 2 raw ISSUE-701 findings (one per deny block), got %d: %+v", len(unpinned), unpinned)
+	}
+	if unpinned[0].Message == unpinned[1].Message {
+		t.Fatalf("the two findings must differ in Message (the step-level and reusable-workflow deny blocks), got identical %q", unpinned[0].Message)
+	}
+
+	want := ComputePlumberScore(map[ErrorCode]int{CodeActionUnpinned: 1})
+	if score.FinalPoints != want.FinalPoints || score.Score != want.Score {
+		t.Fatalf("score = %+v, want %+v (the identity collision must count once)", score, want)
+	}
+}
+
+// TestReEvaluateForConfig_Row41CountsDistinctIdentitiesSeparately is the
+// other half through the per-policy path: two jobs, each with its own
+// unpinned reusable-workflow call to the same ref, are genuinely distinct
+// ISSUE-701 findings because job is a declared identity field, and both
+// must count.
+func TestReEvaluateForConfig_Row41CountsDistinctIdentitiesSeparately(t *testing.T) {
+	pc := &configuration.PlumberConfig{
+		Version: "2.0",
+		GitHub: &configuration.ProviderConfig{
+			Controls: configuration.ControlsConfig{
+				ActionsMustBePinnedByCommitSha: &configuration.ActionsPinnedByShaControlConfig{
+					Enabled: boolPtr(true),
+				},
+			},
+		},
+	}
+	pipeline := &ir.NormalizedPipeline{
+		Provider: ir.ProviderGitHub,
+		Jobs: []ir.Job{
+			{Name: "build", OriginFile: "workflows/ci.yml", ReusableWorkflowUses: "acme/repo@main"},
+			{Name: "deploy", OriginFile: "workflows/ci.yml", ReusableWorkflowUses: "acme/repo@main"},
+		},
+	}
+
+	conf := &configuration.Configuration{PlumberConfig: pc}
+	scoped, score, ok := ReEvaluateForConfig(&AnalysisResult{CiValid: true, GitHubPipeline: pipeline}, conf, "github", pc)
+	if !ok {
+		t.Fatal("re-evaluation must succeed")
+	}
+
+	unpinned := 0
+	for _, f := range scoped.Findings {
+		if f.Code == string(CodeActionUnpinned) {
+			unpinned++
+		}
+	}
+	if unpinned != 2 {
+		t.Fatalf("fixture must produce 2 raw ISSUE-701 findings (one per job), got %d", unpinned)
+	}
+
+	want := ComputePlumberScore(map[ErrorCode]int{CodeActionUnpinned: 2})
+	if score.FinalPoints != want.FinalPoints || score.Score != want.Score {
+		t.Fatalf("score = %+v, want %+v (a different job is a different identity, both must count)", score, want)
+	}
+}
+
 // TestReEvaluateForConfigMarksThePolicysOwnControls is the end-to-end half
 // of TestPerPolicyMarkingUsesThePolicysOwnControls: it drives the real
 // per-policy path rather than the marker in isolation.

--- a/control/scoring.go
+++ b/control/scoring.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"sort"
 
+	"github.com/getplumber/plumber/finding/identity"
 	opaengine "github.com/getplumber/plumber/internal/engine/opa"
 )
 
@@ -110,14 +111,57 @@ func SeverityCountsFromIssueCodes(codes []ErrorCode) SeverityCounts {
 	return c
 }
 
-// AggregateIssueCodeCounts walks analysis issues and counts occurrences per ErrorCode.
+// codeCountsForFindings counts one occurrence per distinct identity per code
+// (row 41): two findings that share a platform identity, the hash
+// identity.PlatformHash derives from a finding's IdentityInput and the very
+// key control.MarkDismissed matches served dismissals against (#447), count
+// once, so the CLI's own score and the platform's recompute over the same
+// findings never disagree about how many occurrences a code has. A finding
+// with no identity (a codeless entry, where PlatformHash reports !ok) has
+// nothing to dedupe against and counts on its own, once per entry. Dismissed
+// findings are skipped before the identity check, same as forEachIssueCode.
+//
+// Both the run-level score (AggregateIssueCodeCounts) and the per-policy
+// score (control/lanes.go's ReEvaluateForConfig) read this one function, so
+// the two counting rules cannot drift the way two separately maintained
+// loops eventually would.
+func codeCountsForFindings(findings []opaengine.Finding) map[ErrorCode]int {
+	out := map[ErrorCode]int{}
+	seen := map[ErrorCode]map[string]struct{}{}
+	for _, f := range findings {
+		if f.Dismissed {
+			continue
+		}
+		code := ErrorCode(f.Code)
+		hash, _, ok := identity.PlatformHash(f.IdentityInput())
+		if !ok {
+			// Codeless: no identity to dedupe against, count the entry itself.
+			out[code]++
+			continue
+		}
+		set, exists := seen[code]
+		if !exists {
+			set = map[string]struct{}{}
+			seen[code] = set
+		}
+		if _, dup := set[hash]; dup {
+			continue
+		}
+		set[hash] = struct{}{}
+		out[code]++
+	}
+	return out
+}
+
+// AggregateIssueCodeCounts walks analysis issues and counts occurrences per ErrorCode,
+// one per distinct identity (row 41): duplicate occurrences of the same finding
+// identity count once, matching the platform's own recompute over the same findings.
 // This is the input expected by ComputePlumberScore in scoring-v3 (per-code caps).
 func AggregateIssueCodeCounts(result *AnalysisResult) map[ErrorCode]int {
-	out := map[ErrorCode]int{}
-	forEachIssueCode(result, func(code ErrorCode) {
-		out[code]++
-	})
-	return out
+	if result == nil {
+		return map[ErrorCode]int{}
+	}
+	return codeCountsForFindings(result.Findings)
 }
 
 // CriticalIssueCodesSorted returns unique Critical-level issue codes present in the analysis, sorted.

--- a/control/scoring_dismissed_test.go
+++ b/control/scoring_dismissed_test.go
@@ -29,6 +29,76 @@ func TestAggregateIssueCodeCounts_SkipsDismissedFindings(t *testing.T) {
 	}
 }
 
+// TestAggregateIssueCodeCounts_Row41CollapsesIdentityCollision pins row 41:
+// two live findings that share a platform identity (same code, and for a
+// {file, job}-keyed code, the same file and job) count once, not twice, so
+// the CLI's own score and the platform's recompute over the same findings
+// agree.
+func TestAggregateIssueCodeCounts_Row41CollapsesIdentityCollision(t *testing.T) {
+	result := &AnalysisResult{
+		Findings: []opaengine.Finding{
+			{Code: string(CodeUndocumentedPermissions), File: "workflows/ci.yml", Job: "build"},
+			{Code: string(CodeUndocumentedPermissions), File: "workflows/ci.yml", Job: "build"},
+		},
+	}
+	counts := AggregateIssueCodeCounts(result)
+	if got := counts[CodeUndocumentedPermissions]; got != 1 {
+		t.Fatalf("counts[%s] = %d, want 1 (same file+job identity collision must count once)", CodeUndocumentedPermissions, got)
+	}
+}
+
+// TestAggregateIssueCodeCounts_Row41CountsDistinctIdentitiesSeparately is
+// the other half: two findings of the same code that differ in a declared
+// identity field (job) are genuinely distinct findings and must both count.
+func TestAggregateIssueCodeCounts_Row41CountsDistinctIdentitiesSeparately(t *testing.T) {
+	result := &AnalysisResult{
+		Findings: []opaengine.Finding{
+			{Code: string(CodeUndocumentedPermissions), File: "workflows/ci.yml", Job: "build"},
+			{Code: string(CodeUndocumentedPermissions), File: "workflows/ci.yml", Job: "deploy"},
+		},
+	}
+	counts := AggregateIssueCodeCounts(result)
+	if got := counts[CodeUndocumentedPermissions]; got != 2 {
+		t.Fatalf("counts[%s] = %d, want 2 (a different job is a different identity)", CodeUndocumentedPermissions, got)
+	}
+}
+
+// TestAggregateIssueCodeCounts_Row41DismissedSkippedBeforeIdentityDedup pins
+// the ordering: a dismissed finding is skipped before the identity check
+// ever runs, so it is not merely absorbed into the same identity bucket as a
+// live duplicate: two colliding live findings plus a dismissed duplicate of
+// the same identity still count once.
+func TestAggregateIssueCodeCounts_Row41DismissedSkippedBeforeIdentityDedup(t *testing.T) {
+	result := &AnalysisResult{
+		Findings: []opaengine.Finding{
+			{Code: string(CodeUndocumentedPermissions), File: "workflows/ci.yml", Job: "build"},
+			{Code: string(CodeUndocumentedPermissions), File: "workflows/ci.yml", Job: "build"},
+			{Code: string(CodeUndocumentedPermissions), File: "workflows/ci.yml", Job: "build", Dismissed: true},
+		},
+	}
+	counts := AggregateIssueCodeCounts(result)
+	if got := counts[CodeUndocumentedPermissions]; got != 1 {
+		t.Fatalf("counts[%s] = %d, want 1 (two colliding live findings plus a dismissed duplicate still count once)", CodeUndocumentedPermissions, got)
+	}
+}
+
+// TestAggregateIssueCodeCounts_Row41CodelessFindingCountsPerEntry: a
+// codeless finding has no identity (identity.PlatformHash reports !ok for
+// an empty code), so there is nothing to dedupe it against and each
+// codeless entry counts on its own.
+func TestAggregateIssueCodeCounts_Row41CodelessFindingCountsPerEntry(t *testing.T) {
+	result := &AnalysisResult{
+		Findings: []opaengine.Finding{
+			{Code: "", File: "workflows/ci.yml", Job: "build"},
+			{Code: "", File: "workflows/ci.yml", Job: "build"},
+		},
+	}
+	counts := AggregateIssueCodeCounts(result)
+	if got := counts[ErrorCode("")]; got != 2 {
+		t.Fatalf("counts[\"\"] = %d, want 2 (a codeless finding has no identity to dedupe against)", got)
+	}
+}
+
 // TestCriticalIssueCodesSorted_StillListsCodeWhenLiveFindingRemains documents
 // the deliberate asymmetry: forEachIssueCode skips a dismissed finding for
 // EVERY reader (AggregateIssueCodeCounts and CriticalIssueCodesSorted alike,

--- a/control/status.go
+++ b/control/status.go
@@ -3,6 +3,8 @@ package control
 import (
 	"sort"
 	"strings"
+
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
 )
 
 // Per-control evaluation statuses. `passed` and `failed` mean the control
@@ -192,6 +194,29 @@ func StatusFor(e ControlEntry, result *AnalysisResult, findingCount int) string 
 		}
 	}
 	return StatusPassed
+}
+
+// EvaluatedControlCount counts the entries whose StatusFor is passed or
+// failed: a run or a policy that evaluated nothing real has no basis for a
+// score, and skipped, lane-missing and not_evaluable controls (including the
+// config_required case, #459) are exactly the statuses that mean "nothing
+// real happened here" (platform decision row 45). Findings not attributed to
+// any entry's control name are read as zero for that entry, matching every
+// other StatusFor caller in this package.
+func EvaluatedControlCount(entries []ControlEntry, result *AnalysisResult) int {
+	var findings []opaengine.Finding
+	if result != nil {
+		findings = result.Findings
+	}
+	findingsByControl := FindingsByControl(findings)
+	n := 0
+	for _, e := range entries {
+		switch StatusFor(e, result, len(findingsByControl[e.ControlName])) {
+		case StatusPassed, StatusFailed:
+			n++
+		}
+	}
+	return n
 }
 
 // CodesForControl returns every ISSUE code registered to a control name,

--- a/control/status_test.go
+++ b/control/status_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/getplumber/plumber/gitlab"
+	opaengine "github.com/getplumber/plumber/internal/engine/opa"
 	glab "gitlab.com/gitlab-org/api/client-go"
 )
 
@@ -68,6 +69,75 @@ func TestStatusFor(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := StatusFor(tc.entry, tc.result, tc.findings); got != tc.want {
 				t.Errorf("StatusFor() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEvaluatedControlCount_Row45 pins platform decision row 45: a control
+// only counts toward "something was evaluated" when its own status is
+// passed or failed. Skipped and not_evaluable (StatusError, including the
+// config_required case) contribute nothing, which is what lets a caller
+// tell "nothing was checked" apart from "everything checked out clean".
+func TestEvaluatedControlCount_Row45(t *testing.T) {
+	debugTrace := ControlEntry{ControlName: "pipelineMustNotEnableDebugTrace"}
+	branch := ControlEntry{ControlName: "branchMustBeProtected"}
+	skipped := ControlEntry{ControlName: "pipelineMustNotEnableDebugTrace", Skipped: true}
+
+	cases := []struct {
+		name    string
+		entries []ControlEntry
+		result  *AnalysisResult
+		want    int
+	}{
+		{
+			name:    "a passed control counts",
+			entries: []ControlEntry{debugTrace},
+			result:  &AnalysisResult{CiValid: true},
+			want:    1,
+		},
+		{
+			name:    "a failed control counts",
+			entries: []ControlEntry{debugTrace},
+			result: &AnalysisResult{CiValid: true, Findings: []opaengine.Finding{
+				{Code: string(CodeDebugTraceEnabled)},
+			}},
+			want: 1,
+		},
+		{
+			name:    "a skipped control does not count",
+			entries: []ControlEntry{skipped},
+			result:  &AnalysisResult{CiValid: true},
+			want:    0,
+		},
+		{
+			name:    "a not_evaluable control (config_required) does not count",
+			entries: []ControlEntry{branch},
+			result: &AnalysisResult{
+				NotEvaluable: map[string]string{"branchMustBeProtected": ReasonConfigRequired},
+			},
+			want: 0,
+		},
+		{
+			name:    "an empty entry set counts nothing (declares no controls)",
+			entries: nil,
+			result:  &AnalysisResult{CiValid: true},
+			want:    0,
+		},
+		{
+			name:    "a mix counts only the evaluated ones",
+			entries: []ControlEntry{debugTrace, branch, skipped},
+			result: &AnalysisResult{
+				CiValid:      true,
+				NotEvaluable: map[string]string{"branchMustBeProtected": ReasonConfigRequired},
+			},
+			want: 1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EvaluatedControlCount(tc.entries, tc.result); got != tc.want {
+				t.Errorf("EvaluatedControlCount() = %d, want %d", got, tc.want)
 			}
 		})
 	}

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -43,6 +43,8 @@ Both views are reported:
 - `counts.{critical,high,medium,low}`: total findings per severity (banner, MR comment).
 - `codeLosses[]`: per-code rows that drive the score (full breakdown via `--score-point`).
 
+Occurrences of a code that share the same finding identity (the platform's own grouping key, see `docs/FINGERPRINT.md`) count once toward that code's tally, so the CLI's own score and the platform's recomputed score are computed over the same input.
+
 An enabled control none of whose substantive configuration fields is set is not evaluated (`not_evaluable`, reason `config_required`) and contributes no findings. When at least one other control genuinely evaluated (a real pass or fail), the loss-based points above are simply computed over that smaller evaluated set, exactly as with any other `not_evaluable` control (#459).
 
 When **nothing at all** evaluated, a run or a policy has no basis for a score. Zero findings over an empty or all-`not_evaluable` control set would otherwise compute the deduction-based formula down to a perfect 100/A, which reads as a clean pass rather than as nothing having been checked. The score is **withheld** instead: the banner prints "Score withheld: no control was evaluated", the JSON report omits `plumberScore` (top-level) and the policy entry's `score`, and the push omits the policy's `score`. This applies at both levels: a whole run with nothing evaluated, and, in platform mode, an individual policy whose own control set evaluated nothing while other policies in the same run scored normally.

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -43,7 +43,9 @@ Both views are reported:
 - `counts.{critical,high,medium,low}`: total findings per severity (banner, MR comment).
 - `codeLosses[]`: per-code rows that drive the score (full breakdown via `--score-point`).
 
-An enabled control none of whose substantive configuration fields is set is not evaluated (`not_evaluable`, reason `config_required`) and contributes no findings; the loss-based points above are unaffected, so such a policy can still read 100 while every one of its controls is marked not evaluated (#459). Whether a policy with no evaluable control should have its score withheld instead is an open platform question.
+An enabled control none of whose substantive configuration fields is set is not evaluated (`not_evaluable`, reason `config_required`) and contributes no findings. When at least one other control genuinely evaluated (a real pass or fail), the loss-based points above are simply computed over that smaller evaluated set, exactly as with any other `not_evaluable` control (#459).
+
+When **nothing at all** evaluated, a run or a policy has no basis for a score. Zero findings over an empty or all-`not_evaluable` control set would otherwise compute the deduction-based formula down to a perfect 100/A, which reads as a clean pass rather than as nothing having been checked. The score is **withheld** instead: the banner prints "Score withheld: no control was evaluated", the JSON report omits `plumberScore` (top-level) and the policy entry's `score`, and the push omits the policy's `score`. This applies at both levels: a whole run with nothing evaluated, and, in platform mode, an individual policy whose own control set evaluated nothing while other policies in the same run scored normally.
 
 ---
 
@@ -152,6 +154,8 @@ top level, the platform's global score.
 A run where **zero controls were evaluated** fails the score gate rather than passing as an empty 100-point pipeline: a `.plumber.yaml` that enables no controls for the scanned provider (e.g. a `github:`-only config on a GitLab project), a filter that skips them all, and — on GitLab, where a missing or unparseable CI configuration leaves no control evaluated — a project with no usable CI. On GitLab this matches the historical default (compliance was 0 in those cases).
 
 **On GitHub, a repository with no workflows (or workflows Plumber cannot parse) passes the default gate** when its enabled controls report no findings — the pre-0.4.0 behavior, deliberately restored so fleet scanners can sweep repositories that have no CI without failing on them. Note the score is then computed over what could be checked; gate on findings, not on CI presence.
+
+A related but distinct shape: GitHub's control count, unlike GitLab's, does not exclude `not_evaluable` controls, so a repository whose enabled controls are all `config_required` still carries a nonzero control count. Nothing was actually checked either way, so the score is withheld exactly as in the zero-control case above, but the **exit code does not change**: this shape already passed the gate before this rule existed (a zero-finding empty set scored a fake 100), and a nil score still passes it now, for the same reason a `.plumber.yaml`-declared empty policy passes. Only the number shown at the grade changes, from a perfect A to none.
 
 The legacy `--threshold` flag (percentage of passing controls) is **deprecated**: it still works, with a warning, and cannot be combined with the score gate flags. Its old default (100) matches the default score gate on any repository with CI to score, since any finding drops both below 100.
 

--- a/docs/superpowers/plans/2026-09-11-cli-batch-2-rows-41-45-46-51-52.md
+++ b/docs/superpowers/plans/2026-09-11-cli-batch-2-rows-41-45-46-51-52.md
@@ -1,0 +1,127 @@
+# CLI batch 2: platform decision rows 41, 45, 46, 51, 52 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the five CLI-side rulings of the platform's tenth decision clearing (2026-09-11): the checkout is recognised again when the runner clone carries a job token in the remote URL (row 51, the never-evaluating include controls), the score is withheld when no control was evaluated (row 45), findings are counted once per identity when scoring (row 41), a plain-http platform URL needs an explicit opt-in (row 46), and the configuration schema exports a `nullable` flag per field (row 52).
+
+**Architecture:** Every change lands at an existing choke point: the remote parser's single constructor, the one score-result builder every consumer already nil-guards, the one code-count walk both scoring paths share, the platform-push endpoint resolver, and the schema reflector. No new package except a tiny shared count helper if needed. Behaviour outside platform mode changes only where the ruling says so (rows 41, 45, 51 apply to every run).
+
+**Tech Stack:** Go 1.25, cobra, logrus, golangci-lint v2.10.1 (`make lint`), `make deadcode`, `make test`; semantic-release generates CHANGELOG.md (never hand-edit).
+
+**Spec:** The platform's decision queue, `docs/QUESTIONS.md` in the getplumber/monorepo repo, rows 41, 45, 46, 51, 52 (tenth clearing, ruled by the maintainer 2026-09-11). Plan-time survey: `/root/.claude/jobs/2f38ab78/tmp/cli-batch-2-verification.md` (file:line for every symbol; read it before touching a file).
+
+## Global Constraints
+
+- Public repository: no AI mention anywhere except the two commit trailer lines; commit messages and doc prose read as the maintainer's.
+- TDD: the failing test first, RED recorded in the report. `make lint` reports 0 issues; `make deadcode` reports only the pre-existing `configuration/schema.go:142 ConfigSchemas`; `go vet ./...` clean; `gofmt -l .` empty.
+- Tests: `go test ./<pkg>/ -count=1` per package, foreground, explicit 600000 ms tool timeout for anything over 120 s; never background runs; never wait on a background notification; the controller runs `make test` on the whole module.
+- Conventional commits (feat/fix/docs, scope = package), header at most 100 chars, lowercase first token after the type, body says why and which platform row; each commit ends with the two trailer lines the dispatch gives; no `git stash` in any form; no subagents; no em dash character anywhere.
+- CHANGELOG.md is generated: do not edit. README/docs are edited where the behaviour they describe changes.
+- The finding bytes the platform hashes (`opaengine.Finding.MarshalJSON`) never change; `internal/platform` wire types change only where a task says so.
+
+---
+
+### Task 1: Row 51 (P1), strip userinfo from the parsed git remote
+
+**Files:**
+- Modify: `utils/gitremote.go` (`ParseGitRemoteURL` ~261-282, `newGitRemoteInfo` ~288-296)
+- Test: `utils/gitremote_test.go` (`TestParseGitRemoteURL`), `cmd/analyze_gitlab_test.go` (a `checkoutIsProject` fixture)
+
+**Interfaces:**
+- Produces: `GitRemoteInfo.Host` and `.URL` never carry userinfo for any scheme; `ProjectPath` unchanged. Every consumer (`detectProvider`, `conf.GithubAPIHost`, `remote.remoteURL`, `githubWebURL`) inherits the fix through the constructor.
+
+- [ ] **Step 1: Failing tests.** Add to `TestParseGitRemoteURL`: `https://gitlab-ci-token:glcbt-xxxx@gitlab.example.com/group/project.git` -> Host `gitlab.example.com`, ProjectPath `group/project`, URL `https://gitlab.example.com`; `https://x-access-token:ghs_xxx@ghes.example.com/org/repo.git` -> Host `ghes.example.com`; `https://user@gitlab.example.com/g/p.git` -> Host `gitlab.example.com`; `ssh://git@gitlab.example.com:2222/g/p.git` unchanged; `git@gitlab.example.com:g/p.git` unchanged. In `cmd/analyze_gitlab_test.go`, a fixture that runs the `checkoutIsProject` computation (through `buildGitLabConf` or the smallest seam it exposes) with a remote URL carrying `gitlab-ci-token:TOKEN@` and the plain `--gitlab-url`, asserting `conf.CheckoutIsAnalyzedProject == true`; name both with `Row51` or `UserinfoStripped`.
+
+- [ ] **Step 2: RED.** The https cases return the polluted host; the checkout fixture reads false.
+
+- [ ] **Step 3: Implement.** In the https branch (and defensively `git://`), drop the userinfo before the host capture: `^https?://(?:[^@/]+@)?([^/]+)/(.+?)(?:\.git)?$`. Keep `newGitRemoteInfo` the single constructor; add a doc comment: the runner's clone carries the job token in the remote (`gitlab-ci-token:<token>@`), and a host that keeps it never equals the server URL (platform row 51) and would reach logs and finding links. Grep every consumer listed in the survey and confirm none re-parses the raw URL.
+
+- [ ] **Step 4: GREEN.** `go test ./utils/ -count=1`, `go test ./cmd/ -run 'Row51|Userinfo|GitRemote|Checkout' -count=1`, then `make lint`.
+
+- [ ] **Step 5: Commit** `fix(utils): strip userinfo from the parsed git remote so a token clone still matches the analyzed project`.
+
+---
+
+### Task 2: Row 45, withhold the score when no control was evaluated
+
+**Files:**
+- Modify: `cmd/analyze_shared.go` (`computeScoreResult` ~746-752, the summary builder ~363-396), `cmd/platform_eval.go` (`evaluatePlatformPolicies` ~107-118), `cmd/platform_render.go` (~66-93), `cmd/analyze_gitlab.go` (`printSummaryScoreBanner` ~1958-1977: the withheld wording; `platformPolicyReportEntries` ~1143-1177), `docs/scoring.md` (the open question at ~46 becomes the rule; the gate section ~140-158)
+- Test: `cmd/gate_test.go`, `cmd/platform_render_test.go` (`TestRenderPolicySections_NoControlsDeclared` gains the absent-score assertion its siblings have), `cmd/analyze_shared_test.go` or the closest existing file, `cmd/platform_report_shape_test.go`
+
+**Interfaces:**
+- Produces: a run or a policy with zero EVALUATED controls (an evaluated control is one whose entry is `pass` or `fail`; skipped, lane-missing and `not_evaluable` controls, including `config_required`, do not count) has NO score: `computeScoreResult` returns nil, `run.Score` stays nil, the banner prints the withheld line (reuse the degraded wording family: "Score withheld: no control was evaluated"), the JSON report omits `plumberScore` and the policy entry's `score`, the push omits that policy's `score`, badge and MR comment behave as for a nil score (already nil-safe), the exit code keeps the existing `ScoreGateError{NoControls}` behaviour.
+- Consumes: the evaluated-control count. Find how `controlCount` is computed (`p.ComputeCompliance(result, conf)`, `cmd/analyze_shared.go:363`) and whether it already excludes `not_evaluable`; if it counts enabled controls, add an `evaluatedCount` derived from the entries' statuses and use it for withholding (keep `controlCount` for the existing gate semantics unless they are the same number).
+
+- [ ] **Step 1: Failing tests.** (a) a summary with `controlCount`/evaluated 0 and `scoreMode` true yields `score == nil` and the text output contains the withheld line and no "Plumber Score" banner; (b) an all-`not_evaluable` result (every control `config_required`) also yields nil; (c) `TestRenderPolicySections_NoControlsDeclared` asserts "Plumber Score" absent; (d) the platform JSON `policies[]` entry for a `declares no controls` policy has no `score` key; (e) the push payload omits `score` for that policy (`cmd/platform_push_test.go` shape). Name them with `Row45`.
+
+- [ ] **Step 2: RED.** Perfect 100/A everywhere today.
+
+- [ ] **Step 3: Implement.** Fold the zero-evaluated case into the existing nil-score switch at the two builders; render the withheld line in the banner's existing withheld branch (extend it with a reason parameter or a second boolean); skip the banner after "declares no controls" (`continue` like the `!r.Applied` branch); omit `score` in the report entry and the push item when `run.Score == nil` (check the push item's `Score` field is a pointer or `omitempty`; if the wire type is a value, make it a pointer with `omitempty`, the platform accepts an absent policy score). Update `docs/scoring.md`: the question at ~46 is answered (a policy with nothing evaluated has no score, not 100), and the gate section says the exit code is unchanged.
+
+- [ ] **Step 4: GREEN.** `go test ./cmd/ -count=1` (explicit 600000 ms timeout), `go test ./control/ -count=1`, `make lint`.
+
+- [ ] **Step 5: Commit** `feat(scoring): withhold the score when no control was evaluated instead of reporting 100`.
+
+---
+
+### Task 3: Row 41, count a finding once per identity when scoring
+
+**Files:**
+- Modify: `control/scoring.go` (`forEachIssueCode` ~77-91, `AggregateIssueCodeCounts` ~113-121), `control/lanes.go` (`ReEvaluateForConfig` ~765-770), `docs/scoring.md` (one sentence: occurrences sharing an identity count once, like the platform)
+- Test: `control/scoring_dismissed_test.go` (sibling test), `control/lanes_test.go` or the closest per-policy test
+
+**Interfaces:**
+- Produces: `AggregateIssueCodeCounts` and the per-policy count in `ReEvaluateForConfig` count one per distinct identity per code, the identity being `identity.PlatformHash(identity.FromFinding(f))` (the platform's own key; use the exported constructor the CLI has for its own findings, grep `finding/identity` for how `MarkDismissed` builds the key in `control/dismissed.go`, and reuse that path so the two never diverge); dismissed findings still skipped; codeless findings (no identity) keep counting once each (`ok == false` from the hash means fall back to the raw entry).
+- One helper `codeCountsForFindings(findings []opaengine.Finding) map[ErrorCode]int` used by both callers (the run-level walk and the per-policy loop), so the rule lives once.
+
+- [ ] **Step 1: Failing tests.** Two findings with the same code, file and job (an identity collision) count 1; two differing in a declared identity field (job) count 2; a dismissed duplicate still skipped; a codeless finding counts; the same four through `ReEvaluateForConfig`'s per-policy count. Names carry `Row41`.
+
+- [ ] **Step 2: RED.** Both loops count 2 for the collision.
+
+- [ ] **Step 3: Implement** the helper with a `map[ErrorCode]map[string]struct{}`, wire both callers, keep `forEachIssueCode` if other callers need the raw walk (grep; delete it if the helper makes it dead, `make deadcode` decides).
+
+- [ ] **Step 4: GREEN.** `go test ./control/ -count=1`, `make lint`, `make deadcode`.
+
+- [ ] **Step 5: Commit** `fix(scoring): count a finding once per identity so the job and the platform score the same input`.
+
+---
+
+### Task 4: Row 52, export a nullable flag per schema field
+
+**Files:**
+- Modify: `configuration/schema.go` (`SchemaField` ~10-22, `structFields` ~84-100)
+- Test: `configuration/schema_test.go`; refresh `cmd/testdata/catalog_golden.json` with `go test ./cmd/ -run TestCatalogCommandGolden -update-catalog`
+
+**Interfaces:**
+- Produces: `SchemaField.Nullable bool` (`json:"nullable,omitempty"`), true iff the Go field is a pointer (unset is meaningful); `Optional` unchanged. Nested struct fields inherit through the existing recursion.
+
+- [ ] **Step 1: Failing test.** A struct with `A *int \`yaml:"a,omitempty"\`` and `B int \`yaml:"b,omitempty"\``: `A` is `Optional` and `Nullable`, `B` is `Optional` and not `Nullable`; a real control with a pointer field (grep the config structs for `*bool`) exports `nullable: true` in `ConfigSchemaFor`.
+
+- [ ] **Step 2: RED.** Compile failure on `Nullable`.
+
+- [ ] **Step 3: Implement** in `structFields` (pointer-ness is gone inside `typeToField`); refresh the golden; diff-review the golden change: only `"nullable": true` keys added, nothing removed or renamed; say so in the commit body.
+
+- [ ] **Step 4: GREEN.** `go test ./configuration/ -count=1`, `go test ./cmd/ -run Catalog -count=1`, `make lint`.
+
+- [ ] **Step 5: Commit** `feat(configuration): export nullable on schema fields so an editor knows when unset is meaningful`.
+
+---
+
+### Task 5: Row 46, plain-http platform URL requires an explicit opt-in
+
+**Files:**
+- Modify: `cmd/analyze_gitlab.go` (flag next to `--platform` ~208, `envKeys` ~594), `cmd/platform_push.go` (`effectivePlatformPush` ~22-38) or `cmd/platform_mode.go` (`setupPlatformMode` before `scoreOIDCToken` ~54), `templates/plumber.yml` (`platform_allow_http` input, default false, passed through like `platform`), `action.yml` (input `platform-allow-http`), `README.md` (platform mode section ~201-260), `docs/platform-push-testing.md` if it names the base URL
+- Test: `cmd/platform_mode_test.go` or `cmd/platform_push_test.go`, `internal/platform/client_test.go` untouched (loopback stays allowed)
+
+**Interfaces:**
+- Produces: flag `--platform-allow-http` (bool, default false), env `PLUMBER_ANALYZE_PLATFORM_ALLOW_HTTP`; a `--platform` URL with scheme `http` whose host is not loopback (`localhost`, `127.0.0.0/8`, `::1`) and the flag unset is refused BEFORE any OIDC token is minted or any request is sent, with the message `refusing to send platform credentials over plain http to <host>: pass --platform-allow-http (PLUMBER_ANALYZE_PLATFORM_ALLOW_HTTP=1) for a trusted internal instance`; exit code = the existing configuration-error code; https and loopback http unchanged; the sentinel `https://platform.invalid` unchanged.
+
+- [ ] **Step 1: Failing tests.** `http://platform.example.com` without the flag -> refusal, no client built, no token minted (assert through the seam `setupPlatformMode` exposes); `http://127.0.0.1:8080` -> allowed; `http://platform.example.com` with the flag -> allowed; `https://...` unchanged. Names carry `Row46`.
+
+- [ ] **Step 2: RED.** All accepted today.
+
+- [ ] **Step 3: Implement** the check with `net/url` + `net.ParseIP(...).IsLoopback()` (and the `localhost` name); mirror the input in the component template and the action with the same default and doc line; README: one paragraph in the platform section.
+
+- [ ] **Step 4: GREEN.** `go test ./cmd/ -run 'Platform|Row46' -count=1` (explicit 600000 ms timeout), `go test ./internal/platform/ -count=1`, `make lint`.
+
+- [ ] **Step 5: Commit** `feat(platform): require --platform-allow-http before sending credentials to a plain-http platform`.

--- a/templates/plumber.yml
+++ b/templates/plumber.yml
@@ -101,6 +101,10 @@ spec:
     platform:
       description: "Plumber platform base URL. Setting it pushes this run's full results there over CI OIDC, and takes precedence over score_push. The default is a placeholder (RFC 2606 .invalid) that never enables a push - GitLab requires the id_tokens audience to be non-empty, so this input cannot default to empty. In platform mode only the platform's policies are evaluated and the platform's gate decides the exit code."
       default: "https://platform.invalid"
+    platform_allow_http:
+      description: "Allow the platform input to be plain http for a non-loopback host. Without it, http to anything but localhost/127.0.0.0/8/::1 is refused before any credential is sent; https and loopback http need no opt-in."
+      default: false
+      type: boolean
     controls:
       description: Run only listed controls (comma-separated control names). Cannot be used with skip_controls.
       default: ""
@@ -202,6 +206,7 @@ spec:
     # in cmd/platform_push.go), so this passthrough alone never turns the push
     # on for everyone.
     PLUMBER_ANALYZE_PLATFORM: $[[ inputs.platform ]]
+    PLUMBER_ANALYZE_PLATFORM_ALLOW_HTTP: $[[ inputs.platform_allow_http ]]
     PLUMBER_ANALYZE_CONTROLS: $[[ inputs.controls ]]
     PLUMBER_ANALYZE_SKIP_CONTROLS: $[[ inputs.skip_controls ]]
     PLUMBER_ANALYZE_FAIL_WARNINGS: $[[ inputs.fail_warnings ]]

--- a/utils/gitremote.go
+++ b/utils/gitremote.go
@@ -272,14 +272,29 @@ func ParseGitRemoteURL(remoteURL string) *GitRemoteInfo {
 		return newGitRemoteInfo(matches[1], matches[2])
 	}
 
-	// Try HTTPS format: https://host[:port]/path.git
-	httpsRegex := regexp.MustCompile(`^https?://([^/]+)/(.+?)(?:\.git)?$`)
+	// Try HTTPS format: https://[userinfo@]host[:port]/path.git
+	//
+	// A CI runner clones with the job token embedded as userinfo
+	// (gitlab-ci-token:<token>@host on GitLab, x-access-token:<token>@host
+	// on GitHub), and the optional `(?:[^@/]+@)?` drops it before the host
+	// is captured (platform row 51): a host that kept it would never equal
+	// the plain server URL the pipeline is configured with, so the checkout
+	// would never be recognized as the analyzed project and the include
+	// controls that depend on that match would never evaluate. Every field
+	// this constructs (Host, URL) flows through newGitRemoteInfo, so every
+	// consumer inherits the fix.
+	httpsRegex := regexp.MustCompile(`^https?://(?:[^@/]+@)?([^/]+)/(.+?)(?:\.git)?$`)
 	if matches := httpsRegex.FindStringSubmatch(remoteURL); matches != nil {
 		return newGitRemoteInfo(matches[1], matches[2])
 	}
 
-	// Try Git protocol format: git://host[:port]/path.git
-	gitRegex := regexp.MustCompile(`^git://([^/:]+)(?::\d+)?/(.+?)(?:\.git)?$`)
+	// Try Git protocol format: git://[userinfo@]host[:port]/path.git
+	//
+	// The git:// protocol carries no authentication of its own, so userinfo
+	// here is not a known real-world case, but stripping it defensively
+	// keeps this branch consistent with the HTTPS one instead of relying on
+	// that absence.
+	gitRegex := regexp.MustCompile(`^git://(?:[^@/]+@)?([^/:]+)(?::\d+)?/(.+?)(?:\.git)?$`)
 	if matches := gitRegex.FindStringSubmatch(remoteURL); matches != nil {
 		return newGitRemoteInfo(matches[1], matches[2])
 	}

--- a/utils/gitremote_test.go
+++ b/utils/gitremote_test.go
@@ -144,6 +144,45 @@ func TestParseGitRemoteURL(t *testing.T) {
 			remoteURL: "ftp://gitlab.com/group/project.git",
 			wantNil:   true,
 		},
+
+		// Row51/UserinfoStripped: a runner clone carries the job token as
+		// userinfo in the remote (gitlab-ci-token:<token>@host), and it must
+		// never survive into Host or URL.
+		{
+			name:        "Row51 GitLab CI job token stripped from HTTPS host",
+			remoteURL:   "https://gitlab-ci-token:glcbt-xxxx@gitlab.example.com/group/project.git",
+			wantHost:    "gitlab.example.com",
+			wantProject: "group/project",
+			wantURL:     "https://gitlab.example.com",
+		},
+		{
+			name:        "Row51 GHES access token stripped from HTTPS host",
+			remoteURL:   "https://x-access-token:ghs_xxx@ghes.example.com/org/repo.git",
+			wantHost:    "ghes.example.com",
+			wantProject: "org/repo",
+			wantURL:     "https://ghes.example.com",
+		},
+		{
+			name:        "Row51 UserinfoStripped bare username stripped from HTTPS host",
+			remoteURL:   "https://user@gitlab.example.com/g/p.git",
+			wantHost:    "gitlab.example.com",
+			wantProject: "g/p",
+			wantURL:     "https://gitlab.example.com",
+		},
+		{
+			name:        "Row51 UserinfoStripped SSH URL unchanged",
+			remoteURL:   "ssh://git@gitlab.example.com:2222/g/p.git",
+			wantHost:    "gitlab.example.com",
+			wantProject: "g/p",
+			wantURL:     "https://gitlab.example.com",
+		},
+		{
+			name:        "Row51 UserinfoStripped SCP-like unchanged",
+			remoteURL:   "git@gitlab.example.com:g/p.git",
+			wantHost:    "gitlab.example.com",
+			wantProject: "g/p",
+			wantURL:     "https://gitlab.example.com",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

Five changes decided on the platform's decision queue on 2026-09-11 (rows 41, 45, 46, 51, 52 of the monorepo's `docs/QUESTIONS.md`), one commit each.

- **Token clones are recognised again (P1, row 51).** GitLab runners clone with the job token in the remote URL (`https://gitlab-ci-token:<token>@host/...`). The remote parser kept that userinfo in the host, so the checkout never matched the analyzed project and the five include controls never evaluated in CI (always `include_attribution_unavailable`). The parser now strips userinfo at its single constructor, so `Host` and `URL` never carry a credential into logs, finding links or the GitHub Enterprise API host either. Bumping the component alone would not have fixed this.
- **No score when nothing was evaluated (row 45).** A run or a policy whose every control is skipped, lane-missing or `not_evaluable` (an enabled control with no configuration included) no longer reports 100 / A. The score is withheld like a degraded collection: the banner says so, the JSON report and the platform push omit it, badge and MR comment behave as for an absent score. The exit code is unchanged (a zero-control run still fails the gate as before). `docs/scoring.md` records the rule.
- **One count per identity when scoring (row 41).** Findings that share an identity (same code and identity fields) count once, the way the platform already counts them, so the job's score and the platform's recomputed score take the same input. Dismissed findings stay excluded.
- **Plain http platform URL needs an opt-in (row 46).** Since the platform's verdict drives the exit code, a plain-http link would let an on-path attacker turn a blocked pipeline green. A non-loopback `http://` platform URL is now refused before any OIDC token is minted, unless `--platform-allow-http` (`PLUMBER_ANALYZE_PLATFORM_ALLOW_HTTP=1`) is set; the component input `platform_allow_http` and the action input `platform-allow-http` pass it through. Loopback stays allowed for local development.
- **`nullable` on schema fields (row 52).** The configuration schema now says when unset is meaningful (`nullable: true` for pointer-typed fields), separately from `optional`, so an editor can stop inferring it from the Go structs. The catalog golden refresh is additive only.

## Platform side

The platform pins the CLI module; its next pin bump reflects `nullable` on `GET /controls` and withholds its own stored score when a pushed policy result has no evaluated control (the pushed `score` is already optional on the wire).

## Testing

TDD per change with the failing test recorded first; `make test`, `make lint` (0 issues), `make deadcode` (only the pre-existing `ConfigSchemas` entry), `go vet` clean.

## Release note

Two behaviour changes worth a line in the notes: a linked run whose policy evaluates nothing no longer prints or pushes a score, and a plain-http platform URL now requires the opt-in flag.
